### PR TITLE
Fix windows issues

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import csv
+import os
 import yaml
 
 import pytest
@@ -19,7 +20,7 @@ def pytest_collect_file(parent, path):
 
 
 def pytest_itemcollected(item):
-    dirs = item.session.fspath.bestrelpath(item.fspath.dirpath()).split('/')
+    dirs = item.session.fspath.bestrelpath(item.fspath.dirpath()).split(os.sep)
     for d in dirs:
         if d != ".":
             item.add_marker(d)

--- a/geocoder_tester/world/france/rhonealpes/fuzzy/test_typo.csv
+++ b/geocoder_tester/world/france/rhonealpes/fuzzy/test_typo.csv
@@ -1,3 +1,3 @@
 query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
 montcul,,,4,,,,Montcul,38230
-saint-bueil - 38 decoup'bois 376 route eglise 38620 saint-bueil,,,4,,376,Route de l'Église,Saint-Bueil
+"saint-bueil - 38 decoup'bois 376 route eglise 38620 saint-bueil",,,4,,376,"Route de l'Église",Saint-Bueil


### PR DESCRIPTION
This PR fixes some failures when running the tests under windows:

When running the tests under windows:

```
>py.test -v -s
============= test session starts =============================
platform win32 -- Python 3.5.1, pytest-3.3.1, py-1.5.2, pluggy-0.6.0 -- c:\...\python.exe
cachedir: .cache
rootdir: C:\geocoder-tester, inifile: pytest.ini
collected 12752 items / 1 errors

!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!
========= 12752 tests deselected ============================
========= 12752 deselected, 1 error in 4.89 seconds ================
```