### PR TITLE
bugfix - get results from the geocoder

### DIFF
--- a/geocoder_tester/base.py
+++ b/geocoder_tester/base.py
@@ -146,11 +146,13 @@ def assert_search(query, expected, limit=1,
         for r in results['features']:
             passed = True
             properties = None
-            failed = r['properties']['failed'] = []
+            
             if 'geocoding' in r['properties']:
                 properties = r['properties']['geocoding']
+                failed = r['properties']['geocoding']['failed'] = []
             else:
                 properties = r['properties']
+                failed = r['properties']['failed'] = []
             for key, value in expected.items():
                 value = str(value)
                 if not compare_values(str(properties.get(key)), value):
@@ -207,6 +209,8 @@ def dicts_to_table(dicts, keys):
         l = lengths.copy()
         for key in keys:
             value = d.get(key, '—')
+            if value is None:
+                value = ''
             if key in d['failed']:
                 l[key] += 10  # Add ANSI chars so python len will turn out.
                 value = "\033[1;4m{}\033[0m".format(value)


### PR DESCRIPTION
geocoder-tester did not work for geocoders that 
* return their result insides `['features']['properties']['geocoding']`
* return some null values instead of empty fields