### PR TITLE
Add markers to ini to silence warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,10 @@
 [pytest]
 addopts = -v --tb no
 norecursedirs = __pycache__
+markers =
+  france
+  geocoder_tester
+  germany
+  iledefrance
+  poland
+  world


### PR DESCRIPTION
Avoids warnings of the kind:

```
geocoder_tester/world/test_big_cities.py:80
PytestUnknownMarkWarning: Unknown pytest.mark.germany - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    @pytest.mark.germany
```
reported in newer pytest versions.