### PR TITLE
Allow for different flavours of API

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,7 @@ import yaml
 
 import pytest
 
-from geocoder_tester.base import assert_search, CONFIG
+from geocoder_tester.base import assert_search, CONFIG, API_TYPES
 
 
 def pytest_collect_file(parent, path):
@@ -36,6 +36,13 @@ def pytest_addoption(parser):
         dest="api_url",
         default=CONFIG['API_URL'],
         help="The URL to use for running tests against."
+    )
+    parser.addoption(
+        '--api-type',
+        dest="api_type",
+        default=CONFIG['API_TYPE'],
+        choices=API_TYPES.keys(),
+        help="The API to test against."
     )
     parser.addoption(
         '--max-run',
@@ -72,6 +79,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     CONFIG['API_URL'] = config.getoption('--api-url')
+    CONFIG['API_TYPE'] = config.getoption('--api-type')
     CONFIG['MAX_RUN'] = config.getoption('--max-run')
     CONFIG['LOOSE_COMPARE'] = config.getoption('--loose-compare')
     CONFIG['GEOJSON'] = config.getoption('--geojson')

--- a/geocoder_tester/base.py
+++ b/geocoder_tester/base.py
@@ -173,7 +173,7 @@ class SearchException(Exception):
 
 def search(url, **params):
     r = http.get(url, params=params,
-                 headers={'user-agent': 'geocode-tester/0.0.1'})
+                 headers={'user-agent': 'geocode-tester'})
     if not r.status_code == 200:
         raise HttpSearchException(error="Non 200 response")
     return r.json()

--- a/geocoder_tester/base.py
+++ b/geocoder_tester/base.py
@@ -34,8 +34,7 @@ class GenericApi:
         if lang:
             params['lang'] = lang
         if center:
-            params['lat'] = center[0]
-            params['lon'] = center[1]
+            params['lat'], params['lon'] = center
 
         return params
 

--- a/geocoder_tester/base.py
+++ b/geocoder_tester/base.py
@@ -43,7 +43,7 @@ class GenericApi:
         return CONFIG['API_URL']
 
 
-class NominatimApi:
+class NominatimApi(GenericApi):
     """ Access proxy for Nominatim APIs. The API URL must be the base
         URL without /search or /reverse path.
 
@@ -67,19 +67,10 @@ class NominatimApi:
         return CONFIG['API_URL'] + '/search'
 
 
-class PhotonApi:
+class PhotonApi(GenericApi):
     """ Access proxy for Photon APIs. The API URL must be the base URL without
         the /api or /reverse path.
     """
-    def search_params(self, query, limit, lang, center):
-        params = {"q": query, "limit": limit}
-        if lang:
-            params['lang'] = lang
-        if center:
-            params['lat'] = center[0]
-            params['lon'] = center[1]
-
-        return params
 
     def search_url(self):
         return CONFIG['API_URL'] + '/api'

--- a/geocoder_tester/world/france/iledefrance/test_addresses.py
+++ b/geocoder_tester/world/france/iledefrance/test_addresses.py
@@ -2,7 +2,7 @@ from geocoder_tester.base import search, assert_search
 
 
 def test_housenumbers_are_missing():
-    results = search(q='rue bergère paris')
+    results = search(query='rue bergère paris')
     for r in results['features']:
         assert (not r['properties'].get('housenumber')
                 or r['properties'].get('name'))


### PR DESCRIPTION
I'm in the process of setting up these tests to be usable against the Nominatim API. The API has slightly different input parameters. Setting up proxy servers is inconvenient for me because I need to run the tests against different installation. So this PR goes a different way. It adds an `--api-type` parameter which allows to select a translator for input parameters. At the moment there is the `default` translator which implements the old behaviour and a `nominatim` translator that is able to run the tests against the Nominatim API.

On a more general note: I see that this repository has been inactive for a while. Does it even make sense to run PRs here or am I better off forking?