### PR TITLE
Add minimal pelias API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Can I change the api URL I'm testing against?
 
     py.test --api-url http://photon.komoot.de/api/
 
+If you want to test not only against another photon instance, but against a nominatim or pelias service, supply the optional --api-type parameter and specify either `photon`, `nominatim` or `pelias`. 
+
+    py.test --api-url https://nominatim.openstreetmap.org/ --api-type nominatim
+
+
+Note that support for pelias is still rudimentary.
+   
 Can I limit the number of tests to be run (even if my filter select thousands
 of tests) ?
 

--- a/geocoder_tester/base.py
+++ b/geocoder_tester/base.py
@@ -142,6 +142,16 @@ class PeliasApi(GenericApi):
         the /search or /reverse path.
     """
 
+    DETAILS_LAYER_MAPPING = {
+        'country': 'country',
+        'state': 'region',
+        'county': 'county',
+        'city': 'locality',
+        'district': 'neighbourhood',
+        'street': 'street',
+        'house': 'address'
+    }
+
     def search_params(self, query, **kwargs):
         params = self._common_params(**kwargs)
         params['text'] = query
@@ -160,8 +170,8 @@ class PeliasApi(GenericApi):
         params = self._common_params(**kwargs)
         params['point.lat'], params['point.lon'] = center
         if 'detail' in kwargs:
-            if kwargs['detail'] == 'street' or kwargs['detail'] == 'house':
-                params['layers'] = 'address'
+            if kwargs['detail'] in self.DETAILS_LAYER_MAPPING:
+                params['layers'] = self.DETAILS_LAYER_MAPPING[kwargs['detail']]
             elif kwargs['detail']:
                 skip("Reverse geocoding detail level '{}' not supported."
                         .format(kwargs['detail']))

--- a/geocoder_tester/base.py
+++ b/geocoder_tester/base.py
@@ -67,6 +67,8 @@ class GenericApi:
             raise HttpSearchException(error="Non 200 response")
         return r.json()
 
+    def _transform_search_results(self, results):
+        return results
 
 class NominatimApi(GenericApi):
     """ Access proxy for Nominatim APIs. The API URL must be the base
@@ -109,9 +111,6 @@ class NominatimApi(GenericApi):
         if kwargs.get('lang'):
             params['accept-language'] = kwargs['lang']
         return params
-
-    def _transform_search_results(self, results):
-        return results
 
 class PhotonApi(GenericApi):
     """ Access proxy for Photon APIs. The API URL must be the base URL without


### PR DESCRIPTION
Besides overwriting the url/param methods, a _transform_results method is introduced, which may be overwritten by subclasses to transform the results to match nominatim/photon result style.
Note that this implementation is only tested against a light-weight [photon-pelias-adapter](https://github.com/mfdz/photon-pelias-adapter) and will require further param/request mappings to work against a plain pelias instance.