### PR TITLE
Reorganize french address tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -133,7 +133,7 @@ class CSVFile(pytest.File):
 
     def collect(self):
         with self.fspath.open(encoding="utf-8") as f:
-            dialect = csv.Sniffer().sniff(f.read(1024))
+            dialect = csv.Sniffer().sniff(f.read(2000))
             f.seek(0)
             reader = csv.DictReader(f, dialect=dialect)
             for row in reader:

--- a/geocoder_tester/world/france/alsace/test_addresses.csv
+++ b/geocoder_tester/world/france/alsace/test_addresses.csv
@@ -1,286 +1,286 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-25 Rue du Presbytère Barembach,,,,25 Rue du Presbytère,,,,67130
-25 Rue du Presbytère 67130,,,,25 Rue du Presbytère,,,Barembach,
-25 Rue du Presbytère,7.226703,48.476278,,25 Rue du Presbytère,,,,67130
-11 Rue de la Caverne Bernardswiller,,,,11 Rue de la Caverne,,,,67210
-11 Rue de la Caverne 67210,,,,11 Rue de la Caverne,,,Bernardswiller,
-11 Rue de la Caverne,7.464688,48.452444,,11 Rue de la Caverne,,,,67210
-18 Rue des Faisans Bischoffsheim,,,,18 Rue des Faisans,,,,67870
-18 Rue des Faisans 67870,,,,18 Rue des Faisans,,,Bischoffsheim,
-18 Rue des Faisans,7.491344,48.489234,,18 Rue des Faisans,,,,67870
-3A Rue de l'Église Bœrsch,,,,3A Rue de l'Église,,,,67530
-3A Rue de l'Église 67530,,,,3A Rue de l'Église,,,Bœrsch,
-3A Rue de l'Église,7.440072,48.478118,,3A Rue de l'Église,,,,67530
-117 Rue du Général de Gaulle La Broque,,,,117 Rue du Général de Gaulle,,,,67570
-117 Rue du Général de Gaulle 67570,,,,117 Rue du Général de Gaulle,,,La Broque,
-117 Rue du Général de Gaulle,7.212540,48.469093,,117 Rue du Général de Gaulle,,,,67570
-20 Rue du Luberon Châtenois,,,,20 Rue du Luberon,,,,67730
-20 Rue du Luberon 67730,,,,20 Rue du Luberon,,,Châtenois,
-20 Rue du Luberon,7.408357,48.268283,,20 Rue du Luberon,,,,67730
-9 Rue de l'Étang Dehlingen,,,,9 Rue de l'Étang,,,,67430
-9 Rue de l'Étang 67430,,,,9 Rue de l'Étang,,,,67430
-9 Rue de l'Étang,7.192760,48.981824,,9 Rue de l'Étang,,,,67430
-121 Rue des Jardins Dossenheim-sur-Zinsel,,,,121 Rue des Jardins,,,,67330
-121 Rue des Jardins 67330,,,,121 Rue des Jardins,,,Dossenheim-sur-Zinsel,
-121 Rue des Jardins,7.403113,48.804362,,121 Rue des Jardins,,,,67330
-2 Rue des Tilleuls Duttlenheim,,,,2 Rue des Tilleuls,,,,67120
-2 Rue des Tilleuls 67120,,,,2 Rue des Tilleuls,,,Duttlenheim,
-2 Rue des Tilleuls,7.564662,48.526747,,2 Rue des Tilleuls,,,,67120
-20 Rue des Griottes Entzheim,,,,20 Rue des Griottes,,,,67960
-20 Rue des Griottes 67960,,,,20 Rue des Griottes,,,Entzheim,
-20 Rue des Griottes,7.642586,48.531972,,20 Rue des Griottes,,,,67960
-1B Rue des Fleurs Eschau,,,,1B Rue des Fleurs,,,,67114
-1B Rue des Fleurs 67114,,,,1B Rue des Fleurs,,,Eschau,
-1B Rue des Fleurs,7.723727,48.486679,,1B Rue des Fleurs,,,,67114
-5 Rue des Jardins Frœschwiller,,,,5 Rue des Jardins,,,,67360
-5 Rue des Jardins 67360,,,,5 Rue des Jardins,,,,67360
-5 Rue des Jardins,7.723738,48.945068,,5 Rue des Jardins,,,,67360
-4 Rue des Pierres Gerstheim,,,,4 Rue des Pierres,,,,67150
-4 Rue des Pierres 67150,,,,4 Rue des Pierres,,,Gerstheim,
-4 Rue des Pierres,7.702393,48.382072,,4 Rue des Pierres,,,,67150
-4 Rue des Traîneaux Gries,,,,4 Rue des Traîneaux,,,,67500
-4 Rue des Traîneaux 67500,,,,4 Rue des Traîneaux,,,Gries,
-4 Rue des Traîneaux,7.810676,48.756553,,4 Rue des Traîneaux,,,,67500
-5 Rue du Colonel d'Oberkirch Haguenau,,,,5 Rue du Colonel d'Oberkirch,,,,67580
-5 Rue du Colonel d'Oberkirch 67580,,,,5 Rue du Colonel d'Oberkirch,,,Haguenau,
-5 Rue du Colonel d'Oberkirch,7.784920,48.802638,,5 Rue du Colonel d'Oberkirch,,,,67580
-100 Route de Strasbourg Haguenau,,,,100 Route de Strasbourg,,,,67580
-100 Route de Strasbourg 67580,,,,100 Route de Strasbourg,,,Haguenau,
-100 Route de Strasbourg,7.767325,48.801744,,100 Route de Strasbourg,,,,67580
-8 Rue de Bischwiller Herrlisheim,,,,8 Rue de Bischwiller,,,,67850
-8 Rue de Bischwiller 67850,,,,8 Rue de Bischwiller,,,Herrlisheim,
-8 Rue de Bischwiller,7.906353,48.733468,,8 Rue de Bischwiller,,,,67850
-7 Rue André Malraux Hœnheim,,,,7 Rue André Malraux,,,,67800
-7 Rue André Malraux 67800,,,,7 Rue André Malraux,,,Hœnheim,
-7 Rue André Malraux,7.760714,48.623107,,7 Rue André Malraux,,,,67800
-12 Rue du Presbytère Holtzheim,,,,12 Rue du Presbytère,,,,67810
-12 Rue du Presbytère 67810,,,,12 Rue du Presbytère,,,Holtzheim,
-12 Rue du Presbytère,7.640938,48.560281,,12 Rue du Presbytère,,,,67810
-9 Rue des Roseaux Illkirch-Graffenstaden,,,,9 Rue des Roseaux,,,,67400
-9 Rue des Roseaux 67400,,,,9 Rue des Roseaux,,,Illkirch-Graffenstaden,
-9 Rue des Roseaux,7.719366,48.519699,,9 Rue des Roseaux,,,,67400
-138 Rue de la Libération Keskastel,,,,138 Rue de la Libération,,,,67260
-138 Rue de la Libération 67260,,,,138 Rue de la Libération,,,Keskastel,
-138 Rue de la Libération,7.044614,48.978884,,138 Rue de la Libération,,,,67260
-2 Route des Romains Kuttolsheim,,,,2 Route des Romains,,,,67520
-2 Route des Romains 67520,,,,2 Route des Romains,,,Kuttolsheim,
-2 Route des Romains,7.528702,48.642353,,2 Route des Romains,,,,67520
-16 Rue du Canal Lingolsheim,,,,16 Rue du Canal,,,,67380
-16 Rue du Canal 67380,,,,16 Rue du Canal,,,Lingolsheim,
-16 Rue du Canal,7.684866,48.563852,,16 Rue du Canal,,,,67380
-13 Rue de la Rivière Mackenheim,,,,13 Rue de la Rivière,,,,67390
-13 Rue de la Rivière 67390,,,,13 Rue de la Rivière,,,Mackenheim,
-13 Rue de la Rivière,7.566034,48.183103,,13 Rue de la Rivière,,,,67390
-84 Rue de Strasbourg Meistratzheim,,,,84 Rue de Strasbourg,,,,67210
-84 Rue de Strasbourg 67210,,,,84 Rue de Strasbourg,,,Meistratzheim,
-84 Rue de Strasbourg,7.548649,48.448995,,84 Rue de Strasbourg,,,,67210
-22A Rue Kling Molsheim,,,,22A Rue Kling,,,,67120
-22A Rue Kling 67120,,,,22A Rue Kling,,,Molsheim,
-22A Rue Kling,7.491387,48.537723,,22A Rue Kling,,,,67120
-4 Rue Gounod Mundolsheim,,,,4 Rue Gounod,,,,67450
-4 Rue Gounod 67450,,,,4 Rue Gounod,,,Mundolsheim,
-4 Rue Gounod,7.710180,48.638481,,4 Rue Gounod,,,,67450
-7 Impasse des la Corderie Niederbronn-les-Bains,,,,7 Impasse des la Corderie,,,,67110
-7 Impasse des la Corderie 67110,,,,7 Impasse des la Corderie,,,Niederbronn-les-Bains,
-7 Impasse des la Corderie,7.652212,48.944879,,7 Impasse des la Corderie,,,,67110
-10 Rue du Général Walter Obenheim,,,,10 Rue du Général Walter,,,,67230
-10 Rue du Général Walter 67230,,,,10 Rue du Général Walter,,,Obenheim,
-10 Rue du Général Walter,7.689310,48.358187,,10 Rue du Général Walter,,,,67230
-4 Rue de Bouxwiller Obermodern-Zutzendorf,,,,4 Rue de Bouxwiller,,,,67330
-4 Rue de Bouxwiller 67330,,,,4 Rue de Bouxwiller,,,,67330
-4 Rue de Bouxwiller,7.538443,48.844463,,4 Rue de Bouxwiller,,,,67330
-1 Rue de la Glockengrube Obersteinbach,,,,1 Rue de la Glockengrube,,,,67510
-1 Rue de la Glockengrube 67510,,,,1 Rue de la Glockengrube,,,Obersteinbach,
-1 Rue de la Glockengrube,7.690583,49.034806,,1 Rue de la Glockengrube,,,,67510
-42 Rue du Maréchal Foch Ostwald,,,,42 Rue du Maréchal Foch,,,,67540
-42 Rue du Maréchal Foch 67540,,,,42 Rue du Maréchal Foch,,,Ostwald,
-42 Rue du Maréchal Foch,7.710164,48.539864,,42 Rue du Maréchal Foch,,,,67540
-275 Route des Princes A Champenay Plaine,,,,275 Route des Princes A Champenay,,,,67420
-275 Route des Princes A Champenay 67420,,,,275 Route des Princes A Champenay,,,Plaine,
-275 Route des Princes A Champenay,7.128735,48.416770,,275 Route des Princes A Champenay,,,,67420
-9 Rue du Climont Reichstett,,,,9 Rue du Climont,,,,67116
-9 Rue du Climont 67116,,,,9 Rue du Climont,,,Reichstett,
-9 Rue du Climont,7.748732,48.643798,,9 Rue du Climont,,,,67116
-18 Rue Neumatt Rohrwiller,,,,18 Rue Neumatt,,,,67410
-18 Rue Neumatt 67410,,,,18 Rue Neumatt,,,Rohrwiller,
-18 Rue Neumatt,7.911118,48.756954,,18 Rue Neumatt,,,,67410
-18 Rue Neuve Rountzenheim,,,,18 Rue Neuve,,,,67480
-18 Rue Neuve 67480,,,,18 Rue Neuve,,,,67480
-18 Rue Neuve,8.005745,48.816675,,18 Rue Neuve,,,,67480
-1 Rue devant le Sapinot Saulxures,,,,1 Rue devant le Sapinot,,,,67420
-1 Rue devant le Sapinot 67420,,,,1 Rue devant le Sapinot,,,Saulxures,
-1 Rue devant le Sapinot,7.130698,48.391071,,1 Rue devant le Sapinot,,,,67420
-1 Rue Sainte-Odile Scherwiller,,,,1 Rue Sainte-Odile,,,,67750
-1 Rue Sainte-Odile 67750,,,,1 Rue Sainte-Odile,,,Scherwiller,
-1 Rue Sainte-Odile,7.425547,48.287263,,1 Rue Sainte-Odile,,,,67750
-85 Rue Principale Schirrhein,,,,85 Rue Principale,,,,67240
-85 Rue Principale 67240,,,,85 Rue Principale,,,,67240
-85 Rue Principale,7.907268,48.801731,,85 Rue Principale,,,,67240
-15 Rue du Bernstein Sélestat,,,,15 Rue du Bernstein,,,,67600
-15 Rue du Bernstein 67600,,,,15 Rue du Bernstein,,,,67600
-15 Rue du Bernstein,7.439836,48.265841,,15 Rue du Bernstein,,,,67600
-27 Rue du Rhin Seltz,,,,27 Rue du Rhin,,,,67470
-27 Rue du Rhin 67470,,,,27 Rue du Rhin,,,,67470
-27 Rue du Rhin,8.108368,48.891956,,27 Rue du Rhin,,,,67470
-12 Rue de la Montée Soufflenheim,,,,12 Rue de la Montée,,,,67620
-12 Rue de la Montée 67620,,,,12 Rue de la Montée,,,Soufflenheim,
-12 Rue de la Montée,7.960217,48.830964,,12 Rue de la Montée,,,,67620
-31 Rue Ampère Strasbourg,,,,31 Rue Ampère,,,,67200
-31 Rue Ampère 67200,,,,31 Rue Ampère,,,Strasbourg,
-31 Rue Ampère,7.787299,48.559960,,31 Rue Ampère,,,,67200
-20 Rue des Coquelicots Strasbourg,,,,20 Rue des Coquelicots,,,,67200
-20 Rue des Coquelicots 67200,,,,20 Rue des Coquelicots,,,Strasbourg,
-20 Rue des Coquelicots,7.713764,48.591024,,20 Rue des Coquelicots,,,,67200
-4A Rue Grimling Strasbourg,,,,4A Rue Grimling,,,,67200
-4A Rue Grimling 67200,,,,4A Rue Grimling,,,Strasbourg,
-4A Rue Grimling,7.716049,48.592258,,4A Rue Grimling,,,,67200
-16 Rue Martin Bucer Strasbourg,,,,16 Rue Martin Bucer,,,,67200
-16 Rue Martin Bucer 67200,,,,16 Rue Martin Bucer,,,Strasbourg,
-16 Rue Martin Bucer,7.733269,48.581744,,16 Rue Martin Bucer,,,,67200
-7 Allée de la Robertsau Strasbourg,,,,7 Allée de la Robertsau,,,,67200
-7 Allée de la Robertsau 67200,,,,7 Allée de la Robertsau,,,Strasbourg,
-7 Allée de la Robertsau,7.763822,48.587026,,7 Allée de la Robertsau,,,,67200
-364 Route de la Wantzenau Strasbourg,,,,364 Route de la Wantzenau,,,,67200
-364 Route de la Wantzenau 67200,,,,364 Route de la Wantzenau,,,Strasbourg,
-364 Route de la Wantzenau,7.805397,48.626456,,364 Route de la Wantzenau,,,,67200
-2 Rue du Tramway Truchtersheim,,,,2 Rue du Tramway,,,,67370
-2 Rue du Tramway 67370,,,,2 Rue du Tramway,,,Truchtersheim,
-2 Rue du Tramway,7.604881,48.660365,,2 Rue du Tramway,,,,67370
-30 Rue de Neuve-Église Villé,,,,30 Rue de Neuve-Église,,,,67220
-30 Rue de Neuve-Église 67220,,,,30 Rue de Neuve-Église,,,Villé,
-30 Rue de Neuve-Église,7.308993,48.339872,,30 Rue de Neuve-Église,,,,67220
-16 Rue des Glaïeuls Wasselonne,,,,16 Rue des Glaïeuls,,,,67310
-16 Rue des Glaïeuls 67310,,,,16 Rue des Glaïeuls,,,Wasselonne,
-16 Rue des Glaïeuls,7.435555,48.642018,,16 Rue des Glaïeuls,,,,67310
-37 Rue de la République Weyersheim,,,,37 Rue de la République,,,,67720
-37 Rue de la République 67720,,,,37 Rue de la République,,,,67720
-37 Rue de la République,7.801562,48.713851,,37 Rue de la République,,,,67720
-16 Rue de la Pépinière Wissembourg,,,,16 Rue de la Pépinière,,,,67160
-16 Rue de la Pépinière 67160,,,,16 Rue de la Pépinière,,,Wissembourg,
-16 Rue de la Pépinière,7.945915,49.030927,,16 Rue de la Pépinière,,,,67160
-33 Rue Griesberg Zinswiller,,,,33 Rue Griesberg,,,,67110
-33 Rue Griesberg 67110,,,,33 Rue Griesberg,,,Zinswiller,
-33 Rue Griesberg,7.591655,48.914191,,33 Rue Griesberg,,,,67110
-16 Rue Gabarret Attenschwiller,,,,16 Rue Gabarret,,,,68220
-16 Rue Gabarret 68220,,,,16 Rue Gabarret,,,Attenschwiller,
-16 Rue Gabarret,7.460162,47.568486,,16 Rue Gabarret,,,,68220
-66 Rue Principale Battenheim,,,,66 Rue Principale,,,,68390
-66 Rue Principale 68390,,,,66 Rue Principale,,,Battenheim,
-66 Rue Principale,7.382636,47.819767,,66 Rue Principale,,,,68390
-3 Rue Principale Bisel,,,,3 Rue Principale,,,,68580
-3 Rue Principale 68580,,,,3 Rue Principale,,,,68580
-3 Rue Principale,7.217449,47.535778,,3 Rue Principale,,,,68580
-34 Rue de la Gare Breitenbach-Haut-Rhin,,,,34 Rue de la Gare,,,,68380
-34 Rue de la Gare 68380,,,,34 Rue de la Gare,,,Breitenbach-Haut-Rhin,
-34 Rue de la Gare,7.099529,48.024870,,34 Rue de la Gare,,,,68380
-30 Rue Oberdorf Carspach,,,,30 Rue Oberdorf,,,,68130
-30 Rue Oberdorf 68130,,,,30 Rue Oberdorf,,,Carspach,
-30 Rue Oberdorf,7.207591,47.616122,,30 Rue Oberdorf,,,,68130
-45 Rue du Cardinal Mercier Colmar,,,,45 Rue du Cardinal Mercier,,,,68000
-45 Rue du Cardinal Mercier 68000,,,,45 Rue du Cardinal Mercier,,,Colmar,
-45 Rue du Cardinal Mercier,7.341848,48.071366,,45 Rue du Cardinal Mercier,,,,68000
-4 Rue Nefftzer Colmar,,,,4 Rue Nefftzer,,,,68000
-4 Rue Nefftzer 68000,,,,4 Rue Nefftzer,,,Colmar,
-4 Rue Nefftzer,7.366773,48.078512,,4 Rue Nefftzer,,,,68000
-5 Rue des Jonquilles Dannemarie,,,,5 Rue des Jonquilles,,,,68210
-5 Rue des Jonquilles 68210,,,,5 Rue des Jonquilles,,,Dannemarie,
-5 Rue des Jonquilles,7.131367,47.628606,,5 Rue des Jonquilles,,,,68210
-16 Rue Jean Rasser Ensisheim,,,,16 Rue Jean Rasser,,,,68190
-16 Rue Jean Rasser 68190,,,,16 Rue Jean Rasser,,,Ensisheim,
-16 Rue Jean Rasser,7.353161,47.868393,,16 Rue Jean Rasser,,,,68190
-3 Rue de la Wanne Flaxlanden,,,,3 Rue de la Wanne,,,,68720
-3 Rue de la Wanne 68720,,,,3 Rue de la Wanne,,,Flaxlanden,
-3 Rue de la Wanne,7.314013,47.694769,,3 Rue de la Wanne,,,,68720
-15 Rue du Général de Gaulle Guebwiller,,,,15 Rue du Général de Gaulle,,,,68500
-15 Rue du Général de Gaulle 68500,,,,15 Rue du Général de Gaulle,,,,68500
-15 Rue du Général de Gaulle,7.213803,47.909945,,15 Rue du Général de Gaulle,,,,68500
-48 Rue de Delle Hagenbach,,,,48 Rue de Delle,,,,68210
-48 Rue de Delle 68210,,,,48 Rue de Delle,,,Hagenbach,
-48 Rue de Delle,7.155796,47.649741,,48 Rue de Delle,,,,68210
-1 Rue des Perdrix Herrlisheim-près-Colmar,,,,1 Rue des Perdrix,,,,68420
-1 Rue des Perdrix 68420,,,,1 Rue des Perdrix,,,Herrlisheim-près-Colmar,
-1 Rue des Perdrix,7.322201,48.021958,,1 Rue des Perdrix,,,,68420
-7C Rue de la Hardt Hombourg,,,,7C Rue de la Hardt,,,,68490
-7C Rue de la Hardt 68490,,,,7C Rue de la Hardt,,,Hombourg,
-7C Rue de la Hardt,7.503440,47.758244,,7C Rue de la Hardt,,,,68490
-3 Route d'Elsenheim Illhaeusern,,,,3 Route d'Elsenheim,,,,68970
-3 Route d'Elsenheim 68970,,,,3 Route d'Elsenheim,,,Illhaeusern,
-3 Route d'Elsenheim,7.437233,48.182285,,3 Route d'Elsenheim,,,,68970
-41 Rue Ostein Issenheim,,,,41 Rue Ostein,,,,68500
-41 Rue Ostein 68500,,,,41 Rue Ostein,,,Issenheim,
-41 Rue Ostein,7.258484,47.903761,,41 Rue Ostein,,,,68500
-19 Rue de Brest Kingersheim,,,,19 Rue de Brest,,,,68260
-19 Rue de Brest 68260,,,,19 Rue de Brest,,,Kingersheim,
-19 Rue de Brest,7.342510,47.791139,,19 Rue de Brest,,,,68260
-2 Rue des Violettes Kunheim,,,,2 Rue des Violettes,,,,68320
-2 Rue des Violettes 68320,,,,2 Rue des Violettes,,,Kunheim,
-2 Rue des Violettes,7.540050,48.074840,,2 Rue des Violettes,,,,68320
-12 Rue du Cuir Luemschwiller,,,,12 Rue du Cuir,,,,68720
-12 Rue du Cuir 68720,,,,12 Rue du Cuir,,,Luemschwiller,
-12 Rue du Cuir,7.289562,47.654579,,12 Rue du Cuir,,,,68720
-3 Rue du Gaschney Metzeral,,,,3 Rue du Gaschney,,,,68380
-3 Rue du Gaschney 68380,,,,3 Rue du Gaschney,,,Metzeral,
-3 Rue du Gaschney,7.071714,48.015184,,3 Rue du Gaschney,,,,68380
-9 Rue du 1er Septembre Muespach,,,,9 Rue du 1er Septembre,,,,68640
-9 Rue du 1er Septembre 68640,,,,9 Rue du 1er Septembre,,,Muespach,
-9 Rue du 1er Septembre,7.374443,47.547891,,9 Rue du 1er Septembre,,,,68640
-13 Rue du Docteur Léon Mangeney Mulhouse,,,,13 Rue du Docteur Léon Mangeney,,,,68200
-13 Rue du Docteur Léon Mangeney 68200,,,,13 Rue du Docteur Léon Mangeney,,,Mulhouse,
-13 Rue du Docteur Léon Mangeney,7.342555,47.726494,,13 Rue du Docteur Léon Mangeney,,,,68200
-10 Avenue du Maréchal Joffre Mulhouse,,,,10 Avenue du Maréchal Joffre,,,,68200
-10 Avenue du Maréchal Joffre 68200,,,,10 Avenue du Maréchal Joffre,,,Mulhouse,
-10 Avenue du Maréchal Joffre,7.342825,47.745284,,10 Avenue du Maréchal Joffre,,,,68200
-52 Rue des Taillis Mulhouse,,,,52 Rue des Taillis,,,,68200
-52 Rue des Taillis 68200,,,,52 Rue des Taillis,,,Mulhouse,
-52 Rue des Taillis,7.333585,47.779997,,52 Rue des Taillis,,,,68200
-22 Rue de l'Avenir Niederentzen,,,,22 Rue de l'Avenir,,,,68127
-22 Rue de l'Avenir 68127,,,,22 Rue de l'Avenir,,,Niederentzen,
-22 Rue de l'Avenir,7.383667,47.950845,,22 Rue de l'Avenir,,,,68127
-8 Rue des Églantines Osenbach,,,,8 Rue des Églantines,,,,68570
-8 Rue des Églantines 68570,,,,8 Rue des Églantines,,,Osenbach,
-8 Rue des Églantines,7.213712,47.990746,,8 Rue des Églantines,,,,68570
-15 Rue de Bretagne Pulversheim,,,,15 Rue de Bretagne,,,,68840
-15 Rue de Bretagne 68840,,,,15 Rue de Bretagne,,,Pulversheim,
-15 Rue de Bretagne,7.306745,47.839383,,15 Rue de Bretagne,,,,68840
-4 Rue de l'Iris Ribeauvillé,,,,4 Rue de l'Iris,,,,68150
-4 Rue de l'Iris 68150,,,,4 Rue de l'Iris,,,Ribeauvillé,
-4 Rue de l'Iris,7.340012,48.192233,,4 Rue de l'Iris,,,,68150
-8 Rue des Vanneaux Riedwihr,,,,8 Rue des Vanneaux,,,,68320
-8 Rue des Vanneaux 68320,,,,8 Rue des Vanneaux,,,Riedwihr,
-8 Rue des Vanneaux,7.446697,48.128654,,8 Rue des Vanneaux,,,,68320
-10 Route de Thann Roderen,,,,10 Route de Thann,,,,68800
-10 Route de Thann 68800,,,,10 Route de Thann,,,Roderen,
-10 Route de Thann,7.094919,47.780043,,10 Route de Thann,,,,68800
-6 Rue de la Carrière Saint-Amarin,,,,6 Rue de la Carrière,,,,68550
-6 Rue de la Carrière 68550,,,,6 Rue de la Carrière,,,Saint-Amarin,
-6 Rue de la Carrière,7.028252,47.876003,,6 Rue de la Carrière,,,,68550
-15 Rue du Paradis Saint-Louis,,,,15 Rue du Paradis,,,,68300
-15 Rue du Paradis 68300,,,,15 Rue du Paradis,,,Saint-Louis,
-15 Rue du Paradis,7.554034,47.582951,,15 Rue du Paradis,,,,68300
-2 Rue de Bettendorf Schwoben,,,,2 Rue de Bettendorf,,,,68130
-2 Rue de Bettendorf 68130,,,,2 Rue de Bettendorf,,,Schwoben,
-2 Rue de Bettendorf,7.300961,47.616148,,2 Rue de Bettendorf,,,,68130
-9 Rue des Soeurs Soultz-Haut-Rhin,,,,9 Rue des Soeurs,,,,68360
-9 Rue des Soeurs 68360,,,,9 Rue des Soeurs,,,Soultz-Haut-Rhin,
-9 Rue des Soeurs,7.230580,47.885942,,9 Rue des Soeurs,,,,68360
-4 Rue de Roppentzwiller Steinsoultz,,,,4 Rue de Roppentzwiller,,,,68640
-4 Rue de Roppentzwiller 68640,,,,4 Rue de Roppentzwiller,,,,68640
-4 Rue de Roppentzwiller,7.336025,47.549512,,4 Rue de Roppentzwiller,,,,68640
-33 Rue Florimont Turckheim,,,,33 Rue Florimont,,,,68230
-33 Rue Florimont 68230,,,,33 Rue Florimont,,,Turckheim,
-33 Rue Florimont,7.284214,48.089840,,33 Rue Florimont,,,,68230
-59 Rue du Maréchal Foch Village-Neuf,,,,59 Rue du Maréchal Foch,,,,68128
-59 Rue du Maréchal Foch 68128,,,,59 Rue du Maréchal Foch,,,Village-Neuf,
-59 Rue du Maréchal Foch,7.568083,47.609427,,59 Rue du Maréchal Foch,,,,68128
-42 Rue de Soultzmatt Westhalten,,,,42 Rue de Soultzmatt,,,,68250
-42 Rue de Soultzmatt 68250,,,,42 Rue de Soultzmatt,,,Westhalten,
-42 Rue de Soultzmatt,7.256254,47.957205,,42 Rue de Soultzmatt,,,,68250
-7B Rue de l'Avenir Wittelsheim,,,,7B Rue de l'Avenir,,,,68310
-7B Rue de l'Avenir 68310,,,,7B Rue de l'Avenir,,,Wittelsheim,
-7B Rue de l'Avenir,7.242469,47.805817,,7B Rue de l'Avenir,,,,68310
-12 Rue de la Forêt Wittenheim,,,,12 Rue de la Forêt,,,,68270
-12 Rue de la Forêt 68270,,,,12 Rue de la Forêt,,,Wittenheim,
-12 Rue de la Forêt,7.333542,47.808725,,12 Rue de la Forêt,,,,68270
-2 Rue Bellevue Zillisheim,,,,2 Rue Bellevue,,,,68720
-2 Rue Bellevue 68720,,,,2 Rue Bellevue,,,Zillisheim,
-2 Rue Bellevue,7.293475,47.693405,,2 Rue Bellevue,,,,68720
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+25 Rue du Presbytère Barembach,,,,25,Rue du Presbytère,,67130
+25 Rue du Presbytère 67130,,,,25,Rue du Presbytère,Barembach,
+25 Rue du Presbytère,7.226703,48.476278,,25,Rue du Presbytère,,67130
+11 Rue de la Caverne Bernardswiller,,,,11,Rue de la Caverne,,67210
+11 Rue de la Caverne 67210,,,,11,Rue de la Caverne,Bernardswiller,
+11 Rue de la Caverne,7.464688,48.452444,,11,Rue de la Caverne,,67210
+18 Rue des Faisans Bischoffsheim,,,,18,Rue des Faisans,,67870
+18 Rue des Faisans 67870,,,,18,Rue des Faisans,Bischoffsheim,
+18 Rue des Faisans,7.491344,48.489234,,18,Rue des Faisans,,67870
+3A Rue de l'Église Bœrsch,,,,3A,Rue de l'Église,,67530
+3A Rue de l'Église 67530,,,,3A,Rue de l'Église,Bœrsch,
+3A Rue de l'Église,7.440072,48.478118,,3A,Rue de l'Église,,67530
+117 Rue du Général de Gaulle La Broque,,,,117,Rue du Général de Gaulle,,67570
+117 Rue du Général de Gaulle 67570,,,,117,Rue du Général de Gaulle,La Broque,
+117 Rue du Général de Gaulle,7.21254,48.469093,,117,Rue du Général de Gaulle,,67570
+20 Rue du Luberon Châtenois,,,,20,Rue du Luberon,,67730
+20 Rue du Luberon 67730,,,,20,Rue du Luberon,Châtenois,
+20 Rue du Luberon,7.408357,48.268283,,20,Rue du Luberon,,67730
+9 Rue de l'Étang Dehlingen,,,,9,Rue de l'Étang,,67430
+9 Rue de l'Étang 67430,,,,9,Rue de l'Étang,,67430
+9 Rue de l'Étang,7.19276,48.981824,,9,Rue de l'Étang,,67430
+121 Rue des Jardins Dossenheim-sur-Zinsel,,,,121,Rue des Jardins,,67330
+121 Rue des Jardins 67330,,,,121,Rue des Jardins,Dossenheim-sur-Zinsel,
+121 Rue des Jardins,7.403113,48.804362,,121,Rue des Jardins,,67330
+2 Rue des Tilleuls Duttlenheim,,,,2,Rue des Tilleuls,,67120
+2 Rue des Tilleuls 67120,,,,2,Rue des Tilleuls,Duttlenheim,
+2 Rue des Tilleuls,7.564662,48.526747,,2,Rue des Tilleuls,,67120
+20 Rue des Griottes Entzheim,,,,20,Rue des Griottes,,67960
+20 Rue des Griottes 67960,,,,20,Rue des Griottes,Entzheim,
+20 Rue des Griottes,7.642586,48.531972,,20,Rue des Griottes,,67960
+1B Rue des Fleurs Eschau,,,,1B,Rue des Fleurs,,67114
+1B Rue des Fleurs 67114,,,,1B,Rue des Fleurs,Eschau,
+1B Rue des Fleurs,7.723727,48.486679,,1B,Rue des Fleurs,,67114
+5 Rue des Jardins Frœschwiller,,,,5,Rue des Jardins,,67360
+5 Rue des Jardins 67360,,,,5,Rue des Jardins,,67360
+5 Rue des Jardins,7.723738,48.945068,,5,Rue des Jardins,,67360
+4 Rue des Pierres Gerstheim,,,,4,Rue des Pierres,,67150
+4 Rue des Pierres 67150,,,,4,Rue des Pierres,Gerstheim,
+4 Rue des Pierres,7.702393,48.382072,,4,Rue des Pierres,,67150
+4 Rue des Traîneaux Gries,,,,4,Rue des Traîneaux,,67500
+4 Rue des Traîneaux 67500,,,,4,Rue des Traîneaux,Gries,
+4 Rue des Traîneaux,7.810676,48.756553,,4,Rue des Traîneaux,,67500
+5 Rue du Colonel d'Oberkirch Haguenau,,,,5,Rue du Colonel d'Oberkirch,,67580
+5 Rue du Colonel d'Oberkirch 67580,,,,5,Rue du Colonel d'Oberkirch,Haguenau,
+5 Rue du Colonel d'Oberkirch,7.78492,48.802638,,5,Rue du Colonel d'Oberkirch,,67580
+100 Route de Strasbourg Haguenau,,,,100,Route de Strasbourg,,67580
+100 Route de Strasbourg 67580,,,,100,Route de Strasbourg,Haguenau,
+100 Route de Strasbourg,7.767325,48.801744,,100,Route de Strasbourg,,67580
+8 Rue de Bischwiller Herrlisheim,,,,8,Rue de Bischwiller,,67850
+8 Rue de Bischwiller 67850,,,,8,Rue de Bischwiller,Herrlisheim,
+8 Rue de Bischwiller,7.906353,48.733468,,8,Rue de Bischwiller,,67850
+7 Rue André Malraux Hœnheim,,,,7,Rue André Malraux,,67800
+7 Rue André Malraux 67800,,,,7,Rue André Malraux,Hœnheim,
+7 Rue André Malraux,7.760714,48.623107,,7,Rue André Malraux,,67800
+12 Rue du Presbytère Holtzheim,,,,12,Rue du Presbytère,,67810
+12 Rue du Presbytère 67810,,,,12,Rue du Presbytère,Holtzheim,
+12 Rue du Presbytère,7.640938,48.560281,,12,Rue du Presbytère,,67810
+9 Rue des Roseaux Illkirch-Graffenstaden,,,,9,Rue des Roseaux,,67400
+9 Rue des Roseaux 67400,,,,9,Rue des Roseaux,Illkirch-Graffenstaden,
+9 Rue des Roseaux,7.719366,48.519699,,9,Rue des Roseaux,,67400
+138 Rue de la Libération Keskastel,,,,138,Rue de la Libération,,67260
+138 Rue de la Libération 67260,,,,138,Rue de la Libération,Keskastel,
+138 Rue de la Libération,7.044614,48.978884,,138,Rue de la Libération,,67260
+2 Route des Romains Kuttolsheim,,,,2,Route des Romains,,67520
+2 Route des Romains 67520,,,,2,Route des Romains,Kuttolsheim,
+2 Route des Romains,7.528702,48.642353,,2,Route des Romains,,67520
+16 Rue du Canal Lingolsheim,,,,16,Rue du Canal,,67380
+16 Rue du Canal 67380,,,,16,Rue du Canal,Lingolsheim,
+16 Rue du Canal,7.684866,48.563852,,16,Rue du Canal,,67380
+13 Rue de la Rivière Mackenheim,,,,13,Rue de la Rivière,,67390
+13 Rue de la Rivière 67390,,,,13,Rue de la Rivière,Mackenheim,
+13 Rue de la Rivière,7.566034,48.183103,,13,Rue de la Rivière,,67390
+84 Rue de Strasbourg Meistratzheim,,,,84,Rue de Strasbourg,,67210
+84 Rue de Strasbourg 67210,,,,84,Rue de Strasbourg,Meistratzheim,
+84 Rue de Strasbourg,7.548649,48.448995,,84,Rue de Strasbourg,,67210
+22A Rue Kling Molsheim,,,,22A,Rue Kling,,67120
+22A Rue Kling 67120,,,,22A,Rue Kling,Molsheim,
+22A Rue Kling,7.491387,48.537723,,22A,Rue Kling,,67120
+4 Rue Gounod Mundolsheim,,,,4,Rue Gounod,,67450
+4 Rue Gounod 67450,,,,4,Rue Gounod,Mundolsheim,
+4 Rue Gounod,7.71018,48.638481,,4,Rue Gounod,,67450
+7 Impasse des la Corderie Niederbronn-les-Bains,,,,7,Impasse des la Corderie,,67110
+7 Impasse des la Corderie 67110,,,,7,Impasse des la Corderie,Niederbronn-les-Bains,
+7 Impasse des la Corderie,7.652212,48.944879,,7,Impasse des la Corderie,,67110
+10 Rue du Général Walter Obenheim,,,,10,Rue du Général Walter,,67230
+10 Rue du Général Walter 67230,,,,10,Rue du Général Walter,Obenheim,
+10 Rue du Général Walter,7.68931,48.358187,,10,Rue du Général Walter,,67230
+4 Rue de Bouxwiller Obermodern-Zutzendorf,,,,4,Rue de Bouxwiller,,67330
+4 Rue de Bouxwiller 67330,,,,4,Rue de Bouxwiller,,67330
+4 Rue de Bouxwiller,7.538443,48.844463,,4,Rue de Bouxwiller,,67330
+1 Rue de la Glockengrube Obersteinbach,,,,1,Rue de la Glockengrube,,67510
+1 Rue de la Glockengrube 67510,,,,1,Rue de la Glockengrube,Obersteinbach,
+1 Rue de la Glockengrube,7.690583,49.034806,,1,Rue de la Glockengrube,,67510
+42 Rue du Maréchal Foch Ostwald,,,,42,Rue du Maréchal Foch,,67540
+42 Rue du Maréchal Foch 67540,,,,42,Rue du Maréchal Foch,Ostwald,
+42 Rue du Maréchal Foch,7.710164,48.539864,,42,Rue du Maréchal Foch,,67540
+275 Route des Princes A Champenay Plaine,,,,275,Route des Princes A Champenay,,67420
+275 Route des Princes A Champenay 67420,,,,275,Route des Princes A Champenay,Plaine,
+275 Route des Princes A Champenay,7.128735,48.41677,,275,Route des Princes A Champenay,,67420
+9 Rue du Climont Reichstett,,,,9,Rue du Climont,,67116
+9 Rue du Climont 67116,,,,9,Rue du Climont,Reichstett,
+9 Rue du Climont,7.748732,48.643798,,9,Rue du Climont,,67116
+18 Rue Neumatt Rohrwiller,,,,18,Rue Neumatt,,67410
+18 Rue Neumatt 67410,,,,18,Rue Neumatt,Rohrwiller,
+18 Rue Neumatt,7.911118,48.756954,,18,Rue Neumatt,,67410
+18 Rue Neuve Rountzenheim,,,,18,Rue Neuve,,67480
+18 Rue Neuve 67480,,,,18,Rue Neuve,,67480
+18 Rue Neuve,8.005745,48.816675,,18,Rue Neuve,,67480
+1 Rue devant le Sapinot Saulxures,,,,1,Rue devant le Sapinot,,67420
+1 Rue devant le Sapinot 67420,,,,1,Rue devant le Sapinot,Saulxures,
+1 Rue devant le Sapinot,7.130698,48.391071,,1,Rue devant le Sapinot,,67420
+1 Rue Sainte-Odile Scherwiller,,,,1,Rue Sainte-Odile,,67750
+1 Rue Sainte-Odile 67750,,,,1,Rue Sainte-Odile,Scherwiller,
+1 Rue Sainte-Odile,7.425547,48.287263,,1,Rue Sainte-Odile,,67750
+85 Rue Principale Schirrhein,,,,85,Rue Principale,,67240
+85 Rue Principale 67240,,,,85,Rue Principale,,67240
+85 Rue Principale,7.907268,48.801731,,85,Rue Principale,,67240
+15 Rue du Bernstein Sélestat,,,,15,Rue du Bernstein,,67600
+15 Rue du Bernstein 67600,,,,15,Rue du Bernstein,,67600
+15 Rue du Bernstein,7.439836,48.265841,,15,Rue du Bernstein,,67600
+27 Rue du Rhin Seltz,,,,27,Rue du Rhin,,67470
+27 Rue du Rhin 67470,,,,27,Rue du Rhin,,67470
+27 Rue du Rhin,8.108368,48.891956,,27,Rue du Rhin,,67470
+12 Rue de la Montée Soufflenheim,,,,12,Rue de la Montée,,67620
+12 Rue de la Montée 67620,,,,12,Rue de la Montée,Soufflenheim,
+12 Rue de la Montée,7.960217,48.830964,,12,Rue de la Montée,,67620
+31 Rue Ampère Strasbourg,,,,31,Rue Ampère,,67200
+31 Rue Ampère 67200,,,,31,Rue Ampère,Strasbourg,
+31 Rue Ampère,7.787299,48.55996,,31,Rue Ampère,,67200
+20 Rue des Coquelicots Strasbourg,,,,20,Rue des Coquelicots,,67200
+20 Rue des Coquelicots 67200,,,,20,Rue des Coquelicots,Strasbourg,
+20 Rue des Coquelicots,7.713764,48.591024,,20,Rue des Coquelicots,,67200
+4A Rue Grimling Strasbourg,,,,4A,Rue Grimling,,67200
+4A Rue Grimling 67200,,,,4A,Rue Grimling,Strasbourg,
+4A Rue Grimling,7.716049,48.592258,,4A,Rue Grimling,,67200
+16 Rue Martin Bucer Strasbourg,,,,16,Rue Martin Bucer,,67200
+16 Rue Martin Bucer 67200,,,,16,Rue Martin Bucer,Strasbourg,
+16 Rue Martin Bucer,7.733269,48.581744,,16,Rue Martin Bucer,,67200
+7 Allée de la Robertsau Strasbourg,,,,7,Allée de la Robertsau,,67200
+7 Allée de la Robertsau 67200,,,,7,Allée de la Robertsau,Strasbourg,
+7 Allée de la Robertsau,7.763822,48.587026,,7,Allée de la Robertsau,,67200
+364 Route de la Wantzenau Strasbourg,,,,364,Route de la Wantzenau,,67200
+364 Route de la Wantzenau 67200,,,,364,Route de la Wantzenau,Strasbourg,
+364 Route de la Wantzenau,7.805397,48.626456,,364,Route de la Wantzenau,,67200
+2 Rue du Tramway Truchtersheim,,,,2,Rue du Tramway,,67370
+2 Rue du Tramway 67370,,,,2,Rue du Tramway,Truchtersheim,
+2 Rue du Tramway,7.604881,48.660365,,2,Rue du Tramway,,67370
+30 Rue de Neuve-Église Villé,,,,30,Rue de Neuve-Église,,67220
+30 Rue de Neuve-Église 67220,,,,30,Rue de Neuve-Église,Villé,
+30 Rue de Neuve-Église,7.308993,48.339872,,30,Rue de Neuve-Église,,67220
+16 Rue des Glaïeuls Wasselonne,,,,16,Rue des Glaïeuls,,67310
+16 Rue des Glaïeuls 67310,,,,16,Rue des Glaïeuls,Wasselonne,
+16 Rue des Glaïeuls,7.435555,48.642018,,16,Rue des Glaïeuls,,67310
+37 Rue de la République Weyersheim,,,,37,Rue de la République,,67720
+37 Rue de la République 67720,,,,37,Rue de la République,,67720
+37 Rue de la République,7.801562,48.713851,,37,Rue de la République,,67720
+16 Rue de la Pépinière Wissembourg,,,,16,Rue de la Pépinière,,67160
+16 Rue de la Pépinière 67160,,,,16,Rue de la Pépinière,Wissembourg,
+16 Rue de la Pépinière,7.945915,49.030927,,16,Rue de la Pépinière,,67160
+33 Rue Griesberg Zinswiller,,,,33,Rue Griesberg,,67110
+33 Rue Griesberg 67110,,,,33,Rue Griesberg,Zinswiller,
+33 Rue Griesberg,7.591655,48.914191,,33,Rue Griesberg,,67110
+16 Rue Gabarret Attenschwiller,,,,16,Rue Gabarret,,68220
+16 Rue Gabarret 68220,,,,16,Rue Gabarret,Attenschwiller,
+16 Rue Gabarret,7.460162,47.568486,,16,Rue Gabarret,,68220
+66 Rue Principale Battenheim,,,,66,Rue Principale,,68390
+66 Rue Principale 68390,,,,66,Rue Principale,Battenheim,
+66 Rue Principale,7.382636,47.819767,,66,Rue Principale,,68390
+3 Rue Principale Bisel,,,,3,Rue Principale,,68580
+3 Rue Principale 68580,,,,3,Rue Principale,,68580
+3 Rue Principale,7.217449,47.535778,,3,Rue Principale,,68580
+34 Rue de la Gare Breitenbach-Haut-Rhin,,,,34,Rue de la Gare,,68380
+34 Rue de la Gare 68380,,,,34,Rue de la Gare,Breitenbach-Haut-Rhin,
+34 Rue de la Gare,7.099529,48.02487,,34,Rue de la Gare,,68380
+30 Rue Oberdorf Carspach,,,,30,Rue Oberdorf,,68130
+30 Rue Oberdorf 68130,,,,30,Rue Oberdorf,Carspach,
+30 Rue Oberdorf,7.207591,47.616122,,30,Rue Oberdorf,,68130
+45 Rue du Cardinal Mercier Colmar,,,,45,Rue du Cardinal Mercier,,68000
+45 Rue du Cardinal Mercier 68000,,,,45,Rue du Cardinal Mercier,Colmar,
+45 Rue du Cardinal Mercier,7.341848,48.071366,,45,Rue du Cardinal Mercier,,68000
+4 Rue Nefftzer Colmar,,,,4,Rue Nefftzer,,68000
+4 Rue Nefftzer 68000,,,,4,Rue Nefftzer,Colmar,
+4 Rue Nefftzer,7.366773,48.078512,,4,Rue Nefftzer,,68000
+5 Rue des Jonquilles Dannemarie,,,,5,Rue des Jonquilles,,68210
+5 Rue des Jonquilles 68210,,,,5,Rue des Jonquilles,Dannemarie,
+5 Rue des Jonquilles,7.131367,47.628606,,5,Rue des Jonquilles,,68210
+16 Rue Jean Rasser Ensisheim,,,,16,Rue Jean Rasser,,68190
+16 Rue Jean Rasser 68190,,,,16,Rue Jean Rasser,Ensisheim,
+16 Rue Jean Rasser,7.353161,47.868393,,16,Rue Jean Rasser,,68190
+3 Rue de la Wanne Flaxlanden,,,,3,Rue de la Wanne,,68720
+3 Rue de la Wanne 68720,,,,3,Rue de la Wanne,Flaxlanden,
+3 Rue de la Wanne,7.314013,47.694769,,3,Rue de la Wanne,,68720
+15 Rue du Général de Gaulle Guebwiller,,,,15,Rue du Général de Gaulle,,68500
+15 Rue du Général de Gaulle 68500,,,,15,Rue du Général de Gaulle,,68500
+15 Rue du Général de Gaulle,7.213803,47.909945,,15,Rue du Général de Gaulle,,68500
+48 Rue de Delle Hagenbach,,,,48,Rue de Delle,,68210
+48 Rue de Delle 68210,,,,48,Rue de Delle,Hagenbach,
+48 Rue de Delle,7.155796,47.649741,,48,Rue de Delle,,68210
+1 Rue des Perdrix Herrlisheim-près-Colmar,,,,1,Rue des Perdrix,,68420
+1 Rue des Perdrix 68420,,,,1,Rue des Perdrix,Herrlisheim-près-Colmar,
+1 Rue des Perdrix,7.322201,48.021958,,1,Rue des Perdrix,,68420
+7C Rue de la Hardt Hombourg,,,,7C,Rue de la Hardt,,68490
+7C Rue de la Hardt 68490,,,,7C,Rue de la Hardt,Hombourg,
+7C Rue de la Hardt,7.50344,47.758244,,7C,Rue de la Hardt,,68490
+3 Route d'Elsenheim Illhaeusern,,,,3,Route d'Elsenheim,,68970
+3 Route d'Elsenheim 68970,,,,3,Route d'Elsenheim,Illhaeusern,
+3 Route d'Elsenheim,7.437233,48.182285,,3,Route d'Elsenheim,,68970
+41 Rue Ostein Issenheim,,,,41,Rue Ostein,,68500
+41 Rue Ostein 68500,,,,41,Rue Ostein,Issenheim,
+41 Rue Ostein,7.258484,47.903761,,41,Rue Ostein,,68500
+19 Rue de Brest Kingersheim,,,,19,Rue de Brest,,68260
+19 Rue de Brest 68260,,,,19,Rue de Brest,Kingersheim,
+19 Rue de Brest,7.34251,47.791139,,19,Rue de Brest,,68260
+2 Rue des Violettes Kunheim,,,,2,Rue des Violettes,,68320
+2 Rue des Violettes 68320,,,,2,Rue des Violettes,Kunheim,
+2 Rue des Violettes,7.54005,48.07484,,2,Rue des Violettes,,68320
+12 Rue du Cuir Luemschwiller,,,,12,Rue du Cuir,,68720
+12 Rue du Cuir 68720,,,,12,Rue du Cuir,Luemschwiller,
+12 Rue du Cuir,7.289562,47.654579,,12,Rue du Cuir,,68720
+3 Rue du Gaschney Metzeral,,,,3,Rue du Gaschney,,68380
+3 Rue du Gaschney 68380,,,,3,Rue du Gaschney,Metzeral,
+3 Rue du Gaschney,7.071714,48.015184,,3,Rue du Gaschney,,68380
+9 Rue du 1er Septembre Muespach,,,,9,Rue du 1er Septembre,,68640
+9 Rue du 1er Septembre 68640,,,,9,Rue du 1er Septembre,Muespach,
+9 Rue du 1er Septembre,7.374443,47.547891,,9,Rue du 1er Septembre,,68640
+13 Rue du Docteur Léon Mangeney Mulhouse,,,,13,Rue du Docteur Léon Mangeney,,68200
+13 Rue du Docteur Léon Mangeney 68200,,,,13,Rue du Docteur Léon Mangeney,Mulhouse,
+13 Rue du Docteur Léon Mangeney,7.342555,47.726494,,13,Rue du Docteur Léon Mangeney,,68200
+10 Avenue du Maréchal Joffre Mulhouse,,,,10,Avenue du Maréchal Joffre,,68200
+10 Avenue du Maréchal Joffre 68200,,,,10,Avenue du Maréchal Joffre,Mulhouse,
+10 Avenue du Maréchal Joffre,7.342825,47.745284,,10,Avenue du Maréchal Joffre,,68200
+52 Rue des Taillis Mulhouse,,,,52,Rue des Taillis,,68200
+52 Rue des Taillis 68200,,,,52,Rue des Taillis,Mulhouse,
+52 Rue des Taillis,7.333585,47.779997,,52,Rue des Taillis,,68200
+22 Rue de l'Avenir Niederentzen,,,,22,Rue de l'Avenir,,68127
+22 Rue de l'Avenir 68127,,,,22,Rue de l'Avenir,Niederentzen,
+22 Rue de l'Avenir,7.383667,47.950845,,22,Rue de l'Avenir,,68127
+8 Rue des Églantines Osenbach,,,,8,Rue des Églantines,,68570
+8 Rue des Églantines 68570,,,,8,Rue des Églantines,Osenbach,
+8 Rue des Églantines,7.213712,47.990746,,8,Rue des Églantines,,68570
+15 Rue de Bretagne Pulversheim,,,,15,Rue de Bretagne,,68840
+15 Rue de Bretagne 68840,,,,15,Rue de Bretagne,Pulversheim,
+15 Rue de Bretagne,7.306745,47.839383,,15,Rue de Bretagne,,68840
+4 Rue de l'Iris Ribeauvillé,,,,4,Rue de l'Iris,,68150
+4 Rue de l'Iris 68150,,,,4,Rue de l'Iris,Ribeauvillé,
+4 Rue de l'Iris,7.340012,48.192233,,4,Rue de l'Iris,,68150
+8 Rue des Vanneaux Riedwihr,,,,8,Rue des Vanneaux,,68320
+8 Rue des Vanneaux 68320,,,,8,Rue des Vanneaux,Riedwihr,
+8 Rue des Vanneaux,7.446697,48.128654,,8,Rue des Vanneaux,,68320
+10 Route de Thann Roderen,,,,10,Route de Thann,,68800
+10 Route de Thann 68800,,,,10,Route de Thann,Roderen,
+10 Route de Thann,7.094919,47.780043,,10,Route de Thann,,68800
+6 Rue de la Carrière Saint-Amarin,,,,6,Rue de la Carrière,,68550
+6 Rue de la Carrière 68550,,,,6,Rue de la Carrière,Saint-Amarin,
+6 Rue de la Carrière,7.028252,47.876003,,6,Rue de la Carrière,,68550
+15 Rue du Paradis Saint-Louis,,,,15,Rue du Paradis,,68300
+15 Rue du Paradis 68300,,,,15,Rue du Paradis,Saint-Louis,
+15 Rue du Paradis,7.554034,47.582951,,15,Rue du Paradis,,68300
+2 Rue de Bettendorf Schwoben,,,,2,Rue de Bettendorf,,68130
+2 Rue de Bettendorf 68130,,,,2,Rue de Bettendorf,Schwoben,
+2 Rue de Bettendorf,7.300961,47.616148,,2,Rue de Bettendorf,,68130
+9 Rue des Soeurs Soultz-Haut-Rhin,,,,9,Rue des Soeurs,,68360
+9 Rue des Soeurs 68360,,,,9,Rue des Soeurs,Soultz-Haut-Rhin,
+9 Rue des Soeurs,7.23058,47.885942,,9,Rue des Soeurs,,68360
+4 Rue de Roppentzwiller Steinsoultz,,,,4,Rue de Roppentzwiller,,68640
+4 Rue de Roppentzwiller 68640,,,,4,Rue de Roppentzwiller,,68640
+4 Rue de Roppentzwiller,7.336025,47.549512,,4,Rue de Roppentzwiller,,68640
+33 Rue Florimont Turckheim,,,,33,Rue Florimont,,68230
+33 Rue Florimont 68230,,,,33,Rue Florimont,Turckheim,
+33 Rue Florimont,7.284214,48.08984,,33,Rue Florimont,,68230
+59 Rue du Maréchal Foch Village-Neuf,,,,59,Rue du Maréchal Foch,,68128
+59 Rue du Maréchal Foch 68128,,,,59,Rue du Maréchal Foch,Village-Neuf,
+59 Rue du Maréchal Foch,7.568083,47.609427,,59,Rue du Maréchal Foch,,68128
+42 Rue de Soultzmatt Westhalten,,,,42,Rue de Soultzmatt,,68250
+42 Rue de Soultzmatt 68250,,,,42,Rue de Soultzmatt,Westhalten,
+42 Rue de Soultzmatt,7.256254,47.957205,,42,Rue de Soultzmatt,,68250
+7B Rue de l'Avenir Wittelsheim,,,,7B,Rue de l'Avenir,,68310
+7B Rue de l'Avenir 68310,,,,7B,Rue de l'Avenir,Wittelsheim,
+7B Rue de l'Avenir,7.242469,47.805817,,7B,Rue de l'Avenir,,68310
+12 Rue de la Forêt Wittenheim,,,,12,Rue de la Forêt,,68270
+12 Rue de la Forêt 68270,,,,12,Rue de la Forêt,Wittenheim,
+12 Rue de la Forêt,7.333542,47.808725,,12,Rue de la Forêt,,68270
+2 Rue Bellevue Zillisheim,,,,2,Rue Bellevue,,68720
+2 Rue Bellevue 68720,,,,2,Rue Bellevue,Zillisheim,
+2 Rue Bellevue,7.293475,47.693405,,2,Rue Bellevue,,68720

--- a/geocoder_tester/world/france/aquitaine/test_addresses.csv
+++ b/geocoder_tester/world/france/aquitaine/test_addresses.csv
@@ -1,520 +1,520 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-3 Rue Docteur Pierre Simbat Bergerac,,,,3 Rue Docteur Pierre Simbat,,,,24100
-3 Rue Docteur Pierre Simbat 24100,,,,3 Rue Docteur Pierre Simbat,,,Bergerac,
-3 Rue Docteur Pierre Simbat,0.475077,44.854347,,3 Rue Docteur Pierre Simbat,,,,24100
-31 Route Pierre Pinson Bergerac,,,,31 Route Pierre Pinson,,,,24100
-31 Route Pierre Pinson 24100,,,,31 Route Pierre Pinson,,,Bergerac,
-31 Route Pierre Pinson,0.454627,44.851248,,31 Route Pierre Pinson,,,,24100
-6 Place du Champ de Foire Brantôme,,,,6 Place du Champ de Foire,,,,24310
-6 Place du Champ de Foire 24310,,,,6 Place du Champ de Foire,,,,24310
-6 Place du Champ de Foire,0.650042,45.361569,,6 Place du Champ de Foire,,,,24310
-47 Avenue Pierre Mendès France Coulounieix-Chamiers,,,,47 Avenue Pierre Mendès France,,,,24660
-47 Avenue Pierre Mendès France 24660,,,,47 Avenue Pierre Mendès France,,,Coulounieix-Chamiers,
-47 Avenue Pierre Mendès France,0.695090,45.162787,,47 Avenue Pierre Mendès France,,,,24660
-5 Impasse du Coureau Lamonzie-Saint-Martin,,,,5 Impasse du Coureau,,,,24680
-5 Impasse du Coureau 24680,,,,5 Impasse du Coureau,,,Lamonzie-Saint-Martin,
-5 Impasse du Coureau,0.376397,44.838837,,5 Impasse du Coureau,,,,24680
-49 Rue de la Nouzillère Mussidan,,,,49 Rue de la Nouzillère,,,,24400
-49 Rue de la Nouzillère 24400,,,,49 Rue de la Nouzillère,,,Mussidan,
-49 Rue de la Nouzillère,0.359680,45.031254,,49 Rue de la Nouzillère,,,,24400
-8 Rue de la Constitution Périgueux,,,,8 Rue de la Constitution,,,,24000
-8 Rue de la Constitution 24000,,,,8 Rue de la Constitution,,,Périgueux,
-8 Rue de la Constitution,0.723692,45.184609,,8 Rue de la Constitution,,,,24000
-65 Rue du Président Wilson Périgueux,,,,65 Rue du Président Wilson,,,,24000
-65 Rue du Président Wilson 24000,,,,65 Rue du Président Wilson,,,Périgueux,
-65 Rue du Président Wilson,0.712912,45.185299,,65 Rue du Président Wilson,,,,24000
-34 Route de Peymilou Prigonrieux,,,,34 Route de Peymilou,,,,24130
-34 Route de Peymilou 24130,,,,34 Route de Peymilou,,,Prigonrieux,
-34 Route de Peymilou,0.411217,44.884759,,34 Route de Peymilou,,,,24130
-9 Rue Henri Saumande Thiviers,,,,9 Rue Henri Saumande,,,,24800
-9 Rue Henri Saumande 24800,,,,9 Rue Henri Saumande,,,Thiviers,
-9 Rue Henri Saumande,0.921633,45.420576,,9 Rue Henri Saumande,,,,24800
-16B Avenue du Général de Gaulle Ambès,,,,16B Avenue du Général de Gaulle,,,,33810
-16B Avenue du Général de Gaulle 33810,,,,16B Avenue du Général de Gaulle,,,Ambès,
-16B Avenue du Général de Gaulle,-0.526682,45.011379,,16B Avenue du Général de Gaulle,,,,33810
-14 Avenue Johann Strauss Andernos-les-Bains,,,,14 Avenue Johann Strauss,,,,33510
-14 Avenue Johann Strauss 33510,,,,14 Avenue Johann Strauss,,,Andernos-les-Bains,
-14 Avenue Johann Strauss,-1.079634,44.739466,,14 Avenue Johann Strauss,,,,33510
-111 Boulevard de la Côte d'Argent Arcachon,,,,111 Boulevard de la Côte d'Argent,,,,33120
-111 Boulevard de la Côte d'Argent 33120,,,,111 Boulevard de la Côte d'Argent,,,Arcachon,
-111 Boulevard de la Côte d'Argent,-1.186492,44.651653,,111 Boulevard de la Côte d'Argent,,,,33120
-31BIS Avenue Victor Hugo Arcachon,,,,31BIS Avenue Victor Hugo,,,,33120
-31BIS Avenue Victor Hugo 33120,,,,31BIS Avenue Victor Hugo,,,Arcachon,
-31BIS Avenue Victor Hugo,-1.172149,44.657159,,31BIS Avenue Victor Hugo,,,,33120
-15 Avenue de Lestrille Artigues-près-Bordeaux,,,,15 Avenue de Lestrille,,,,33370
-15 Avenue de Lestrille 33370,,,,15 Avenue de Lestrille,,,Artigues-près-Bordeaux,
-15 Avenue de Lestrille,-0.496308,44.871065,,15 Avenue de Lestrille,,,,33370
-8 Résidence Le Courtiou Audenge,,,,8 Résidence Le Courtiou,,,,33980
-8 Résidence Le Courtiou 33980,,,,8 Résidence Le Courtiou,,,Audenge,
-8 Résidence Le Courtiou,-0.990967,44.690035,,8 Résidence Le Courtiou,,,,33980
-23 Rue Maurice Toutaud Bassens,,,,23 Rue Maurice Toutaud,,,,33530
-23 Rue Maurice Toutaud 33530,,,,23 Rue Maurice Toutaud,,,Bassens,
-23 Rue Maurice Toutaud,-0.520141,44.893901,,23 Rue Maurice Toutaud,,,,33530
-56 Avenue Alexis Capelle Bègles,,,,56 Avenue Alexis Capelle,,,,33130
-56 Avenue Alexis Capelle 33130,,,,56 Avenue Alexis Capelle,,,Bègles,
-56 Avenue Alexis Capelle,-0.548946,44.813630,,56 Avenue Alexis Capelle,,,,33130
-50 Avenue Lucien Lerousseau Bègles,,,,50 Avenue Lucien Lerousseau,,,,33130
-50 Avenue Lucien Lerousseau 33130,,,,50 Avenue Lucien Lerousseau,,,Bègles,
-50 Avenue Lucien Lerousseau,-0.556357,44.807703,,50 Avenue Lucien Lerousseau,,,,33130
-3 Route de Maison Rouge Belin-Béliet,,,,3 Route de Maison Rouge,,,,33830
-3 Route de Maison Rouge 33830,,,,3 Route de Maison Rouge,,,Belin-Béliet,
-3 Route de Maison Rouge,-0.779524,44.503739,,3 Route de Maison Rouge,,,,33830
-35 Rue du Cardinal Lecot Blanquefort,,,,35 Rue du Cardinal Lecot,,,,33290
-35 Rue du Cardinal Lecot 33290,,,,35 Rue du Cardinal Lecot,,,Blanquefort,
-35 Rue du Cardinal Lecot,-0.648799,44.915606,,35 Rue du Cardinal Lecot,,,,33290
-1 Chemin du Monteil Blaye,,,,1 Chemin du Monteil,,,,33390
-1 Chemin du Monteil 33390,,,,1 Chemin du Monteil,,,Blaye,
-1 Chemin du Monteil,-0.656628,45.128046,,1 Chemin du Monteil,,,,33390
-2 Rue d'Aviau Bordeaux,,,,2 Rue d'Aviau,,,,33090
-2 Rue d'Aviau 33090,,,,2 Rue d'Aviau,,,Bordeaux,
-2 Rue d'Aviau,-0.575711,44.849723,,2 Rue d'Aviau,,,,33090
-17B Rue Bourbon Bordeaux,,,,17B Rue Bourbon,,,,33090
-17B Rue Bourbon 33090,,,,17B Rue Bourbon,,,Bordeaux,
-17B Rue Bourbon,-0.556596,44.859876,,17B Rue Bourbon,,,,33090
-123 Quai des Chartrons Bordeaux,,,,123 Quai des Chartrons,,,,33090
-123 Quai des Chartrons 33090,,,,123 Quai des Chartrons,,,Bordeaux,
-123 Quai des Chartrons,-0.563341,44.856034,,123 Quai des Chartrons,,,,33090
-5 Cité Dulamon Bordeaux,,,,5 Cité Dulamon,,,,33090
-5 Cité Dulamon 33090,,,,5 Cité Dulamon,,,Bordeaux,
-5 Cité Dulamon,-0.572776,44.834117,,5 Cité Dulamon,,,,33090
-6 Passage François Ducom Bordeaux,,,,6 Passage François Ducom,,,,33090
-6 Passage François Ducom 33090,,,,6 Passage François Ducom,,,Bordeaux,
-6 Passage François Ducom,-0.579374,44.823163,,6 Passage François Ducom,,,,33090
-9 Rue Hoche Bordeaux,,,,9 Rue Hoche,,,,33090
-9 Rue Hoche 33090,,,,9 Rue Hoche,,,Bordeaux,
-9 Rue Hoche,-0.603882,44.847715,,9 Rue Hoche,,,,33090
-114 Chemin Lafitte Bordeaux,,,,114 Chemin Lafitte,,,,33090
-114 Chemin Lafitte 33090,,,,114 Chemin Lafitte,,,Bordeaux,
-114 Chemin Lafitte,-0.549965,44.881709,,114 Chemin Lafitte,,,,33090
-58 Rue de Macau Bordeaux,,,,58 Rue de Macau,,,,33090
-58 Rue de Macau 33090,,,,58 Rue de Macau,,,Bordeaux,
-58 Rue de Macau,-0.587626,44.856104,,58 Rue de Macau,,,,33090
-61 Rue Mondenard Bordeaux,,,,61 Rue Mondenard,,,,33090
-61 Rue Mondenard 33090,,,,61 Rue Mondenard,,,Bordeaux,
-61 Rue Mondenard,-0.588301,44.846301,,61 Rue Mondenard,,,,33090
-172 Rue Pelleport Bordeaux,,,,172 Rue Pelleport,,,,33090
-172 Rue Pelleport 33090,,,,172 Rue Pelleport,,,Bordeaux,
-172 Rue Pelleport,-0.565360,44.821270,,172 Rue Pelleport,,,,33090
-13 Rue des Remparts Bordeaux,,,,13 Rue des Remparts,,,,33090
-13 Rue des Remparts 33090,,,,13 Rue des Remparts,,,Bordeaux,
-13 Rue des Remparts,-0.579634,44.840237,,13 Rue des Remparts,,,,33090
-7 Rue du Soldat Moncourrier Bordeaux,,,,7 Rue du Soldat Moncourrier,,,,33090
-7 Rue du Soldat Moncourrier 33090,,,,7 Rue du Soldat Moncourrier,,,Bordeaux,
-7 Rue du Soldat Moncourrier,-0.597601,44.821230,,7 Rue du Soldat Moncourrier,,,,33090
-17 Rue Victor et Louis Liotard Bordeaux,,,,17 Rue Victor et Louis Liotard,,,,33090
-17 Rue Victor et Louis Liotard 33090,,,,17 Rue Victor et Louis Liotard,,,Bordeaux,
-17 Rue Victor et Louis Liotard,-0.596909,44.823322,,17 Rue Victor et Louis Liotard,,,,33090
-36B Avenue du Général Leclerc Le Bouscat,,,,36B Avenue du Général Leclerc,,,,33110
-36B Avenue du Général Leclerc 33110,,,,36B Avenue du Général Leclerc,,,Le Bouscat,
-36B Avenue du Général Leclerc,-0.597711,44.854511,,36B Avenue du Général Leclerc,,,,33110
-4 Place de l'Église Branne,,,,4 Place de l'Église,,,,33420
-4 Place de l'Église 33420,,,,4 Place de l'Église,,,Branne,
-4 Place de l'Église,-0.185841,44.830631,,4 Place de l'Église,,,,33420
-12 Rue du Camp Bas Cabanac-et-Villagrains,,,,12 Rue du Camp Bas,,,,33650
-12 Rue du Camp Bas 33650,,,,12 Rue du Camp Bas,,,Cabanac-et-Villagrains,
-12 Rue du Camp Bas,-0.592585,44.571301,,12 Rue du Camp Bas,,,,33650
-37 Route de Morillon Camblanes-et-Meynac,,,,37 Route de Morillon,,,,33360
-37 Route de Morillon 33360,,,,37 Route de Morillon,,,Camblanes-et-Meynac,
-37 Route de Morillon,-0.480489,44.764428,,37 Route de Morillon,,,,33360
-1 Rue Pierre Corneille Carbon-Blanc,,,,1 Rue Pierre Corneille,,,,33560
-1 Rue Pierre Corneille 33560,,,,1 Rue Pierre Corneille,,,Carbon-Blanc,
-1 Rue Pierre Corneille,-0.494346,44.906445,,1 Rue Pierre Corneille,,,,33560
-8 Rue du 14 Juillet Castelnau-de-Médoc,,,,8 Rue du 14 Juillet,,,,33480
-8 Rue du 14 Juillet 33480,,,,8 Rue du 14 Juillet,,,Castelnau-de-Médoc,
-8 Rue du 14 Juillet,-0.798072,45.028678,,8 Rue du 14 Juillet,,,,33480
-34 Chemin des Bories Cenon,,,,34 Chemin des Bories,,,,33150
-34 Chemin des Bories 33150,,,,34 Chemin des Bories,,,Cenon,
-34 Chemin des Bories,-0.516612,44.849890,,34 Chemin des Bories,,,,33150
-4 Lotissement Les Moulins Cérons,,,,4 Lotissement Les Moulins,,,,33720
-4 Lotissement Les Moulins 33720,,,,4 Lotissement Les Moulins,,,Cérons,
-4 Lotissement Les Moulins,-0.348354,44.632741,,4 Lotissement Les Moulins,,,,33720
-14 Chemin de Peyre Cestas,,,,14 Chemin de Peyre,,,,33610
-14 Chemin de Peyre 33610,,,,14 Chemin de Peyre,,,Cestas,
-14 Chemin de Peyre,-0.651919,44.733530,,14 Chemin de Peyre,,,,33610
-2 Rue Epernon Créon,,,,2 Rue Epernon,,,,33670
-2 Rue Epernon 33670,,,,2 Rue Epernon,,,Créon,
-2 Rue Epernon,-0.347629,44.774049,,2 Rue Epernon,,,,33670
-71 Rue du College Technique Eysines,,,,71 Rue du College Technique,,,,33320
-71 Rue du College Technique 33320,,,,71 Rue du College Technique,,,Eysines,
-71 Rue du College Technique,-0.629469,44.884043,,71 Rue du College Technique,,,,33320
-5 Route de Dardenac Faleyras,,,,5 Route de Dardenac,,,,33760
-5 Route de Dardenac 33760,,,,5 Route de Dardenac,,,Faleyras,
-5 Route de Dardenac,-0.241729,44.778078,,5 Route de Dardenac,,,,33760
-13 Rue Racine Floirac,,,,13 Rue Racine,,,,33270
-13 Rue Racine 33270,,,,13 Rue Racine,,,Floirac,
-13 Rue Racine,-0.514491,44.845523,,13 Rue Racine,,,,33270
-2 Allée de la Clairière Gradignan,,,,2 Allée de la Clairière,,,,33170
-2 Allée de la Clairière 33170,,,,2 Allée de la Clairière,,,Gradignan,
-2 Allée de la Clairière,-0.612658,44.776573,,2 Allée de la Clairière,,,,33170
-15 Allée Paul Cézanne Gradignan,,,,15 Allée Paul Cézanne,,,,33170
-15 Allée Paul Cézanne 33170,,,,15 Allée Paul Cézanne,,,Gradignan,
-15 Allée Paul Cézanne,-0.634094,44.771633,,15 Allée Paul Cézanne,,,,33170
-64 Rue Chante Cigale Gujan-Mestras,,,,64 Rue Chante Cigale,,,,33470
-64 Rue Chante Cigale 33470,,,,64 Rue Chante Cigale,,,Gujan-Mestras,
-64 Rue Chante Cigale,-1.062088,44.629659,,64 Rue Chante Cigale,,,,33470
-73 Allée des Places Gujan-Mestras,,,,73 Allée des Places,,,,33470
-73 Allée des Places 33470,,,,73 Allée des Places,,,Gujan-Mestras,
-73 Allée des Places,-1.092154,44.633911,,73 Allée des Places,,,,33470
-10 Rue des Potiers Le Haillan,,,,10 Rue des Potiers,,,,33185
-10 Rue des Potiers 33185,,,,10 Rue des Potiers,,,Le Haillan,
-10 Rue des Potiers,-0.686257,44.876153,,10 Rue des Potiers,,,,33185
-438 Avenue du Général de Gaulle Izon,,,,438 Avenue du Général de Gaulle,,,,33450
-438 Avenue du Général de Gaulle 33450,,,,438 Avenue du Général de Gaulle,,,Izon,
-438 Avenue du Général de Gaulle,-0.350218,44.917525,,438 Avenue du Général de Gaulle,,,,33450
-106 Chemin des Gemmeurs Lacanau,,,,106 Chemin des Gemmeurs,,,,33680
-106 Chemin des Gemmeurs 33680,,,,106 Chemin des Gemmeurs,,,Lacanau,
-106 Chemin des Gemmeurs,-1.178049,45.002652,,106 Chemin des Gemmeurs,,,,33680
-68 Avenue du Général De Gaulle Langoiran,,,,68 Avenue du Général De Gaulle,,,,33550
-68 Avenue du Général De Gaulle 33550,,,,68 Avenue du Général De Gaulle,,,Langoiran,
-68 Avenue du Général De Gaulle,-0.399080,44.705610,,68 Avenue du Général De Gaulle,,,,33550
-25 Boulevard de la Plage Lanton,,,,25 Boulevard de la Plage,,,,33138
-25 Boulevard de la Plage 33138,,,,25 Boulevard de la Plage,,,Lanton,
-25 Boulevard de la Plage,-1.067437,44.717438,,25 Boulevard de la Plage,,,,33138
-20 Rue des Chevreuils Piraillan Lège-Cap-Ferret,,,,20 Rue des Chevreuils Piraillan,,,,33950
-20 Rue des Chevreuils Piraillan 33950,,,,20 Rue des Chevreuils Piraillan,,,Lège-Cap-Ferret,
-20 Rue des Chevreuils Piraillan,-1.228406,44.711892,,20 Rue des Chevreuils Piraillan,,,,33950
-8BIS Rue de la Poste Cap Ferret Lège-Cap-Ferret,,,,8BIS Rue de la Poste Cap Ferret,,,,33950
-8BIS Rue de la Poste Cap Ferret 33950,,,,8BIS Rue de la Poste Cap Ferret,,,Lège-Cap-Ferret,
-8BIS Rue de la Poste Cap Ferret,-1.248688,44.647288,,8BIS Rue de la Poste Cap Ferret,,,,33950
-2BIS Rue des Abbés Collin Lesparre-Médoc,,,,2BIS Rue des Abbés Collin,,,,33340
-2BIS Rue des Abbés Collin 33340,,,,2BIS Rue des Abbés Collin,,,Lesparre-Médoc,
-2BIS Rue des Abbés Collin,-0.923608,45.303859,,2BIS Rue des Abbés Collin,,,,33340
-195 Avenue de l'Épinette Libourne,,,,195 Avenue de l'Épinette,,,,33500
-195 Avenue de l'Épinette 33500,,,,195 Avenue de l'Épinette,,,Libourne,
-195 Avenue de l'Épinette,-0.214421,44.906517,,195 Avenue de l'Épinette,,,,33500
-10 Rue des 4 Frères Robert Libourne,,,,10 Rue des 4 Frères Robert,,,,33500
-10 Rue des 4 Frères Robert 33500,,,,10 Rue des 4 Frères Robert,,,Libourne,
-10 Rue des 4 Frères Robert,-0.246306,44.911514,,10 Rue des 4 Frères Robert,,,,33500
-89 Rue du Général de Gaulle Lormont,,,,89 Rue du Général de Gaulle,,,,33310
-89 Rue du Général de Gaulle 33310,,,,89 Rue du Général de Gaulle,,,Lormont,
-89 Rue du Général de Gaulle,-0.528535,44.877435,,89 Rue du Général de Gaulle,,,,33310
-11 Rue Combattants Afn 1952 1962 Macau,,,,11 Rue Combattants Afn 1952 1962,,,,33460
-11 Rue Combattants Afn 1952 1962 33460,,,,11 Rue Combattants Afn 1952 1962,,,Macau,
-11 Rue Combattants Afn 1952 1962,-0.620015,45.002512,,11 Rue Combattants Afn 1952 1962,,,,33460
-29 Rue Alphonse Daudet Mérignac,,,,29 Rue Alphonse Daudet,,,,33700
-29 Rue Alphonse Daudet 33700,,,,29 Rue Alphonse Daudet,,,Mérignac,
-29 Rue Alphonse Daudet,-0.657175,44.852947,,29 Rue Alphonse Daudet,,,,33700
-64 Avenue de l'Europe Mérignac,,,,64 Avenue de l'Europe,,,,33700
-64 Avenue de l'Europe 33700,,,,64 Avenue de l'Europe,,,Mérignac,
-64 Avenue de l'Europe,-0.672518,44.820343,,64 Avenue de l'Europe,,,,33700
-110 Avenue de la Libération Mérignac,,,,110 Avenue de la Libération,,,,33700
-110 Avenue de la Libération 33700,,,,110 Avenue de la Libération,,,Mérignac,
-110 Avenue de la Libération,-0.644571,44.854168,,110 Avenue de la Libération,,,,33700
-23 Avenue Pythagore Mérignac,,,,23 Avenue Pythagore,,,,33700
-23 Avenue Pythagore 33700,,,,23 Avenue Pythagore,,,Mérignac,
-23 Avenue Pythagore,-0.680333,44.831207,,23 Avenue Pythagore,,,,33700
-34 Rue Porte de la Réole Monségur,,,,34 Rue Porte de la Réole,,,,33580
-34 Rue Porte de la Réole 33580,,,,34 Rue Porte de la Réole,,,Monségur,
-34 Rue Porte de la Réole,0.078745,44.649933,,34 Rue Porte de la Réole,,,,33580
-22 Allée de la Forêt d'Arboudeau Parempuyre,,,,22 Allée de la Forêt d'Arboudeau,,,,33290
-22 Allée de la Forêt d'Arboudeau 33290,,,,22 Allée de la Forêt d'Arboudeau,,,Parempuyre,
-22 Allée de la Forêt d'Arboudeau,-0.609884,44.943862,,22 Allée de la Forêt d'Arboudeau,,,,33290
-4 Allée de l'Aube Pessac,,,,4 Allée de l'Aube,,,,33600
-4 Allée de l'Aube 33600,,,,4 Allée de l'Aube,,,Pessac,
-4 Allée de l'Aube,-0.679580,44.796945,,4 Allée de l'Aube,,,,33600
-19 Avenue des Erables Pessac,,,,19 Avenue des Erables,,,,33600
-19 Avenue des Erables 33600,,,,19 Avenue des Erables,,,Pessac,
-19 Avenue des Erables,-0.622953,44.812073,,19 Avenue des Erables,,,,33600
-14 Avenue Léon Blum Pessac,,,,14 Avenue Léon Blum,,,,33600
-14 Avenue Léon Blum 33600,,,,14 Avenue Léon Blum,,,Pessac,
-14 Avenue Léon Blum,-0.624426,44.814299,,14 Avenue Léon Blum,,,,33600
-158 Rue de la Poudrière Pessac,,,,158 Rue de la Poudrière,,,,33600
-158 Rue de la Poudrière 33600,,,,158 Rue de la Poudrière,,,Pessac,
-158 Rue de la Poudrière,-0.701315,44.791874,,158 Rue de la Poudrière,,,,33600
-296 Chemin Font Martin Le Pian-Médoc,,,,296 Chemin Font Martin,,,,33290
-296 Chemin Font Martin 33290,,,,296 Chemin Font Martin,,,Le Pian-Médoc,
-296 Chemin Font Martin,-0.684848,44.942391,,296 Chemin Font Martin,,,,33290
-4 Chemin de Callonge Pompignac,,,,4 Chemin de Callonge,,,,33370
-4 Chemin de Callonge 33370,,,,4 Chemin de Callonge,,,Pompignac,
-4 Chemin de Callonge,-0.435860,44.849075,,4 Chemin de Callonge,,,,33370
-11 Rue du Général de Gaulle Reignac,,,,11 Rue du Général de Gaulle,,,,33860
-11 Rue du Général de Gaulle 33860,,,,11 Rue du Général de Gaulle,,,Reignac,
-11 Rue du Général de Gaulle,-0.506287,45.232121,,11 Rue du Général de Gaulle,,,,33860
-25 Rue de Montalon Saint-André-de-Cubzac,,,,25 Rue de Montalon,,,,33240
-25 Rue de Montalon 33240,,,,25 Rue de Montalon,,,Saint-André-de-Cubzac,
-25 Rue de Montalon,-0.447362,44.996219,,25 Rue de Montalon,,,,33240
-10 Rue de l'Église Saint-Christoly-Médoc,,,,10 Rue de l'Église,,,,33340
-10 Rue de l'Église 33340,,,,10 Rue de l'Église,,,Saint-Christoly-Médoc,
-10 Rue de l'Église,-0.826166,45.356896,,10 Rue de l'Église,,,,33340
-75 Rue François Boulière Sainte-Eulalie,,,,75 Rue François Boulière,,,,33560
-75 Rue François Boulière 33560,,,,75 Rue François Boulière,,,Sainte-Eulalie,
-75 Rue François Boulière,-0.464408,44.907859,,75 Rue François Boulière,,,,33560
-15 Impasse Bugade Saint-Jean-d'Illac,,,,15 Impasse Bugade,,,,33127
-15 Impasse Bugade 33127,,,,15 Impasse Bugade,,,Saint-Jean-d'Illac,
-15 Impasse Bugade,-0.834097,44.801573,,15 Impasse Bugade,,,,33127
-31 Rue du Moulin de Conilh Saint-Loubès,,,,31 Rue du Moulin de Conilh,,,,33450
-31 Rue du Moulin de Conilh 33450,,,,31 Rue du Moulin de Conilh,,,Saint-Loubès,
-31 Rue du Moulin de Conilh,-0.440753,44.916946,,31 Rue du Moulin de Conilh,,,,33450
-12BIS Chemin du Bruilleau Saint-Médard-d'Eyrans,,,,12BIS Chemin du Bruilleau,,,,33650
-12BIS Chemin du Bruilleau 33650,,,,12BIS Chemin du Bruilleau,,,Saint-Médard-d'Eyrans,
-12BIS Chemin du Bruilleau,-0.519029,44.694191,,12BIS Chemin du Bruilleau,,,,33650
-20 Rue Fernand Labrousse Saint-Médard-en-Jalles,,,,20 Rue Fernand Labrousse,,,,33160
-20 Rue Fernand Labrousse 33160,,,,20 Rue Fernand Labrousse,,,Saint-Médard-en-Jalles,
-20 Rue Fernand Labrousse,-0.753604,44.891912,,20 Rue Fernand Labrousse,,,,33160
-12 Allée des Palombes Saint-Médard-en-Jalles,,,,12 Allée des Palombes,,,,33160
-12 Allée des Palombes 33160,,,,12 Allée des Palombes,,,Saint-Médard-en-Jalles,
-12 Allée des Palombes,-0.782343,44.894470,,12 Allée des Palombes,,,,33160
-43 Rue Célestin Joubert Saint-Savin,,,,43 Rue Célestin Joubert,,,,33920
-43 Rue Célestin Joubert 33920,,,,43 Rue Célestin Joubert,,,Saint-Savin,
-43 Rue Célestin Joubert,-0.447718,45.140065,,43 Rue Célestin Joubert,,,,33920
-12 Chemin des Pins Saint-Vivien-de-Médoc,,,,12 Chemin des Pins,,,,33590
-12 Chemin des Pins 33590,,,,12 Chemin des Pins,,,Saint-Vivien-de-Médoc,
-12 Chemin des Pins,-1.045862,45.423773,,12 Chemin des Pins,,,,33590
-18 Résidence Le Parc de Taudignon Salles,,,,18 Résidence Le Parc de Taudignon,,,,33770
-18 Résidence Le Parc de Taudignon 33770,,,,18 Résidence Le Parc de Taudignon,,,Salles,
-18 Résidence Le Parc de Taudignon,-0.874498,44.563054,,18 Résidence Le Parc de Taudignon,,,,33770
-12 Place de la République Soulac-sur-Mer,,,,12 Place de la République,,,,33780
-12 Place de la République 33780,,,,12 Place de la République,,,Soulac-sur-Mer,
-12 Place de la République,-1.126167,45.508096,,12 Place de la République,,,,33780
-77 Rue Victor Schoelcher Le Taillan-Médoc,,,,77 Rue Victor Schoelcher,,,,33320
-77 Rue Victor Schoelcher 33320,,,,77 Rue Victor Schoelcher,,,Le Taillan-Médoc,
-77 Rue Victor Schoelcher,-0.677172,44.903033,,77 Rue Victor Schoelcher,,,,33320
-97 Boulevard George V Talence,,,,97 Boulevard George V,,,,33400
-97 Boulevard George V 33400,,,,97 Boulevard George V,,,Talence,
-97 Boulevard George V,-0.587917,44.824324,,97 Boulevard George V,,,,33400
-8 Rue Vergnaud Talence,,,,8 Rue Vergnaud,,,,33400
-8 Rue Vergnaud 33400,,,,8 Rue Vergnaud,,,Talence,
-8 Rue Vergnaud,-0.575896,44.809673,,8 Rue Vergnaud,,,,33400
-78 Avenue de la Brasserie La Teste-de-Buch,,,,78 Avenue de la Brasserie,,,,33164
-78 Avenue de la Brasserie 33164,,,,78 Avenue de la Brasserie,,,La Teste-de-Buch,
-78 Avenue de la Brasserie,-1.147982,44.628861,,78 Avenue de la Brasserie,,,,33164
-22 Rue Jean Saint-Marc La Teste-de-Buch,,,,22 Rue Jean Saint-Marc,,,,33164
-22 Rue Jean Saint-Marc 33164,,,,22 Rue Jean Saint-Marc,,,La Teste-de-Buch,
-22 Rue Jean Saint-Marc,-1.117454,44.634571,,22 Rue Jean Saint-Marc,,,,33164
-5 Allée des Platanes de Castéra La Teste-de-Buch,,,,5 Allée des Platanes de Castéra,,,,33164
-5 Allée des Platanes de Castéra 33164,,,,5 Allée des Platanes de Castéra,,,La Teste-de-Buch,
-5 Allée des Platanes de Castéra,-1.145141,44.538804,,5 Allée des Platanes de Castéra,,,,33164
-27 Route de Montalivet Vendays-Montalivet,,,,27 Route de Montalivet,,,,33930
-27 Route de Montalivet 33930,,,,27 Route de Montalivet,,,Vendays-Montalivet,
-27 Route de Montalivet,-1.066271,45.357160,,27 Route de Montalivet,,,,33930
-16 Rue des Bleuets Villenave-d'Ornon,,,,16 Rue des Bleuets,,,,33140
-16 Rue des Bleuets 33140,,,,16 Rue des Bleuets,,,Villenave-d'Ornon,
-16 Rue des Bleuets,-0.577113,44.756149,,16 Rue des Bleuets,,,,33140
-31 Chemin Lalaurie Villenave-d'Ornon,,,,31 Chemin Lalaurie,,,,33140
-31 Chemin Lalaurie 33140,,,,31 Chemin Lalaurie,,,Villenave-d'Ornon,
-31 Chemin Lalaurie,-0.566619,44.765003,,31 Chemin Lalaurie,,,,33140
-77 Rue Yvon Mansencal Villenave-d'Ornon,,,,77 Rue Yvon Mansencal,,,,33140
-77 Rue Yvon Mansencal 33140,,,,77 Rue Yvon Mansencal,,,Villenave-d'Ornon,
-77 Rue Yvon Mansencal,-0.574044,44.778289,,77 Rue Yvon Mansencal,,,,33140
-190 Route du Château Arsague,,,,190 Route du Château,,,,40330
-190 Route du Château 40330,,,,190 Route du Château,,,Arsague,
-190 Route du Château,-0.792188,43.585772,,190 Route du Château,,,,40330
-1660 Chemin de Sablaret Bénesse-Maremne,,,,1660 Chemin de Sablaret,,,,40230
-1660 Chemin de Sablaret 40230,,,,1660 Chemin de Sablaret,,,Bénesse-Maremne,
-1660 Chemin de Sablaret,-1.376576,43.620787,,1660 Chemin de Sablaret,,,,40230
-578 Avenue Gabriele d'Annunzio Biscarrosse,,,,578 Avenue Gabriele d'Annunzio,,,,40600
-578 Avenue Gabriele d'Annunzio 40600,,,,578 Avenue Gabriele d'Annunzio,,,Biscarrosse,
-578 Avenue Gabriele d'Annunzio,-1.248768,44.453087,,578 Avenue Gabriele d'Annunzio,,,,40600
-502 Rue d'Yquem Biscarrosse,,,,502 Rue d'Yquem,,,,40600
-502 Rue d'Yquem 40600,,,,502 Rue d'Yquem,,,Biscarrosse,
-502 Rue d'Yquem,-1.152588,44.395253,,502 Rue d'Yquem,,,,40600
-22 Boulevard du Docteur Junqua Capbreton,,,,22 Boulevard du Docteur Junqua,,,,40130
-22 Boulevard du Docteur Junqua 40130,,,,22 Boulevard du Docteur Junqua,,,Capbreton,
-22 Boulevard du Docteur Junqua,-1.429401,43.643674,,22 Boulevard du Docteur Junqua,,,,40130
-123 Laplaçote Cauneille,,,,123 Laplaçote,,,,40300
-123 Laplaçote 40300,,,,123 Laplaçote,,,Cauneille,
-123 Laplaçote,-1.082044,43.547036,,123 Laplaçote,,,,40300
-76 Avenue Georges Clémenceau Dax,,,,76 Avenue Georges Clemenceau,,,,40100
-76 Avenue Georges Clémenceau 40100,,,,76 Avenue Georges Clemenceau,,,Dax,
-76 Avenue Georges Clémenceau,-1.046628,43.707986,,76 Avenue Georges Clemenceau,,,,40100
-58 Route du Lac de Tastoa Estibeaux,,,,58 Route du Lac de Tastoa,,,,40290
-58 Route du Lac de Tastoa 40290,,,,58 Route du Lac de Tastoa,,,Estibeaux,
-58 Route du Lac de Tastoa,-0.895449,43.592815,,58 Route du Lac de Tastoa,,,,40290
-48 Rue René Vielle Grenade-sur-l'Adour,,,,48 Rue René Vielle,,,,40270
-48 Rue René Vielle 40270,,,,48 Rue René Vielle,,,Grenade-sur-l'Adour,
-48 Rue René Vielle,-0.425961,43.772494,,48 Rue René Vielle,,,,40270
-77 Rue des Cerisiers Josse,,,,77 Rue des Cerisiers,,,,40230
-77 Rue des Cerisiers 40230,,,,77 Rue des Cerisiers,,,Josse,
-77 Rue des Cerisiers,-1.221092,43.642049,,77 Rue des Cerisiers,,,,40230
-56 Chemin de Pesques Laluque,,,,56 Chemin de Pesques,,,,40465
-56 Chemin de Pesques 40465,,,,56 Chemin de Pesques,,,Laluque,
-56 Chemin de Pesques,-0.991764,43.855019,,56 Chemin de Pesques,,,,40465
-131 Rue des Tilleuls Lit-et-Mixe,,,,131 Rue des Tilleuls,,,,40170
-131 Rue des Tilleuls 40170,,,,131 Rue des Tilleuls,,,Lit-et-Mixe,
-131 Rue des Tilleuls,-1.256387,44.033363,,131 Rue des Tilleuls,,,,40170
-150 Chemin du Pey de l'Ancre Messanges,,,,150 Chemin du Pey de l'Ancre,,,,40660
-150 Chemin du Pey de l'Ancre 40660,,,,150 Chemin du Pey de l'Ancre,,,Messanges,
-150 Chemin du Pey de l'Ancre,-1.388481,43.796055,,150 Chemin du Pey de l'Ancre,,,,40660
-477 Chemin de Condom Misson,,,,477 Chemin de Condom,,,,40290
-477 Chemin de Condom 40290,,,,477 Chemin de Condom,,,Misson,
-477 Chemin de Condom,-0.957415,43.579464,,477 Chemin de Condom,,,,40290
-10 Avenue du Doct René Lataste Mont-de-Marsan,,,,10 Avenue du Doct René Lataste,,,,40000
-10 Avenue du Doct René Lataste 40000,,,,10 Avenue du Doct René Lataste,,,Mont-de-Marsan,
-10 Avenue du Doct René Lataste,-0.481489,43.880640,,10 Avenue du Doct René Lataste,,,,40000
-150 Avenue de Morcenx Mont-de-Marsan,,,,150 Avenue de Morcenx,,,,40000
-150 Avenue de Morcenx 40000,,,,150 Avenue de Morcenx,,,Mont-de-Marsan,
-150 Avenue de Morcenx,-0.522942,43.903836,,150 Avenue de Morcenx,,,,40000
-35 Rue des Cigales Morcenx,,,,35 Rue des Cigales,,,,40110
-35 Rue des Cigales 40110,,,,35 Rue des Cigales,,,Morcenx,
-35 Rue des Cigales,-0.896936,44.025986,,35 Rue des Cigales,,,,40110
-301 Allée des Bruyères Ondres,,,,301 Allée des Bruyères,,,,40440
-301 Allée des Bruyères 40440,,,,301 Allée des Bruyères,,,Ondres,
-301 Allée des Bruyères,-1.458190,43.570357,,301 Allée des Bruyères,,,,40440
-11 Avenue de Verdun Parentis-en-Born,,,,11 Avenue de Verdun,,,,40160
-11 Avenue de Verdun 40160,,,,11 Avenue de Verdun,,,Parentis-en-Born,
-11 Avenue de Verdun,-1.068463,44.358469,,11 Avenue de Verdun,,,,40160
-40 Thiou de la Lande Pontonx-sur-l'Adour,,,,40 Thiou de la Lande,,,,40465
-40 Thiou de la Lande 40465,,,,40 Thiou de la Lande,,,Pontonx-sur-l'Adour,
-40 Thiou de la Lande,-0.938654,43.787333,,40 Thiou de la Lande,,,,40465
-563 Avenue Gaston Lescouzères Roquefort,,,,563 Avenue Gaston Lescouzères,,,,40120
-563 Avenue Gaston Lescouzères 40120,,,,563 Avenue Gaston Lescouzères,,,Roquefort,
-563 Avenue Gaston Lescouzères,-0.321924,44.043769,,563 Avenue Gaston Lescouzères,,,,40120
-227 Route de l'Auribat Saint-Jean-de-Lier,,,,227 Route de l'Auribat,,,,40380
-227 Route de l'Auribat 40380,,,,227 Route de l'Auribat,,,Saint-Jean-de-Lier,
-227 Route de l'Auribat,-0.875903,43.788860,,227 Route de l'Auribat,,,,40380
-2553 Avenue du Quartier Neuf Saint-Martin-de-Seignanx,,,,2553 Avenue du Quartier Neuf,,,,40390
-2553 Avenue du Quartier Neuf 40390,,,,2553 Avenue du Quartier Neuf,,,Saint-Martin-de-Seignanx,
-2553 Avenue du Quartier Neuf,-1.386432,43.531772,,2553 Avenue du Quartier Neuf,,,,40390
-344 Avenue de la Résistance Saint-Paul-lès-Dax,,,,344 Avenue de la Résistance,,,,40990
-344 Avenue de la Résistance 40990,,,,344 Avenue de la Résistance,,,Saint-Paul-lès-Dax,
-344 Avenue de la Résistance,-1.055410,43.724307,,344 Avenue de la Résistance,,,,40990
-2 Rue Guillaume Sanche Saint-Sever,,,,2 Rue Guillaume Sanche,,,,40500
-2 Rue Guillaume Sanche 40500,,,,2 Rue Guillaume Sanche,,,Saint-Sever,
-2 Rue Guillaume Sanche,-0.564599,43.749650,,2 Rue Guillaume Sanche,,,,40500
-249 Chemin de Pierrot Samadet,,,,249 Chemin de Pierrot,,,,40320
-249 Chemin de Pierrot 40320,,,,249 Chemin de Pierrot,,,Samadet,
-249 Chemin de Pierrot,-0.498466,43.651077,,249 Chemin de Pierrot,,,,40320
-33 Avenue d'Augusta Seignosse,,,,33 Avenue d'Augusta,,,,40510
-33 Avenue d'Augusta 40510,,,,33 Avenue d'Augusta,,,Seignosse,
-33 Avenue d'Augusta,-1.421023,43.695156,,33 Avenue d'Augusta,,,,40510
-205 Avenue Paul Lahary Soorts-Hossegor,,,,205 Avenue Paul Lahary,,,,40150
-205 Avenue Paul Lahary 40150,,,,205 Avenue Paul Lahary,,,Soorts-Hossegor,
-205 Avenue Paul Lahary,-1.430593,43.659827,,205 Avenue Paul Lahary,,,,40150
-8 Rue de Piric Soustons,,,,8 Rue de Piric,,,,40140
-8 Rue de Piric 40140,,,,8 Rue de Piric,,,Soustons,
-8 Rue de Piric,-1.310569,43.741685,,8 Rue de Piric,,,,40140
-808 Rue des Mimosas Tartas,,,,808 Rue des Mimosas,,,,40400
-808 Rue des Mimosas 40400,,,,808 Rue des Mimosas,,,Tartas,
-808 Rue des Mimosas,-0.812372,43.836854,,808 Rue des Mimosas,,,,40400
-7 Rue Claude Debussy Vieux-Boucau-les-Bains,,,,7 Rue Claude Debussy,,,,40480
-7 Rue Claude Debussy 40480,,,,7 Rue Claude Debussy,,,Vieux-Boucau-les-Bains,
-7 Rue Claude Debussy,-1.395571,43.793057,,7 Rue Claude Debussy,,,,40480
-28 Rue Laboulbéne Agen,,,,28 Rue Laboulbéne,,,,47000
-28 Rue Laboulbéne 47000,,,,28 Rue Laboulbéne,,,Agen,
-28 Rue Laboulbéne,0.621702,44.200821,,28 Rue Laboulbéne,,,,47000
-5 Avenue du Marechal-Joffre Aiguillon,,,,5 Avenue du Marechal-Joffre,,,,47190
-5 Avenue du Marechal-Joffre 47190,,,,5 Avenue du Marechal-Joffre,,,Aiguillon,
-5 Avenue du Marechal-Joffre,0.338871,44.287799,,5 Avenue du Marechal-Joffre,,,,47190
-33 Rue de l'École Boé,,,,33 Rue de l'École,,,,47550
-33 Rue de l'École 47550,,,,33 Rue de l'École,,,Boé,
-33 Rue de l'École,0.630073,44.161242,,33 Rue de l'École,,,,47550
-10 Rue Baptiste Marcet Casteljaloux,,,,10 Rue Baptiste Marcet,,,,47700
-10 Rue Baptiste Marcet 47700,,,,10 Rue Baptiste Marcet,,,Casteljaloux,
-10 Rue Baptiste Marcet,0.081247,44.308950,,10 Rue Baptiste Marcet,,,,47700
-156 Route de Lacaussade La Croix-Blanche,,,,156 Route de Lacaussade,,,,47340
-156 Route de Lacaussade 47340,,,,156 Route de Lacaussade,,,La Croix-Blanche,
-156 Route de Lacaussade,0.678807,44.280839,,156 Route de Lacaussade,,,,47340
-10 Rue Neuve Fumel,,,,10 Rue Neuve,,,,47500
-10 Rue Neuve 47500,,,,10 Rue Neuve,,,Fumel,
-10 Rue Neuve,0.955720,44.489609,,10 Rue Neuve,,,,47500
-122 Avenue du Commandant Christian Baylac Marmande,,,,122 Avenue du Commandant Christian Baylac,,,,47200
-122 Avenue du Commandant Christian Baylac 47200,,,,122 Avenue du Commandant Christian Baylac,,,Marmande,
-122 Avenue du Commandant Christian Baylac,0.178997,44.500245,,122 Avenue du Commandant Christian Baylac,,,,47200
-14 Rue Toulouse Lautrec Marmande,,,,14 Rue Toulouse Lautrec,,,,47200
-14 Rue Toulouse Lautrec 47200,,,,14 Rue Toulouse Lautrec,,,Marmande,
-14 Rue Toulouse Lautrec,0.162686,44.508085,,14 Rue Toulouse Lautrec,,,,47200
-19 Rue de l'Union Monflanquin,,,,19 Rue de l'Union,,,,47150
-19 Rue de l'Union 47150,,,,19 Rue de l'Union,,,Monflanquin,
-19 Rue de l'Union,0.768862,44.532183,,19 Rue de l'Union,,,,47150
-6 Rue Helene Boucher Le Passage,,,,6 Rue Hélène Boucher,,,,47520
-6 Rue Helene Boucher 47520,,,,6 Rue Hélène Boucher,,,Le Passage,
-6 Rue Helene Boucher,0.595985,44.199905,,6 Rue Hélène Boucher,,,,47520
-52 Avenue de Saint-Antoine Pujols,,,,52 Avenue de Saint-Antoine,,,,47300
-52 Avenue de Saint-Antoine 47300,,,,52 Avenue de Saint-Antoine,,,Pujols,
-52 Avenue de Saint-Antoine,0.700492,44.377337,,52 Avenue de Saint-Antoine,,,,47300
-33 Rue de la République Saint-Sylvestre-sur-Lot,,,,33 Rue de la République,,,,47140
-33 Rue de la République 47140,,,,33 Rue de la République,,,Saint-Sylvestre-sur-Lot,
-33 Rue de la République,0.803990,44.397284,,33 Rue de la République,,,,47140
-25 Rue Allende Villeneuve-sur-Lot,,,,25 Rue Allende,,,,47300
-25 Rue Allende 47300,,,,25 Rue Allende,,,Villeneuve-sur-Lot,
-25 Rue Allende,0.726070,44.410430,,25 Rue Allende,,,,47300
-7 Rue de Luneville Villeneuve-sur-Lot,,,,7 Rue de Luneville,,,,47300
-7 Rue de Luneville 47300,,,,7 Rue de Luneville,,,Villeneuve-sur-Lot,
-7 Rue de Luneville,0.711374,44.405217,,7 Rue de Luneville,,,,47300
-26 Avenue des Dauphins Anglet,,,,26 Avenue des Dauphins,,,,64600
-26 Avenue des Dauphins 64600,,,,26 Avenue des Dauphins,,,Anglet,
-26 Avenue des Dauphins,-1.540230,43.500891,,26 Avenue des Dauphins,,,,64600
-24 Rue de Saint-Léon Anglet,,,,24 Rue de Saint-Léon,,,,64600
-24 Rue de Saint-Léon 64600,,,,24 Rue de Saint-Léon,,,Anglet,
-24 Rue de Saint-Léon,-1.537594,43.488101,,24 Rue de Saint-Léon,,,,64600
-4 Lotissement Domaine du Piqueur Artiguelouve,,,,4 Lotissement Domaine du Piqueur,,,,64230
-4 Lotissement Domaine du Piqueur 64230,,,,4 Lotissement Domaine du Piqueur,,,Artiguelouve,
-4 Lotissement Domaine du Piqueur,-0.477150,43.315818,,4 Lotissement Domaine du Piqueur,,,,64230
-1069 Chemin de Bellegarde Balansun,,,,1069 Chemin de Bellegarde,,,,64300
-1069 Chemin de Bellegarde 64300,,,,1069 Chemin de Bellegarde,,,Balansun,
-1069 Chemin de Bellegarde,-0.691926,43.494464,,1069 Chemin de Bellegarde,,,,64300
-27 Rue Jules Labat Bayonne,,,,27 Rue Jules Labat,,,,64100
-27 Rue Jules Labat 64100,,,,27 Rue Jules Labat,,,Bayonne,
-27 Rue Jules Labat,-1.478165,43.492781,,27 Rue Jules Labat,,,,64100
-22 D 934 /Qua Sansou Bescat,,,,22 D 934 /Qua Sansou,,,,64260
-22 D 934 /Qua Sansou 64260,,,,22 D 934 /Qua Sansou,,,Bescat,
-22 D 934 /Qua Sansou,-0.401612,43.136794,,22 D 934 /Qua Sansou,,,,64260
-3 Allée des Ormeaux Biarritz,,,,3 Allée des Ormeaux,,,,64200
-3 Allée des Ormeaux 64200,,,,3 Allée des Ormeaux,,,Biarritz,
-3 Allée des Ormeaux,-1.552418,43.473679,,3 Allée des Ormeaux,,,,64200
-7 Rue Laspalettes Bielle,,,,7 Rue Laspalettes,,,,64260
-7 Rue Laspalettes 64260,,,,7 Rue Laspalettes,,,Bielle,
-7 Rue Laspalettes,-0.425447,43.059424,,7 Rue Laspalettes,,,,64260
-2BIS Rue Albert Mora Boucau,,,,2BIS Rue Albert Mora,,,,64340
-2BIS Rue Albert Mora 64340,,,,2BIS Rue Albert Mora,,,Boucau,
-2BIS Rue Albert Mora,-1.466059,43.527856,,2BIS Rue Albert Mora,,,,64340
-26 Rue des Hortensias Cambo-les-Bains,,,,26 Rue des Hortensias,,,,64250
-26 Rue des Hortensias 64250,,,,26 Rue des Hortensias,,,Cambo-les-Bains,
-26 Rue des Hortensias,-1.395730,43.355425,,26 Rue des Hortensias,,,,64250
-11 Rue du Gabizos Coarraze,,,,11 Rue du Gabizos,,,,64800
-11 Rue du Gabizos 64800,,,,11 Rue du Gabizos,,,Coarraze,
-11 Rue du Gabizos,-0.245030,43.179542,,11 Rue du Gabizos,,,,64800
-8 Rue du Padoin Gan,,,,8 Rue du Padoin,,,,64290
-8 Rue du Padoin 64290,,,,8 Rue du Padoin,,,Gan,
-8 Rue du Padoin,-0.386857,43.232652,,8 Rue du Padoin,,,,64290
-5 Place du Jeu de Paume Hasparren,,,,5 Place du Jeu de Paume,,,,64240
-5 Place du Jeu de Paume 64240,,,,5 Place du Jeu de Paume,,,Hasparren,
-5 Place du Jeu de Paume,-1.304446,43.384880,,5 Place du Jeu de Paume,,,,64240
-3 Rue Saint-Louis Idron,,,,3 Rue Saint-Louis,,,,64320
-3 Rue Saint-Louis 64320,,,,3 Rue Saint-Louis,,,Idron,
-3 Rue Saint-Louis,-0.303599,43.288433,,3 Rue Saint-Louis,,,,64320
-581 Route de l'Eglise Lalonquette,,,,581 Route de l'Eglise,,,,64450
-581 Route de l'Eglise 64450,,,,581 Route de l'Eglise,,,Lalonquette,
-581 Route de l'Eglise,-0.322203,43.487934,,581 Route de l'Eglise,,,,64450
-10 Rue du Parvis Lescar,,,,10 Rue du Parvis,,,,64230
-10 Rue du Parvis 64230,,,,10 Rue du Parvis,,,Lescar,
-10 Rue du Parvis,-0.435641,43.332656,,10 Rue du Parvis,,,,64230
-390 Chemin de la Pouble Loubieng,,,,390 Chemin de la Pouble,,,,64300
-390 Chemin de la Pouble 64300,,,,390 Chemin de la Pouble,,,Loubieng,
-390 Chemin de la Pouble,-0.725574,43.430203,,390 Chemin de la Pouble,,,,64300
-7 Allée des Chevreuils Monein,,,,7 Allée des Chevreuils,,,,64360
-7 Allée des Chevreuils 64360,,,,7 Allée des Chevreuils,,,Monein,
-7 Allée des Chevreuils,-0.565611,43.321021,,7 Allée des Chevreuils,,,,64360
-183 Route du Plateau Mouguerre,,,,183 Route du Plateau,,,,64990
-183 Route du Plateau 64990,,,,183 Route du Plateau,,,Mouguerre,
-183 Route du Plateau,-1.431111,43.477527,,183 Route du Plateau,,,,64990
-10 Rue Adoue Oloron-Sainte-Marie,,,,10 Rue Adoue,,,,64400
-10 Rue Adoue 64400,,,,10 Rue Adoue,,,Oloron-Sainte-Marie,
-10 Rue Adoue,-0.610700,43.187819,,10 Rue Adoue,,,,64400
-22 Avenue du 8 Mai Orthez,,,,22 Avenue du 8 Mai,,,,64300
-22 Avenue du 8 Mai 64300,,,,22 Avenue du 8 Mai,,,Orthez,
-22 Avenue du 8 Mai,-0.780128,43.490966,,22 Avenue du 8 Mai,,,,64300
-44 Rue Castetnau Pau,,,,44 Rue Castetnau,,,,64000
-44 Rue Castetnau 64000,,,,44 Rue Castetnau,,,Pau,
-44 Rue Castetnau,-0.364267,43.300539,,44 Rue Castetnau,,,,64000
-9 Rue du Marsan Pau,,,,9 Rue du Marsan,,,,64000
-9 Rue du Marsan 64000,,,,9 Rue du Marsan,,,Pau,
-9 Rue du Marsan,-0.369473,43.326873,,9 Rue du Marsan,,,,64000
-276 Route du Haou Pomps,,,,276 Route du Haou,,,,64370
-276 Route du Haou 64370,,,,276 Route du Haou,,,Pomps,
-276 Route du Haou,-0.548295,43.493244,,276 Route du Haou,,,,64370
-40 Avenue Argi Eder Saint-Jean-de-Luz,,,,40 Avenue Argi Eder,,,,64500
-40 Avenue Argi Eder 64500,,,,40 Avenue Argi Eder,,,Saint-Jean-de-Luz,
-40 Avenue Argi Eder,-1.638311,43.401596,,40 Avenue Argi Eder,,,,64500
-27 Rue des Pyrénées Saint-Laurent-Bretagne,,,,27 Rue des Pyrénées,,,,64160
-27 Rue des Pyrénées 64160,,,,27 Rue des Pyrénées,,,Saint-Laurent-Bretagne,
-27 Rue des Pyrénées,-0.225524,43.390578,,27 Rue des Pyrénées,,,,64160
-1 Impasse Laban Sendets,,,,1 Impasse Laban,,,,64320
-1 Impasse Laban 64320,,,,1 Impasse Laban,,,Sendets,
-1 Impasse Laban,-0.271652,43.293096,,1 Impasse Laban,,,,64320
-318 Chemin Bordenave Urcuit,,,,318 Chemin Bordenave,,,,64990
-318 Chemin Bordenave 64990,,,,318 Chemin Bordenave,,,Urcuit,
-318 Chemin Bordenave,-1.356450,43.495035,,318 Chemin Bordenave,,,,64990
-16 Rue de Hiribehere Ustaritz,,,,16 Rue de Hiribehere,,,,64480
-16 Rue de Hiribehere 64480,,,,16 Rue de Hiribehere,,,Ustaritz,
-16 Rue de Hiribehere,-1.457295,43.400521,,16 Rue de Hiribehere,,,,64480
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+3 Rue Docteur Pierre Simbat Bergerac,,,,3,Rue Docteur Pierre Simbat,,24100
+3 Rue Docteur Pierre Simbat 24100,,,,3,Rue Docteur Pierre Simbat,Bergerac,
+3 Rue Docteur Pierre Simbat,0.475077,44.854347,,3,Rue Docteur Pierre Simbat,,24100
+31 Route Pierre Pinson Bergerac,,,,31,Route Pierre Pinson,,24100
+31 Route Pierre Pinson 24100,,,,31,Route Pierre Pinson,Bergerac,
+31 Route Pierre Pinson,0.454627,44.851248,,31,Route Pierre Pinson,,24100
+6 Place du Champ de Foire Brantôme,,,,6,Place du Champ de Foire,,24310
+6 Place du Champ de Foire 24310,,,,6,Place du Champ de Foire,,24310
+6 Place du Champ de Foire,0.650042,45.361569,,6,Place du Champ de Foire,,24310
+47 Avenue Pierre Mendès France Coulounieix-Chamiers,,,,47,Avenue Pierre Mendès France,,24660
+47 Avenue Pierre Mendès France 24660,,,,47,Avenue Pierre Mendès France,Coulounieix-Chamiers,
+47 Avenue Pierre Mendès France,0.69509,45.162787,,47,Avenue Pierre Mendès France,,24660
+5 Impasse du Coureau Lamonzie-Saint-Martin,,,,5,Impasse du Coureau,,24680
+5 Impasse du Coureau 24680,,,,5,Impasse du Coureau,Lamonzie-Saint-Martin,
+5 Impasse du Coureau,0.376397,44.838837,,5,Impasse du Coureau,,24680
+49 Rue de la Nouzillère Mussidan,,,,49,Rue de la Nouzillère,,24400
+49 Rue de la Nouzillère 24400,,,,49,Rue de la Nouzillère,Mussidan,
+49 Rue de la Nouzillère,0.35968,45.031254,,49,Rue de la Nouzillère,,24400
+8 Rue de la Constitution Périgueux,,,,8,Rue de la Constitution,,24000
+8 Rue de la Constitution 24000,,,,8,Rue de la Constitution,Périgueux,
+8 Rue de la Constitution,0.723692,45.184609,,8,Rue de la Constitution,,24000
+65 Rue du Président Wilson Périgueux,,,,65,Rue du Président Wilson,,24000
+65 Rue du Président Wilson 24000,,,,65,Rue du Président Wilson,Périgueux,
+65 Rue du Président Wilson,0.712912,45.185299,,65,Rue du Président Wilson,,24000
+34 Route de Peymilou Prigonrieux,,,,34,Route de Peymilou,,24130
+34 Route de Peymilou 24130,,,,34,Route de Peymilou,Prigonrieux,
+34 Route de Peymilou,0.411217,44.884759,,34,Route de Peymilou,,24130
+9 Rue Henri Saumande Thiviers,,,,9,Rue Henri Saumande,,24800
+9 Rue Henri Saumande 24800,,,,9,Rue Henri Saumande,Thiviers,
+9 Rue Henri Saumande,0.921633,45.420576,,9,Rue Henri Saumande,,24800
+16B Avenue du Général de Gaulle Ambès,,,,16B,Avenue du Général de Gaulle,,33810
+16B Avenue du Général de Gaulle 33810,,,,16B,Avenue du Général de Gaulle,Ambès,
+16B Avenue du Général de Gaulle,-0.526682,45.011379,,16B,Avenue du Général de Gaulle,,33810
+14 Avenue Johann Strauss Andernos-les-Bains,,,,14,Avenue Johann Strauss,,33510
+14 Avenue Johann Strauss 33510,,,,14,Avenue Johann Strauss,Andernos-les-Bains,
+14 Avenue Johann Strauss,-1.079634,44.739466,,14,Avenue Johann Strauss,,33510
+111 Boulevard de la Côte d'Argent Arcachon,,,,111,Boulevard de la Côte d'Argent,,33120
+111 Boulevard de la Côte d'Argent 33120,,,,111,Boulevard de la Côte d'Argent,Arcachon,
+111 Boulevard de la Côte d'Argent,-1.186492,44.651653,,111,Boulevard de la Côte d'Argent,,33120
+31BIS Avenue Victor Hugo Arcachon,,,,31BIS,Avenue Victor Hugo,,33120
+31BIS Avenue Victor Hugo 33120,,,,31BIS,Avenue Victor Hugo,Arcachon,
+31BIS Avenue Victor Hugo,-1.172149,44.657159,,31BIS,Avenue Victor Hugo,,33120
+15 Avenue de Lestrille Artigues-près-Bordeaux,,,,15,Avenue de Lestrille,,33370
+15 Avenue de Lestrille 33370,,,,15,Avenue de Lestrille,Artigues-près-Bordeaux,
+15 Avenue de Lestrille,-0.496308,44.871065,,15,Avenue de Lestrille,,33370
+8 Résidence Le Courtiou Audenge,,,,8,Résidence Le Courtiou,,33980
+8 Résidence Le Courtiou 33980,,,,8,Résidence Le Courtiou,Audenge,
+8 Résidence Le Courtiou,-0.990967,44.690035,,8,Résidence Le Courtiou,,33980
+23 Rue Maurice Toutaud Bassens,,,,23,Rue Maurice Toutaud,,33530
+23 Rue Maurice Toutaud 33530,,,,23,Rue Maurice Toutaud,Bassens,
+23 Rue Maurice Toutaud,-0.520141,44.893901,,23,Rue Maurice Toutaud,,33530
+56 Avenue Alexis Capelle Bègles,,,,56,Avenue Alexis Capelle,,33130
+56 Avenue Alexis Capelle 33130,,,,56,Avenue Alexis Capelle,Bègles,
+56 Avenue Alexis Capelle,-0.548946,44.81363,,56,Avenue Alexis Capelle,,33130
+50 Avenue Lucien Lerousseau Bègles,,,,50,Avenue Lucien Lerousseau,,33130
+50 Avenue Lucien Lerousseau 33130,,,,50,Avenue Lucien Lerousseau,Bègles,
+50 Avenue Lucien Lerousseau,-0.556357,44.807703,,50,Avenue Lucien Lerousseau,,33130
+3 Route de Maison Rouge Belin-Béliet,,,,3,Route de Maison Rouge,,33830
+3 Route de Maison Rouge 33830,,,,3,Route de Maison Rouge,Belin-Béliet,
+3 Route de Maison Rouge,-0.779524,44.503739,,3,Route de Maison Rouge,,33830
+35 Rue du Cardinal Lecot Blanquefort,,,,35,Rue du Cardinal Lecot,,33290
+35 Rue du Cardinal Lecot 33290,,,,35,Rue du Cardinal Lecot,Blanquefort,
+35 Rue du Cardinal Lecot,-0.648799,44.915606,,35,Rue du Cardinal Lecot,,33290
+1 Chemin du Monteil Blaye,,,,1,Chemin du Monteil,,33390
+1 Chemin du Monteil 33390,,,,1,Chemin du Monteil,Blaye,
+1 Chemin du Monteil,-0.656628,45.128046,,1,Chemin du Monteil,,33390
+2 Rue d'Aviau Bordeaux,,,,2,Rue d'Aviau,,33090
+2 Rue d'Aviau 33090,,,,2,Rue d'Aviau,Bordeaux,
+2 Rue d'Aviau,-0.575711,44.849723,,2,Rue d'Aviau,,33090
+17B Rue Bourbon Bordeaux,,,,17B,Rue Bourbon,,33090
+17B Rue Bourbon 33090,,,,17B,Rue Bourbon,Bordeaux,
+17B Rue Bourbon,-0.556596,44.859876,,17B,Rue Bourbon,,33090
+123 Quai des Chartrons Bordeaux,,,,123,Quai des Chartrons,,33090
+123 Quai des Chartrons 33090,,,,123,Quai des Chartrons,Bordeaux,
+123 Quai des Chartrons,-0.563341,44.856034,,123,Quai des Chartrons,,33090
+5 Cité Dulamon Bordeaux,,,,5,Cité Dulamon,,33090
+5 Cité Dulamon 33090,,,,5,Cité Dulamon,Bordeaux,
+5 Cité Dulamon,-0.572776,44.834117,,5,Cité Dulamon,,33090
+6 Passage François Ducom Bordeaux,,,,6,Passage François Ducom,,33090
+6 Passage François Ducom 33090,,,,6,Passage François Ducom,Bordeaux,
+6 Passage François Ducom,-0.579374,44.823163,,6,Passage François Ducom,,33090
+9 Rue Hoche Bordeaux,,,,9,Rue Hoche,,33090
+9 Rue Hoche 33090,,,,9,Rue Hoche,Bordeaux,
+9 Rue Hoche,-0.603882,44.847715,,9,Rue Hoche,,33090
+114 Chemin Lafitte Bordeaux,,,,114,Chemin Lafitte,,33090
+114 Chemin Lafitte 33090,,,,114,Chemin Lafitte,Bordeaux,
+114 Chemin Lafitte,-0.549965,44.881709,,114,Chemin Lafitte,,33090
+58 Rue de Macau Bordeaux,,,,58,Rue de Macau,,33090
+58 Rue de Macau 33090,,,,58,Rue de Macau,Bordeaux,
+58 Rue de Macau,-0.587626,44.856104,,58,Rue de Macau,,33090
+61 Rue Mondenard Bordeaux,,,,61,Rue Mondenard,,33090
+61 Rue Mondenard 33090,,,,61,Rue Mondenard,Bordeaux,
+61 Rue Mondenard,-0.588301,44.846301,,61,Rue Mondenard,,33090
+172 Rue Pelleport Bordeaux,,,,172,Rue Pelleport,,33090
+172 Rue Pelleport 33090,,,,172,Rue Pelleport,Bordeaux,
+172 Rue Pelleport,-0.56536,44.82127,,172,Rue Pelleport,,33090
+13 Rue des Remparts Bordeaux,,,,13,Rue des Remparts,,33090
+13 Rue des Remparts 33090,,,,13,Rue des Remparts,Bordeaux,
+13 Rue des Remparts,-0.579634,44.840237,,13,Rue des Remparts,,33090
+7 Rue du Soldat Moncourrier Bordeaux,,,,7,Rue du Soldat Moncourrier,,33090
+7 Rue du Soldat Moncourrier 33090,,,,7,Rue du Soldat Moncourrier,Bordeaux,
+7 Rue du Soldat Moncourrier,-0.597601,44.82123,,7,Rue du Soldat Moncourrier,,33090
+17 Rue Victor et Louis Liotard Bordeaux,,,,17,Rue Victor et Louis Liotard,,33090
+17 Rue Victor et Louis Liotard 33090,,,,17,Rue Victor et Louis Liotard,Bordeaux,
+17 Rue Victor et Louis Liotard,-0.596909,44.823322,,17,Rue Victor et Louis Liotard,,33090
+36B Avenue du Général Leclerc Le Bouscat,,,,36B,Avenue du Général Leclerc,,33110
+36B Avenue du Général Leclerc 33110,,,,36B,Avenue du Général Leclerc,Le Bouscat,
+36B Avenue du Général Leclerc,-0.597711,44.854511,,36B,Avenue du Général Leclerc,,33110
+4 Place de l'Église Branne,,,,4,Place de l'Église,,33420
+4 Place de l'Église 33420,,,,4,Place de l'Église,Branne,
+4 Place de l'Église,-0.185841,44.830631,,4,Place de l'Église,,33420
+12 Rue du Camp Bas Cabanac-et-Villagrains,,,,12,Rue du Camp Bas,,33650
+12 Rue du Camp Bas 33650,,,,12,Rue du Camp Bas,Cabanac-et-Villagrains,
+12 Rue du Camp Bas,-0.592585,44.571301,,12,Rue du Camp Bas,,33650
+37 Route de Morillon Camblanes-et-Meynac,,,,37,Route de Morillon,,33360
+37 Route de Morillon 33360,,,,37,Route de Morillon,Camblanes-et-Meynac,
+37 Route de Morillon,-0.480489,44.764428,,37,Route de Morillon,,33360
+1 Rue Pierre Corneille Carbon-Blanc,,,,1,Rue Pierre Corneille,,33560
+1 Rue Pierre Corneille 33560,,,,1,Rue Pierre Corneille,Carbon-Blanc,
+1 Rue Pierre Corneille,-0.494346,44.906445,,1,Rue Pierre Corneille,,33560
+8 Rue du 14 Juillet Castelnau-de-Médoc,,,,8,Rue du 14 Juillet,,33480
+8 Rue du 14 Juillet 33480,,,,8,Rue du 14 Juillet,Castelnau-de-Médoc,
+8 Rue du 14 Juillet,-0.798072,45.028678,,8,Rue du 14 Juillet,,33480
+34 Chemin des Bories Cenon,,,,34,Chemin des Bories,,33150
+34 Chemin des Bories 33150,,,,34,Chemin des Bories,Cenon,
+34 Chemin des Bories,-0.516612,44.84989,,34,Chemin des Bories,,33150
+4 Lotissement Les Moulins Cérons,,,,4,Lotissement Les Moulins,,33720
+4 Lotissement Les Moulins 33720,,,,4,Lotissement Les Moulins,Cérons,
+4 Lotissement Les Moulins,-0.348354,44.632741,,4,Lotissement Les Moulins,,33720
+14 Chemin de Peyre Cestas,,,,14,Chemin de Peyre,,33610
+14 Chemin de Peyre 33610,,,,14,Chemin de Peyre,Cestas,
+14 Chemin de Peyre,-0.651919,44.73353,,14,Chemin de Peyre,,33610
+2 Rue Epernon Créon,,,,2,Rue Epernon,,33670
+2 Rue Epernon 33670,,,,2,Rue Epernon,Créon,
+2 Rue Epernon,-0.347629,44.774049,,2,Rue Epernon,,33670
+71 Rue du College Technique Eysines,,,,71,Rue du College Technique,,33320
+71 Rue du College Technique 33320,,,,71,Rue du College Technique,Eysines,
+71 Rue du College Technique,-0.629469,44.884043,,71,Rue du College Technique,,33320
+5 Route de Dardenac Faleyras,,,,5,Route de Dardenac,,33760
+5 Route de Dardenac 33760,,,,5,Route de Dardenac,Faleyras,
+5 Route de Dardenac,-0.241729,44.778078,,5,Route de Dardenac,,33760
+13 Rue Racine Floirac,,,,13,Rue Racine,,33270
+13 Rue Racine 33270,,,,13,Rue Racine,Floirac,
+13 Rue Racine,-0.514491,44.845523,,13,Rue Racine,,33270
+2 Allée de la Clairière Gradignan,,,,2,Allée de la Clairière,,33170
+2 Allée de la Clairière 33170,,,,2,Allée de la Clairière,Gradignan,
+2 Allée de la Clairière,-0.612658,44.776573,,2,Allée de la Clairière,,33170
+15 Allée Paul Cézanne Gradignan,,,,15,Allée Paul Cézanne,,33170
+15 Allée Paul Cézanne 33170,,,,15,Allée Paul Cézanne,Gradignan,
+15 Allée Paul Cézanne,-0.634094,44.771633,,15,Allée Paul Cézanne,,33170
+64 Rue Chante Cigale Gujan-Mestras,,,,64,Rue Chante Cigale,,33470
+64 Rue Chante Cigale 33470,,,,64,Rue Chante Cigale,Gujan-Mestras,
+64 Rue Chante Cigale,-1.062088,44.629659,,64,Rue Chante Cigale,,33470
+73 Allée des Places Gujan-Mestras,,,,73,Allée des Places,,33470
+73 Allée des Places 33470,,,,73,Allée des Places,Gujan-Mestras,
+73 Allée des Places,-1.092154,44.633911,,73,Allée des Places,,33470
+10 Rue des Potiers Le Haillan,,,,10,Rue des Potiers,,33185
+10 Rue des Potiers 33185,,,,10,Rue des Potiers,Le Haillan,
+10 Rue des Potiers,-0.686257,44.876153,,10,Rue des Potiers,,33185
+438 Avenue du Général de Gaulle Izon,,,,438,Avenue du Général de Gaulle,,33450
+438 Avenue du Général de Gaulle 33450,,,,438,Avenue du Général de Gaulle,Izon,
+438 Avenue du Général de Gaulle,-0.350218,44.917525,,438,Avenue du Général de Gaulle,,33450
+106 Chemin des Gemmeurs Lacanau,,,,106,Chemin des Gemmeurs,,33680
+106 Chemin des Gemmeurs 33680,,,,106,Chemin des Gemmeurs,Lacanau,
+106 Chemin des Gemmeurs,-1.178049,45.002652,,106,Chemin des Gemmeurs,,33680
+68 Avenue du Général De Gaulle Langoiran,,,,68,Avenue du Général De Gaulle,,33550
+68 Avenue du Général De Gaulle 33550,,,,68,Avenue du Général De Gaulle,Langoiran,
+68 Avenue du Général De Gaulle,-0.39908,44.70561,,68,Avenue du Général De Gaulle,,33550
+25 Boulevard de la Plage Lanton,,,,25,Boulevard de la Plage,,33138
+25 Boulevard de la Plage 33138,,,,25,Boulevard de la Plage,Lanton,
+25 Boulevard de la Plage,-1.067437,44.717438,,25,Boulevard de la Plage,,33138
+20 Rue des Chevreuils Piraillan Lège-Cap-Ferret,,,,20,Rue des Chevreuils Piraillan,,33950
+20 Rue des Chevreuils Piraillan 33950,,,,20,Rue des Chevreuils Piraillan,Lège-Cap-Ferret,
+20 Rue des Chevreuils Piraillan,-1.228406,44.711892,,20,Rue des Chevreuils Piraillan,,33950
+8BIS Rue de la Poste Cap Ferret Lège-Cap-Ferret,,,,8BIS,Rue de la Poste Cap Ferret,,33950
+8BIS Rue de la Poste Cap Ferret 33950,,,,8BIS,Rue de la Poste Cap Ferret,Lège-Cap-Ferret,
+8BIS Rue de la Poste Cap Ferret,-1.248688,44.647288,,8BIS,Rue de la Poste Cap Ferret,,33950
+2BIS Rue des Abbés Collin Lesparre-Médoc,,,,2BIS,Rue des Abbés Collin,,33340
+2BIS Rue des Abbés Collin 33340,,,,2BIS,Rue des Abbés Collin,Lesparre-Médoc,
+2BIS Rue des Abbés Collin,-0.923608,45.303859,,2BIS,Rue des Abbés Collin,,33340
+195 Avenue de l'Épinette Libourne,,,,195,Avenue de l'Épinette,,33500
+195 Avenue de l'Épinette 33500,,,,195,Avenue de l'Épinette,Libourne,
+195 Avenue de l'Épinette,-0.214421,44.906517,,195,Avenue de l'Épinette,,33500
+10 Rue des 4 Frères Robert Libourne,,,,10,Rue des 4 Frères Robert,,33500
+10 Rue des 4 Frères Robert 33500,,,,10,Rue des 4 Frères Robert,Libourne,
+10 Rue des 4 Frères Robert,-0.246306,44.911514,,10,Rue des 4 Frères Robert,,33500
+89 Rue du Général de Gaulle Lormont,,,,89,Rue du Général de Gaulle,,33310
+89 Rue du Général de Gaulle 33310,,,,89,Rue du Général de Gaulle,Lormont,
+89 Rue du Général de Gaulle,-0.528535,44.877435,,89,Rue du Général de Gaulle,,33310
+11 Rue Combattants Afn 1952 1962 Macau,,,,11,Rue Combattants Afn 1952 1962,,33460
+11 Rue Combattants Afn 1952 1962 33460,,,,11,Rue Combattants Afn 1952 1962,Macau,
+11 Rue Combattants Afn 1952 1962,-0.620015,45.002512,,11,Rue Combattants Afn 1952 1962,,33460
+29 Rue Alphonse Daudet Mérignac,,,,29,Rue Alphonse Daudet,,33700
+29 Rue Alphonse Daudet 33700,,,,29,Rue Alphonse Daudet,Mérignac,
+29 Rue Alphonse Daudet,-0.657175,44.852947,,29,Rue Alphonse Daudet,,33700
+64 Avenue de l'Europe Mérignac,,,,64,Avenue de l'Europe,,33700
+64 Avenue de l'Europe 33700,,,,64,Avenue de l'Europe,Mérignac,
+64 Avenue de l'Europe,-0.672518,44.820343,,64,Avenue de l'Europe,,33700
+110 Avenue de la Libération Mérignac,,,,110,Avenue de la Libération,,33700
+110 Avenue de la Libération 33700,,,,110,Avenue de la Libération,Mérignac,
+110 Avenue de la Libération,-0.644571,44.854168,,110,Avenue de la Libération,,33700
+23 Avenue Pythagore Mérignac,,,,23,Avenue Pythagore,,33700
+23 Avenue Pythagore 33700,,,,23,Avenue Pythagore,Mérignac,
+23 Avenue Pythagore,-0.680333,44.831207,,23,Avenue Pythagore,,33700
+34 Rue Porte de la Réole Monségur,,,,34,Rue Porte de la Réole,,33580
+34 Rue Porte de la Réole 33580,,,,34,Rue Porte de la Réole,Monségur,
+34 Rue Porte de la Réole,0.078745,44.649933,,34,Rue Porte de la Réole,,33580
+22 Allée de la Forêt d'Arboudeau Parempuyre,,,,22,Allée de la Forêt d'Arboudeau,,33290
+22 Allée de la Forêt d'Arboudeau 33290,,,,22,Allée de la Forêt d'Arboudeau,Parempuyre,
+22 Allée de la Forêt d'Arboudeau,-0.609884,44.943862,,22,Allée de la Forêt d'Arboudeau,,33290
+4 Allée de l'Aube Pessac,,,,4,Allée de l'Aube,,33600
+4 Allée de l'Aube 33600,,,,4,Allée de l'Aube,Pessac,
+4 Allée de l'Aube,-0.67958,44.796945,,4,Allée de l'Aube,,33600
+19 Avenue des Erables Pessac,,,,19,Avenue des Erables,,33600
+19 Avenue des Erables 33600,,,,19,Avenue des Erables,Pessac,
+19 Avenue des Erables,-0.622953,44.812073,,19,Avenue des Erables,,33600
+14 Avenue Léon Blum Pessac,,,,14,Avenue Léon Blum,,33600
+14 Avenue Léon Blum 33600,,,,14,Avenue Léon Blum,Pessac,
+14 Avenue Léon Blum,-0.624426,44.814299,,14,Avenue Léon Blum,,33600
+158 Rue de la Poudrière Pessac,,,,158,Rue de la Poudrière,,33600
+158 Rue de la Poudrière 33600,,,,158,Rue de la Poudrière,Pessac,
+158 Rue de la Poudrière,-0.701315,44.791874,,158,Rue de la Poudrière,,33600
+296 Chemin Font Martin Le Pian-Médoc,,,,296,Chemin Font Martin,,33290
+296 Chemin Font Martin 33290,,,,296,Chemin Font Martin,Le Pian-Médoc,
+296 Chemin Font Martin,-0.684848,44.942391,,296,Chemin Font Martin,,33290
+4 Chemin de Callonge Pompignac,,,,4,Chemin de Callonge,,33370
+4 Chemin de Callonge 33370,,,,4,Chemin de Callonge,Pompignac,
+4 Chemin de Callonge,-0.43586,44.849075,,4,Chemin de Callonge,,33370
+11 Rue du Général de Gaulle Reignac,,,,11,Rue du Général de Gaulle,,33860
+11 Rue du Général de Gaulle 33860,,,,11,Rue du Général de Gaulle,Reignac,
+11 Rue du Général de Gaulle,-0.506287,45.232121,,11,Rue du Général de Gaulle,,33860
+25 Rue de Montalon Saint-André-de-Cubzac,,,,25,Rue de Montalon,,33240
+25 Rue de Montalon 33240,,,,25,Rue de Montalon,Saint-André-de-Cubzac,
+25 Rue de Montalon,-0.447362,44.996219,,25,Rue de Montalon,,33240
+10 Rue de l'Église Saint-Christoly-Médoc,,,,10,Rue de l'Église,,33340
+10 Rue de l'Église 33340,,,,10,Rue de l'Église,Saint-Christoly-Médoc,
+10 Rue de l'Église,-0.826166,45.356896,,10,Rue de l'Église,,33340
+75 Rue François Boulière Sainte-Eulalie,,,,75,Rue François Boulière,,33560
+75 Rue François Boulière 33560,,,,75,Rue François Boulière,Sainte-Eulalie,
+75 Rue François Boulière,-0.464408,44.907859,,75,Rue François Boulière,,33560
+15 Impasse Bugade Saint-Jean-d'Illac,,,,15,Impasse Bugade,,33127
+15 Impasse Bugade 33127,,,,15,Impasse Bugade,Saint-Jean-d'Illac,
+15 Impasse Bugade,-0.834097,44.801573,,15,Impasse Bugade,,33127
+31 Rue du Moulin de Conilh Saint-Loubès,,,,31,Rue du Moulin de Conilh,,33450
+31 Rue du Moulin de Conilh 33450,,,,31,Rue du Moulin de Conilh,Saint-Loubès,
+31 Rue du Moulin de Conilh,-0.440753,44.916946,,31,Rue du Moulin de Conilh,,33450
+12BIS Chemin du Bruilleau Saint-Médard-d'Eyrans,,,,12BIS,Chemin du Bruilleau,,33650
+12BIS Chemin du Bruilleau 33650,,,,12BIS,Chemin du Bruilleau,Saint-Médard-d'Eyrans,
+12BIS Chemin du Bruilleau,-0.519029,44.694191,,12BIS,Chemin du Bruilleau,,33650
+20 Rue Fernand Labrousse Saint-Médard-en-Jalles,,,,20,Rue Fernand Labrousse,,33160
+20 Rue Fernand Labrousse 33160,,,,20,Rue Fernand Labrousse,Saint-Médard-en-Jalles,
+20 Rue Fernand Labrousse,-0.753604,44.891912,,20,Rue Fernand Labrousse,,33160
+12 Allée des Palombes Saint-Médard-en-Jalles,,,,12,Allée des Palombes,,33160
+12 Allée des Palombes 33160,,,,12,Allée des Palombes,Saint-Médard-en-Jalles,
+12 Allée des Palombes,-0.782343,44.89447,,12,Allée des Palombes,,33160
+43 Rue Célestin Joubert Saint-Savin,,,,43,Rue Célestin Joubert,,33920
+43 Rue Célestin Joubert 33920,,,,43,Rue Célestin Joubert,Saint-Savin,
+43 Rue Célestin Joubert,-0.447718,45.140065,,43,Rue Célestin Joubert,,33920
+12 Chemin des Pins Saint-Vivien-de-Médoc,,,,12,Chemin des Pins,,33590
+12 Chemin des Pins 33590,,,,12,Chemin des Pins,Saint-Vivien-de-Médoc,
+12 Chemin des Pins,-1.045862,45.423773,,12,Chemin des Pins,,33590
+18 Résidence Le Parc de Taudignon Salles,,,,18,Résidence Le Parc de Taudignon,,33770
+18 Résidence Le Parc de Taudignon 33770,,,,18,Résidence Le Parc de Taudignon,Salles,
+18 Résidence Le Parc de Taudignon,-0.874498,44.563054,,18,Résidence Le Parc de Taudignon,,33770
+12 Place de la République Soulac-sur-Mer,,,,12,Place de la République,,33780
+12 Place de la République 33780,,,,12,Place de la République,Soulac-sur-Mer,
+12 Place de la République,-1.126167,45.508096,,12,Place de la République,,33780
+77 Rue Victor Schoelcher Le Taillan-Médoc,,,,77,Rue Victor Schoelcher,,33320
+77 Rue Victor Schoelcher 33320,,,,77,Rue Victor Schoelcher,Le Taillan-Médoc,
+77 Rue Victor Schoelcher,-0.677172,44.903033,,77,Rue Victor Schoelcher,,33320
+97 Boulevard George V Talence,,,,97,Boulevard George V,,33400
+97 Boulevard George V 33400,,,,97,Boulevard George V,Talence,
+97 Boulevard George V,-0.587917,44.824324,,97,Boulevard George V,,33400
+8 Rue Vergnaud Talence,,,,8,Rue Vergnaud,,33400
+8 Rue Vergnaud 33400,,,,8,Rue Vergnaud,Talence,
+8 Rue Vergnaud,-0.575896,44.809673,,8,Rue Vergnaud,,33400
+78 Avenue de la Brasserie La Teste-de-Buch,,,,78,Avenue de la Brasserie,,33164
+78 Avenue de la Brasserie 33164,,,,78,Avenue de la Brasserie,La Teste-de-Buch,
+78 Avenue de la Brasserie,-1.147982,44.628861,,78,Avenue de la Brasserie,,33164
+22 Rue Jean Saint-Marc La Teste-de-Buch,,,,22,Rue Jean Saint-Marc,,33164
+22 Rue Jean Saint-Marc 33164,,,,22,Rue Jean Saint-Marc,La Teste-de-Buch,
+22 Rue Jean Saint-Marc,-1.117454,44.634571,,22,Rue Jean Saint-Marc,,33164
+5 Allée des Platanes de Castéra La Teste-de-Buch,,,,5,Allée des Platanes de Castéra,,33164
+5 Allée des Platanes de Castéra 33164,,,,5,Allée des Platanes de Castéra,La Teste-de-Buch,
+5 Allée des Platanes de Castéra,-1.145141,44.538804,,5,Allée des Platanes de Castéra,,33164
+27 Route de Montalivet Vendays-Montalivet,,,,27,Route de Montalivet,,33930
+27 Route de Montalivet 33930,,,,27,Route de Montalivet,Vendays-Montalivet,
+27 Route de Montalivet,-1.066271,45.35716,,27,Route de Montalivet,,33930
+16 Rue des Bleuets Villenave-d'Ornon,,,,16,Rue des Bleuets,,33140
+16 Rue des Bleuets 33140,,,,16,Rue des Bleuets,Villenave-d'Ornon,
+16 Rue des Bleuets,-0.577113,44.756149,,16,Rue des Bleuets,,33140
+31 Chemin Lalaurie Villenave-d'Ornon,,,,31,Chemin Lalaurie,,33140
+31 Chemin Lalaurie 33140,,,,31,Chemin Lalaurie,Villenave-d'Ornon,
+31 Chemin Lalaurie,-0.566619,44.765003,,31,Chemin Lalaurie,,33140
+77 Rue Yvon Mansencal Villenave-d'Ornon,,,,77,Rue Yvon Mansencal,,33140
+77 Rue Yvon Mansencal 33140,,,,77,Rue Yvon Mansencal,Villenave-d'Ornon,
+77 Rue Yvon Mansencal,-0.574044,44.778289,,77,Rue Yvon Mansencal,,33140
+190 Route du Château Arsague,,,,190,Route du Château,,40330
+190 Route du Château 40330,,,,190,Route du Château,Arsague,
+190 Route du Château,-0.792188,43.585772,,190,Route du Château,,40330
+1660 Chemin de Sablaret Bénesse-Maremne,,,,1660,Chemin de Sablaret,,40230
+1660 Chemin de Sablaret 40230,,,,1660,Chemin de Sablaret,Bénesse-Maremne,
+1660 Chemin de Sablaret,-1.376576,43.620787,,1660,Chemin de Sablaret,,40230
+578 Avenue Gabriele d'Annunzio Biscarrosse,,,,578,Avenue Gabriele d'Annunzio,,40600
+578 Avenue Gabriele d'Annunzio 40600,,,,578,Avenue Gabriele d'Annunzio,Biscarrosse,
+578 Avenue Gabriele d'Annunzio,-1.248768,44.453087,,578,Avenue Gabriele d'Annunzio,,40600
+502 Rue d'Yquem Biscarrosse,,,,502,Rue d'Yquem,,40600
+502 Rue d'Yquem 40600,,,,502,Rue d'Yquem,Biscarrosse,
+502 Rue d'Yquem,-1.152588,44.395253,,502,Rue d'Yquem,,40600
+22 Boulevard du Docteur Junqua Capbreton,,,,22,Boulevard du Docteur Junqua,,40130
+22 Boulevard du Docteur Junqua 40130,,,,22,Boulevard du Docteur Junqua,Capbreton,
+22 Boulevard du Docteur Junqua,-1.429401,43.643674,,22,Boulevard du Docteur Junqua,,40130
+123 Laplaçote Cauneille,,,,123,Laplaçote,,40300
+123 Laplaçote 40300,,,,123,Laplaçote,Cauneille,
+123 Laplaçote,-1.082044,43.547036,,123,Laplaçote,,40300
+76 Avenue Georges Clémenceau Dax,,,,76,Avenue Georges Clemenceau,,40100
+76 Avenue Georges Clémenceau 40100,,,,76,Avenue Georges Clemenceau,Dax,
+76 Avenue Georges Clémenceau,-1.046628,43.707986,,76,Avenue Georges Clemenceau,,40100
+58 Route du Lac de Tastoa Estibeaux,,,,58,Route du Lac de Tastoa,,40290
+58 Route du Lac de Tastoa 40290,,,,58,Route du Lac de Tastoa,Estibeaux,
+58 Route du Lac de Tastoa,-0.895449,43.592815,,58,Route du Lac de Tastoa,,40290
+48 Rue René Vielle Grenade-sur-l'Adour,,,,48,Rue René Vielle,,40270
+48 Rue René Vielle 40270,,,,48,Rue René Vielle,Grenade-sur-l'Adour,
+48 Rue René Vielle,-0.425961,43.772494,,48,Rue René Vielle,,40270
+77 Rue des Cerisiers Josse,,,,77,Rue des Cerisiers,,40230
+77 Rue des Cerisiers 40230,,,,77,Rue des Cerisiers,Josse,
+77 Rue des Cerisiers,-1.221092,43.642049,,77,Rue des Cerisiers,,40230
+56 Chemin de Pesques Laluque,,,,56,Chemin de Pesques,,40465
+56 Chemin de Pesques 40465,,,,56,Chemin de Pesques,Laluque,
+56 Chemin de Pesques,-0.991764,43.855019,,56,Chemin de Pesques,,40465
+131 Rue des Tilleuls Lit-et-Mixe,,,,131,Rue des Tilleuls,,40170
+131 Rue des Tilleuls 40170,,,,131,Rue des Tilleuls,Lit-et-Mixe,
+131 Rue des Tilleuls,-1.256387,44.033363,,131,Rue des Tilleuls,,40170
+150 Chemin du Pey de l'Ancre Messanges,,,,150,Chemin du Pey de l'Ancre,,40660
+150 Chemin du Pey de l'Ancre 40660,,,,150,Chemin du Pey de l'Ancre,Messanges,
+150 Chemin du Pey de l'Ancre,-1.388481,43.796055,,150,Chemin du Pey de l'Ancre,,40660
+477 Chemin de Condom Misson,,,,477,Chemin de Condom,,40290
+477 Chemin de Condom 40290,,,,477,Chemin de Condom,Misson,
+477 Chemin de Condom,-0.957415,43.579464,,477,Chemin de Condom,,40290
+10 Avenue du Doct René Lataste Mont-de-Marsan,,,,10,Avenue du Doct René Lataste,,40000
+10 Avenue du Doct René Lataste 40000,,,,10,Avenue du Doct René Lataste,Mont-de-Marsan,
+10 Avenue du Doct René Lataste,-0.481489,43.88064,,10,Avenue du Doct René Lataste,,40000
+150 Avenue de Morcenx Mont-de-Marsan,,,,150,Avenue de Morcenx,,40000
+150 Avenue de Morcenx 40000,,,,150,Avenue de Morcenx,Mont-de-Marsan,
+150 Avenue de Morcenx,-0.522942,43.903836,,150,Avenue de Morcenx,,40000
+35 Rue des Cigales Morcenx,,,,35,Rue des Cigales,,40110
+35 Rue des Cigales 40110,,,,35,Rue des Cigales,Morcenx,
+35 Rue des Cigales,-0.896936,44.025986,,35,Rue des Cigales,,40110
+301 Allée des Bruyères Ondres,,,,301,Allée des Bruyères,,40440
+301 Allée des Bruyères 40440,,,,301,Allée des Bruyères,Ondres,
+301 Allée des Bruyères,-1.45819,43.570357,,301,Allée des Bruyères,,40440
+11 Avenue de Verdun Parentis-en-Born,,,,11,Avenue de Verdun,,40160
+11 Avenue de Verdun 40160,,,,11,Avenue de Verdun,Parentis-en-Born,
+11 Avenue de Verdun,-1.068463,44.358469,,11,Avenue de Verdun,,40160
+40 Thiou de la Lande Pontonx-sur-l'Adour,,,,40,Thiou de la Lande,,40465
+40 Thiou de la Lande 40465,,,,40,Thiou de la Lande,Pontonx-sur-l'Adour,
+40 Thiou de la Lande,-0.938654,43.787333,,40,Thiou de la Lande,,40465
+563 Avenue Gaston Lescouzères Roquefort,,,,563,Avenue Gaston Lescouzères,,40120
+563 Avenue Gaston Lescouzères 40120,,,,563,Avenue Gaston Lescouzères,Roquefort,
+563 Avenue Gaston Lescouzères,-0.321924,44.043769,,563,Avenue Gaston Lescouzères,,40120
+227 Route de l'Auribat Saint-Jean-de-Lier,,,,227,Route de l'Auribat,,40380
+227 Route de l'Auribat 40380,,,,227,Route de l'Auribat,Saint-Jean-de-Lier,
+227 Route de l'Auribat,-0.875903,43.78886,,227,Route de l'Auribat,,40380
+2553 Avenue du Quartier Neuf Saint-Martin-de-Seignanx,,,,2553,Avenue du Quartier Neuf,,40390
+2553 Avenue du Quartier Neuf 40390,,,,2553,Avenue du Quartier Neuf,Saint-Martin-de-Seignanx,
+2553 Avenue du Quartier Neuf,-1.386432,43.531772,,2553,Avenue du Quartier Neuf,,40390
+344 Avenue de la Résistance Saint-Paul-lès-Dax,,,,344,Avenue de la Résistance,,40990
+344 Avenue de la Résistance 40990,,,,344,Avenue de la Résistance,Saint-Paul-lès-Dax,
+344 Avenue de la Résistance,-1.05541,43.724307,,344,Avenue de la Résistance,,40990
+2 Rue Guillaume Sanche Saint-Sever,,,,2,Rue Guillaume Sanche,,40500
+2 Rue Guillaume Sanche 40500,,,,2,Rue Guillaume Sanche,Saint-Sever,
+2 Rue Guillaume Sanche,-0.564599,43.74965,,2,Rue Guillaume Sanche,,40500
+249 Chemin de Pierrot Samadet,,,,249,Chemin de Pierrot,,40320
+249 Chemin de Pierrot 40320,,,,249,Chemin de Pierrot,Samadet,
+249 Chemin de Pierrot,-0.498466,43.651077,,249,Chemin de Pierrot,,40320
+33 Avenue d'Augusta Seignosse,,,,33,Avenue d'Augusta,,40510
+33 Avenue d'Augusta 40510,,,,33,Avenue d'Augusta,Seignosse,
+33 Avenue d'Augusta,-1.421023,43.695156,,33,Avenue d'Augusta,,40510
+205 Avenue Paul Lahary Soorts-Hossegor,,,,205,Avenue Paul Lahary,,40150
+205 Avenue Paul Lahary 40150,,,,205,Avenue Paul Lahary,Soorts-Hossegor,
+205 Avenue Paul Lahary,-1.430593,43.659827,,205,Avenue Paul Lahary,,40150
+8 Rue de Piric Soustons,,,,8,Rue de Piric,,40140
+8 Rue de Piric 40140,,,,8,Rue de Piric,Soustons,
+8 Rue de Piric,-1.310569,43.741685,,8,Rue de Piric,,40140
+808 Rue des Mimosas Tartas,,,,808,Rue des Mimosas,,40400
+808 Rue des Mimosas 40400,,,,808,Rue des Mimosas,Tartas,
+808 Rue des Mimosas,-0.812372,43.836854,,808,Rue des Mimosas,,40400
+7 Rue Claude Debussy Vieux-Boucau-les-Bains,,,,7,Rue Claude Debussy,,40480
+7 Rue Claude Debussy 40480,,,,7,Rue Claude Debussy,Vieux-Boucau-les-Bains,
+7 Rue Claude Debussy,-1.395571,43.793057,,7,Rue Claude Debussy,,40480
+28 Rue Laboulbéne Agen,,,,28,Rue Laboulbéne,,47000
+28 Rue Laboulbéne 47000,,,,28,Rue Laboulbéne,Agen,
+28 Rue Laboulbéne,0.621702,44.200821,,28,Rue Laboulbéne,,47000
+5 Avenue du Marechal-Joffre Aiguillon,,,,5,Avenue du Marechal-Joffre,,47190
+5 Avenue du Marechal-Joffre 47190,,,,5,Avenue du Marechal-Joffre,Aiguillon,
+5 Avenue du Marechal-Joffre,0.338871,44.287799,,5,Avenue du Marechal-Joffre,,47190
+33 Rue de l'École Boé,,,,33,Rue de l'École,,47550
+33 Rue de l'École 47550,,,,33,Rue de l'École,Boé,
+33 Rue de l'École,0.630073,44.161242,,33,Rue de l'École,,47550
+10 Rue Baptiste Marcet Casteljaloux,,,,10,Rue Baptiste Marcet,,47700
+10 Rue Baptiste Marcet 47700,,,,10,Rue Baptiste Marcet,Casteljaloux,
+10 Rue Baptiste Marcet,0.081247,44.30895,,10,Rue Baptiste Marcet,,47700
+156 Route de Lacaussade La Croix-Blanche,,,,156,Route de Lacaussade,,47340
+156 Route de Lacaussade 47340,,,,156,Route de Lacaussade,La Croix-Blanche,
+156 Route de Lacaussade,0.678807,44.280839,,156,Route de Lacaussade,,47340
+10 Rue Neuve Fumel,,,,10,Rue Neuve,,47500
+10 Rue Neuve 47500,,,,10,Rue Neuve,Fumel,
+10 Rue Neuve,0.95572,44.489609,,10,Rue Neuve,,47500
+122 Avenue du Commandant Christian Baylac Marmande,,,,122,Avenue du Commandant Christian Baylac,,47200
+122 Avenue du Commandant Christian Baylac 47200,,,,122,Avenue du Commandant Christian Baylac,Marmande,
+122 Avenue du Commandant Christian Baylac,0.178997,44.500245,,122,Avenue du Commandant Christian Baylac,,47200
+14 Rue Toulouse Lautrec Marmande,,,,14,Rue Toulouse Lautrec,,47200
+14 Rue Toulouse Lautrec 47200,,,,14,Rue Toulouse Lautrec,Marmande,
+14 Rue Toulouse Lautrec,0.162686,44.508085,,14,Rue Toulouse Lautrec,,47200
+19 Rue de l'Union Monflanquin,,,,19,Rue de l'Union,,47150
+19 Rue de l'Union 47150,,,,19,Rue de l'Union,Monflanquin,
+19 Rue de l'Union,0.768862,44.532183,,19,Rue de l'Union,,47150
+6 Rue Helene Boucher Le Passage,,,,6,Rue Hélène Boucher,,47520
+6 Rue Helene Boucher 47520,,,,6,Rue Hélène Boucher,Le Passage,
+6 Rue Helene Boucher,0.595985,44.199905,,6,Rue Hélène Boucher,,47520
+52 Avenue de Saint-Antoine Pujols,,,,52,Avenue de Saint-Antoine,,47300
+52 Avenue de Saint-Antoine 47300,,,,52,Avenue de Saint-Antoine,Pujols,
+52 Avenue de Saint-Antoine,0.700492,44.377337,,52,Avenue de Saint-Antoine,,47300
+33 Rue de la République Saint-Sylvestre-sur-Lot,,,,33,Rue de la République,,47140
+33 Rue de la République 47140,,,,33,Rue de la République,Saint-Sylvestre-sur-Lot,
+33 Rue de la République,0.80399,44.397284,,33,Rue de la République,,47140
+25 Rue Allende Villeneuve-sur-Lot,,,,25,Rue Allende,,47300
+25 Rue Allende 47300,,,,25,Rue Allende,Villeneuve-sur-Lot,
+25 Rue Allende,0.72607,44.41043,,25,Rue Allende,,47300
+7 Rue de Luneville Villeneuve-sur-Lot,,,,7,Rue de Luneville,,47300
+7 Rue de Luneville 47300,,,,7,Rue de Luneville,Villeneuve-sur-Lot,
+7 Rue de Luneville,0.711374,44.405217,,7,Rue de Luneville,,47300
+26 Avenue des Dauphins Anglet,,,,26,Avenue des Dauphins,,64600
+26 Avenue des Dauphins 64600,,,,26,Avenue des Dauphins,Anglet,
+26 Avenue des Dauphins,-1.54023,43.500891,,26,Avenue des Dauphins,,64600
+24 Rue de Saint-Léon Anglet,,,,24,Rue de Saint-Léon,,64600
+24 Rue de Saint-Léon 64600,,,,24,Rue de Saint-Léon,Anglet,
+24 Rue de Saint-Léon,-1.537594,43.488101,,24,Rue de Saint-Léon,,64600
+4 Lotissement Domaine du Piqueur Artiguelouve,,,,4,Lotissement Domaine du Piqueur,,64230
+4 Lotissement Domaine du Piqueur 64230,,,,4,Lotissement Domaine du Piqueur,Artiguelouve,
+4 Lotissement Domaine du Piqueur,-0.47715,43.315818,,4,Lotissement Domaine du Piqueur,,64230
+1069 Chemin de Bellegarde Balansun,,,,1069,Chemin de Bellegarde,,64300
+1069 Chemin de Bellegarde 64300,,,,1069,Chemin de Bellegarde,Balansun,
+1069 Chemin de Bellegarde,-0.691926,43.494464,,1069,Chemin de Bellegarde,,64300
+27 Rue Jules Labat Bayonne,,,,27,Rue Jules Labat,,64100
+27 Rue Jules Labat 64100,,,,27,Rue Jules Labat,Bayonne,
+27 Rue Jules Labat,-1.478165,43.492781,,27,Rue Jules Labat,,64100
+22 D 934 /Qua Sansou Bescat,,,,22,/Qua Sansou,,64260
+22 D 934 /Qua Sansou 64260,,,,22,/Qua Sansou,Bescat,
+22 D 934 /Qua Sansou,-0.401612,43.136794,,22,/Qua Sansou,,64260
+3 Allée des Ormeaux Biarritz,,,,3,Allée des Ormeaux,,64200
+3 Allée des Ormeaux 64200,,,,3,Allée des Ormeaux,Biarritz,
+3 Allée des Ormeaux,-1.552418,43.473679,,3,Allée des Ormeaux,,64200
+7 Rue Laspalettes Bielle,,,,7,Rue Laspalettes,,64260
+7 Rue Laspalettes 64260,,,,7,Rue Laspalettes,Bielle,
+7 Rue Laspalettes,-0.425447,43.059424,,7,Rue Laspalettes,,64260
+2BIS Rue Albert Mora Boucau,,,,2BIS,Rue Albert Mora,,64340
+2BIS Rue Albert Mora 64340,,,,2BIS,Rue Albert Mora,Boucau,
+2BIS Rue Albert Mora,-1.466059,43.527856,,2BIS,Rue Albert Mora,,64340
+26 Rue des Hortensias Cambo-les-Bains,,,,26,Rue des Hortensias,,64250
+26 Rue des Hortensias 64250,,,,26,Rue des Hortensias,Cambo-les-Bains,
+26 Rue des Hortensias,-1.39573,43.355425,,26,Rue des Hortensias,,64250
+11 Rue du Gabizos Coarraze,,,,11,Rue du Gabizos,,64800
+11 Rue du Gabizos 64800,,,,11,Rue du Gabizos,Coarraze,
+11 Rue du Gabizos,-0.24503,43.179542,,11,Rue du Gabizos,,64800
+8 Rue du Padoin Gan,,,,8,Rue du Padoin,,64290
+8 Rue du Padoin 64290,,,,8,Rue du Padoin,Gan,
+8 Rue du Padoin,-0.386857,43.232652,,8,Rue du Padoin,,64290
+5 Place du Jeu de Paume Hasparren,,,,5,Place du Jeu de Paume,,64240
+5 Place du Jeu de Paume 64240,,,,5,Place du Jeu de Paume,Hasparren,
+5 Place du Jeu de Paume,-1.304446,43.38488,,5,Place du Jeu de Paume,,64240
+3 Rue Saint-Louis Idron,,,,3,Rue Saint-Louis,,64320
+3 Rue Saint-Louis 64320,,,,3,Rue Saint-Louis,Idron,
+3 Rue Saint-Louis,-0.303599,43.288433,,3,Rue Saint-Louis,,64320
+581 Route de l'Eglise Lalonquette,,,,581,Route de l'Eglise,,64450
+581 Route de l'Eglise 64450,,,,581,Route de l'Eglise,Lalonquette,
+581 Route de l'Eglise,-0.322203,43.487934,,581,Route de l'Eglise,,64450
+10 Rue du Parvis Lescar,,,,10,Rue du Parvis,,64230
+10 Rue du Parvis 64230,,,,10,Rue du Parvis,Lescar,
+10 Rue du Parvis,-0.435641,43.332656,,10,Rue du Parvis,,64230
+390 Chemin de la Pouble Loubieng,,,,390,Chemin de la Pouble,,64300
+390 Chemin de la Pouble 64300,,,,390,Chemin de la Pouble,Loubieng,
+390 Chemin de la Pouble,-0.725574,43.430203,,390,Chemin de la Pouble,,64300
+7 Allée des Chevreuils Monein,,,,7,Allée des Chevreuils,,64360
+7 Allée des Chevreuils 64360,,,,7,Allée des Chevreuils,Monein,
+7 Allée des Chevreuils,-0.565611,43.321021,,7,Allée des Chevreuils,,64360
+183 Route du Plateau Mouguerre,,,,183,Route du Plateau,,64990
+183 Route du Plateau 64990,,,,183,Route du Plateau,Mouguerre,
+183 Route du Plateau,-1.431111,43.477527,,183,Route du Plateau,,64990
+10 Rue Adoue Oloron-Sainte-Marie,,,,10,Rue Adoue,,64400
+10 Rue Adoue 64400,,,,10,Rue Adoue,Oloron-Sainte-Marie,
+10 Rue Adoue,-0.6107,43.187819,,10,Rue Adoue,,64400
+22 Avenue du 8 Mai Orthez,,,,22,Avenue du 8 Mai,,64300
+22 Avenue du 8 Mai 64300,,,,22,Avenue du 8 Mai,Orthez,
+22 Avenue du 8 Mai,-0.780128,43.490966,,22,Avenue du 8 Mai,,64300
+44 Rue Castetnau Pau,,,,44,Rue Castetnau,,64000
+44 Rue Castetnau 64000,,,,44,Rue Castetnau,Pau,
+44 Rue Castetnau,-0.364267,43.300539,,44,Rue Castetnau,,64000
+9 Rue du Marsan Pau,,,,9,Rue du Marsan,,64000
+9 Rue du Marsan 64000,,,,9,Rue du Marsan,Pau,
+9 Rue du Marsan,-0.369473,43.326873,,9,Rue du Marsan,,64000
+276 Route du Haou Pomps,,,,276,Route du Haou,,64370
+276 Route du Haou 64370,,,,276,Route du Haou,Pomps,
+276 Route du Haou,-0.548295,43.493244,,276,Route du Haou,,64370
+40 Avenue Argi Eder Saint-Jean-de-Luz,,,,40,Avenue Argi Eder,,64500
+40 Avenue Argi Eder 64500,,,,40,Avenue Argi Eder,Saint-Jean-de-Luz,
+40 Avenue Argi Eder,-1.638311,43.401596,,40,Avenue Argi Eder,,64500
+27 Rue des Pyrénées Saint-Laurent-Bretagne,,,,27,Rue des Pyrénées,,64160
+27 Rue des Pyrénées 64160,,,,27,Rue des Pyrénées,Saint-Laurent-Bretagne,
+27 Rue des Pyrénées,-0.225524,43.390578,,27,Rue des Pyrénées,,64160
+1 Impasse Laban Sendets,,,,1,Impasse Laban,,64320
+1 Impasse Laban 64320,,,,1,Impasse Laban,Sendets,
+1 Impasse Laban,-0.271652,43.293096,,1,Impasse Laban,,64320
+318 Chemin Bordenave Urcuit,,,,318,Chemin Bordenave,,64990
+318 Chemin Bordenave 64990,,,,318,Chemin Bordenave,Urcuit,
+318 Chemin Bordenave,-1.35645,43.495035,,318,Chemin Bordenave,,64990
+16 Rue de Hiribehere Ustaritz,,,,16,Rue de Hiribehere,,64480
+16 Rue de Hiribehere 64480,,,,16,Rue de Hiribehere,Ustaritz,
+16 Rue de Hiribehere,-1.457295,43.400521,,16,Rue de Hiribehere,,64480

--- a/geocoder_tester/world/france/auvergne/test_addresses.csv
+++ b/geocoder_tester/world/france/auvergne/test_addresses.csv
@@ -1,184 +1,184 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-19 Avenue Fernand Auberger Bellerive-sur-Allier,,,,19 Avenue Fernand Auberger,,,,03700
-19 Avenue Fernand Auberger 03700,,,,19 Avenue Fernand Auberger,,,Bellerive-sur-Allier,
-19 Avenue Fernand Auberger,3.411255,46.113456,,19 Avenue Fernand Auberger,,,,03700
-31 Avenue de l'Europe Brugheas,,,,31 Avenue de l'Europe,,,,03700
-31 Avenue de l'Europe 03700,,,,31 Avenue de l'Europe,,,Brugheas,
-31 Avenue de l'Europe,3.392669,46.093357,,31 Avenue de l'Europe,,,,03700
-17 Avenue Marx Dormoy Commentry,,,,17 Avenue Marx Dormoy,,,,03600
-17 Avenue Marx Dormoy 03600,,,,17 Avenue Marx Dormoy,,,Commentry,
-17 Avenue Marx Dormoy,2.739995,46.294358,,17 Avenue Marx Dormoy,,,,03600
-18 Avenue du Drapeau Cusset,,,,18 Avenue du Drapeau,,,,03300
-18 Avenue du Drapeau 03300,,,,18 Avenue du Drapeau,,,Cusset,
-18 Avenue du Drapeau,3.456709,46.133141,,18 Avenue du Drapeau,,,,03300
-19 Rue Henri Martin Désertines,,,,19 Rue Henri Martin,,,,03630
-19 Rue Henri Martin 03630,,,,19 Rue Henri Martin,,,Désertines,
-19 Rue Henri Martin,2.627281,46.354071,,19 Rue Henri Martin,,,,03630
-70 Rue des Pensées Domérat,,,,70 Rue des Pensées,,,,03410
-70 Rue des Pensées 03410,,,,70 Rue des Pensées,,,Domérat,
-70 Rue des Pensées,2.570733,46.348857,,70 Rue des Pensées,,,,03410
-114 Route de Vozelle Espinasse-Vozelle,,,,114 Route de Vozelle,,,,03110
-114 Route de Vozelle 03110,,,,114 Route de Vozelle,,,Espinasse-Vozelle,
-114 Route de Vozelle,3.344051,46.131371,,114 Route de Vozelle,,,,03110
-49 Route des Nautes Magnet,,,,49 Route des Nautes,,,,03260
-49 Route des Nautes 03260,,,,49 Route des Nautes,,,Magnet,
-49 Route des Nautes,3.526694,46.221292,,49 Route des Nautes,,,,03260
-19 Rue Charles Hennecart Montluçon,,,,19 Rue Charles Hennecart,,,,03100
-19 Rue Charles Hennecart 03100,,,,19 Rue Charles Hennecart,,,Montluçon,
-19 Rue Charles Hennecart,2.598946,46.351143,,19 Rue Charles Hennecart,,,,03100
-50 Avenue Jean Macé Montluçon,,,,50 Avenue Jean Macé,,,,03100
-50 Avenue Jean Macé 03100,,,,50 Avenue Jean Macé,,,Montluçon,
-50 Avenue Jean Macé,2.581927,46.356544,,50 Avenue Jean Macé,,,,03100
-106 Rue de Rimard Montluçon,,,,106 Rue de Rimard,,,,03100
-106 Rue de Rimard 03100,,,,106 Rue de Rimard,,,Montluçon,
-106 Rue de Rimard,2.614397,46.331381,,106 Rue de Rimard,,,,03100
-7 Rue de la Font Vinée Moulins,,,,7 Rue de la Font Vinée,,,,03000
-7 Rue de la Font Vinée 03000,,,,7 Rue de la Font Vinée,,,Moulins,
-7 Rue de la Font Vinée,3.331822,46.554214,,7 Rue de la Font Vinée,,,,03000
-30 Rue Paul Constans Néris-les-Bains,,,,30 Rue Paul Constans,,,,03310
-30 Rue Paul Constans 03310,,,,30 Rue Paul Constans,,,Néris-les-Bains,
-30 Rue Paul Constans,2.665203,46.280492,,30 Rue Paul Constans,,,,03310
-1 Rue Romaine Saint-Martinien,,,,1 Rue Romaine,,,,03380
-1 Rue Romaine 03380,,,,1 Rue Romaine,,,Saint-Martinien,
-1 Rue Romaine,2.469318,46.336477,,1 Rue Romaine,,,,03380
-32 Rue des Bernachets Toulon-sur-Allier,,,,32 Rue des Bernachets,,,,03400
-32 Rue des Bernachets 03400,,,,32 Rue des Bernachets,,,Toulon-sur-Allier,
-32 Rue des Bernachets,3.367714,46.513695,,32 Rue des Bernachets,,,,03400
-1 Rue de Chamonix Vichy,,,,1 Rue de Chamonix,,,,03200
-1 Rue de Chamonix 03200,,,,1 Rue de Chamonix,,,Vichy,
-1 Rue de Chamonix,3.428307,46.135747,,1 Rue de Chamonix,,,,03200
-2 Rue de Pont-à-Mousson Vichy,,,,2 Rue de Pont-à-Mousson,,,,03200
-2 Rue de Pont-à-Mousson 03200,,,,2 Rue de Pont-à-Mousson,,,Vichy,
-2 Rue de Pont-à-Mousson,3.440982,46.116797,,2 Rue de Pont-à-Mousson,,,,03200
-8 Chemin Dela Croix de la Faloterie Yzeure,,,,8 Chemin de la Croix de la Faloterie,,,,03400
-8 Chemin Dela Croix de la Faloterie 03400,,,,8 Chemin de la Croix de la Faloterie,,,Yzeure,
-8 Chemin Dela Croix de la Faloterie,3.353359,46.577369,,8 Chemin de la Croix de la Faloterie,,,,03400
-8 Rue Fontaine de l'Aumone Aurillac,,,,8 Rue Fontaine de l'Aumone,,,,15000
-8 Rue Fontaine de l'Aumone 15000,,,,8 Rue Fontaine de l'Aumone,,,Aurillac,
-8 Rue Fontaine de l'Aumone,2.448989,44.931240,,8 Rue Fontaine de l'Aumone,,,,15000
-8 Rue de la Courtille Crandelles,,,,8 Rue de la Courtille,,,,15250
-8 Rue de la Courtille 15250,,,,8 Rue de la Courtille,,,Crandelles,
-8 Rue de la Courtille,2.347828,44.959103,,8 Rue de la Courtille,,,,15250
-46 Route de Varet Naucelles,,,,46 Route de Varet,,,,15250
-46 Route de Varet 15250,,,,46 Route de Varet,,,Naucelles,
-46 Route de Varet,2.404563,44.958991,,46 Route de Varet,,,,15250
-30 Rue des Lacs Saint-Flour,,,,30 Rue des Lacs,,,,15100
-30 Rue des Lacs 15100,,,,30 Rue des Lacs,,,Saint-Flour,
-30 Rue des Lacs,3.089826,45.032924,,30 Rue des Lacs,,,,15100
-1 Impasse Martial Lapeyre Ydes,,,,1 Impasse Martial Lapeyre,,,,15210
-1 Impasse Martial Lapeyre 15210,,,,1 Impasse Martial Lapeyre,,,Ydes,
-1 Impasse Martial Lapeyre,2.441995,45.348398,,1 Impasse Martial Lapeyre,,,,15210
-9 Place de Laufen Brioude,,,,9 Place de Laufen,,,,43100
-9 Place de Laufen 43100,,,,9 Place de Laufen,,,Brioude,
-9 Place de Laufen,3.382916,45.293457,,9 Place de Laufen,,,,43100
-21 Avenue du Gévaudan Langeac,,,,21 Avenue du Gévaudan,,,,43300
-21 Avenue du Gévaudan 43300,,,,21 Avenue du Gévaudan,,,Langeac,
-21 Avenue du Gévaudan,3.505075,45.091996,,21 Avenue du Gévaudan,,,,43300
-20 Rue du Château Le Puy-en-Velay,,,,20 Rue du Château,,,,43750
-20 Rue du Château 43750,,,,20 Rue du Château,,,Le Puy-en-Velay,
-20 Rue du Château,3.893231,45.020288,,20 Rue du Château,,,,43750
-34 Rue d'Armois Sainte-Florine,,,,34 Rue d'Armois,,,,43250
-34 Rue d'Armois 43250,,,,34 Rue d'Armois,,,Sainte-Florine,
-34 Rue d'Armois,3.314876,45.410372,,34 Rue d'Armois,,,,43250
-25 Le Suc Saint-Pal-de-Mons,,,,25 Le Suc,,,,43620
-25 Le Suc 43620,,,,25 Le Suc,,,Saint-Pal-de-Mons,
-25 Le Suc,4.273248,45.250445,,25 Le Suc,,,,43620
-59 Rue Clovis Chirin Aubière,,,,59 Rue Clovis Chirin,,,,63170
-59 Rue Clovis Chirin 63170,,,,59 Rue Clovis Chirin,,,Aubière,
-59 Rue Clovis Chirin,3.105888,45.745978,,59 Rue Clovis Chirin,,,,63170
-22 Avenue de la Croix Morand Auzat-la-Combelle,,,,22 Avenue de la Croix Morand,,,,63570
-22 Avenue de la Croix Morand 63570,,,,22 Avenue de la Croix Morand,,,Auzat-la-Combelle,
-22 Avenue de la Croix Morand,3.309161,45.438491,,22 Avenue de la Croix Morand,,,,63570
-72 Rue Nationale Beaumont,,,,72 Rue Nationale,,,,63110
-72 Rue Nationale 63110,,,,72 Rue Nationale,,,Beaumont,
-72 Rue Nationale,3.084244,45.750439,,72 Rue Nationale,,,,63110
-163 Rue du Clos Blanzat,,,,163 Rue du Clos,,,,63112
-163 Rue du Clos 63112,,,,163 Rue du Clos,,,Blanzat,
-163 Rue du Clos,3.078353,45.831110,,163 Rue du Clos,,,,63112
-1 Traverse des Sagnes Le Broc,,,,1 Traverse des Sagnes,,,,63500
-1 Traverse des Sagnes 63500,,,,1 Traverse des Sagnes,,,Le Broc,
-1 Traverse des Sagnes,3.241032,45.500459,,1 Traverse des Sagnes,,,,63500
-18 Rue de Gergovie Le Cendre,,,,18 Rue de Gergovie,,,,63670
-18 Rue de Gergovie 63670,,,,18 Rue de Gergovie,,,Le Cendre,
-18 Rue de Gergovie,3.193774,45.725774,,18 Rue de Gergovie,,,,63670
-31 Avenue de la Gare Chamalières,,,,31 Avenue de la Gare,,,,63400
-31 Avenue de la Gare 63400,,,,31 Avenue de la Gare,,,Chamalières,
-31 Avenue de la Gare,3.060120,45.767723,,31 Avenue de la Gare,,,,63400
-54 Route de Volvic - Paugnat Charbonnières-les-Varennes,,,,54 Route de Volvic - Paugnat,,,,63410
-54 Route de Volvic - Paugnat 63410,,,,54 Route de Volvic - Paugnat,,,Charbonnières-les-Varennes,
-54 Route de Volvic - Paugnat,2.984622,45.883453,,54 Route de Volvic - Paugnat,,,,63410
-7 Rue des Plantades Chauriat,,,,7 Rue des Plantades,,,,63117
-7 Rue des Plantades 63117,,,,7 Rue des Plantades,,,Chauriat,
-7 Rue des Plantades,3.279480,45.749446,,7 Rue des Plantades,,,,63117
-32 Rue de la Cartoucherie Clermont-Ferrand,,,,32 Rue de la Cartoucherie,,,,63100
-32 Rue de la Cartoucherie 63100,,,,32 Rue de la Cartoucherie,,,Clermont-Ferrand,
-32 Rue de la Cartoucherie,3.100016,45.775061,,32 Rue de la Cartoucherie,,,,63100
-3 Rue Flameng Clermont-Ferrand,,,,3 Rue Flameng,,,,63100
-3 Rue Flameng 63100,,,,3 Rue Flameng,,,Clermont-Ferrand,
-3 Rue Flameng,3.095798,45.758707,,3 Rue Flameng,,,,63100
-18 Allée des Marronniers Clermont-Ferrand,,,,18 Allée des Marronniers,,,,63100
-18 Allée des Marronniers 63100,,,,18 Allée des Marronniers,,,Clermont-Ferrand,
-18 Allée des Marronniers,3.111780,45.787719,,18 Allée des Marronniers,,,,63100
-33 Rue Saint-Antoine Clermont-Ferrand,,,,33 Rue Saint-Antoine,,,,63100
-33 Rue Saint-Antoine 63100,,,,33 Rue Saint-Antoine,,,Clermont-Ferrand,
-33 Rue Saint-Antoine,3.116173,45.792260,,33 Rue Saint-Antoine,,,,63100
-1 Rue Aristide Briand Cournon-d'Auvergne,,,,1 Rue Aristide Briand,,,,63800
-1 Rue Aristide Briand 63800,,,,1 Rue Aristide Briand,,,Cournon-d'Auvergne,
-1 Rue Aristide Briand,3.186222,45.731510,,1 Rue Aristide Briand,,,,63800
-14 Impasse de la Roseraie Cournon-d'Auvergne,,,,14 Impasse de la Roseraie,,,,63800
-14 Impasse de la Roseraie 63800,,,,14 Impasse de la Roseraie,,,Cournon-d'Auvergne,
-14 Impasse de la Roseraie,3.198639,45.727507,,14 Impasse de la Roseraie,,,,63800
-28 Rue de la Grave Durtol,,,,28 Rue de la Grave,,,,63830
-28 Rue de la Grave 63830,,,,28 Rue de la Grave,,,Durtol,
-28 Rue de la Grave,3.058386,45.795515,,28 Rue de la Grave,,,,63830
-21 Rue Moulin du Roy Gerzat,,,,21 Rue Moulin du Roy,,,,63360
-21 Rue Moulin du Roy 63360,,,,21 Rue Moulin du Roy,,,Gerzat,
-21 Rue Moulin du Roy,3.152813,45.826178,,21 Rue Moulin du Roy,,,,63360
-40 Rue du Pont Issoire,,,,40 Rue du Pont,,,,63500
-40 Rue du Pont 63500,,,,40 Rue du Pont,,,Issoire,
-40 Rue du Pont,3.248942,45.541879,,40 Rue du Pont,,,,63500
-28 Rue Bernard Roquefeuil Lezoux,,,,28 Rue Bernard Roquefeuil,,,,63190
-28 Rue Bernard Roquefeuil 63190,,,,28 Rue Bernard Roquefeuil,,,Lezoux,
-28 Rue Bernard Roquefeuil,3.391867,45.820026,,28 Rue Bernard Roquefeuil,,,,63190
-4 Place de la Petite Charme Maringues,,,,4 Place de la Petite Charme,,,,63350
-4 Place de la Petite Charme 63350,,,,4 Place de la Petite Charme,,,Maringues,
-4 Place de la Petite Charme,3.330262,45.922831,,4 Place de la Petite Charme,,,,63350
-6152 Rue Célestin Tourres Mezel,,,,6152 Rue Célestin Tourres,,,,63115
-6152 Rue Célestin Tourres 63115,,,,6152 Rue Célestin Tourres,,,Mezel,
-6152 Rue Célestin Tourres,3.238716,45.757945,,6152 Rue Célestin Tourres,,,,63115
-9 Rue Gabriel Mercier Mozac,,,,9 Rue Gabriel Mercier,,,,63200
-9 Rue Gabriel Mercier 63200,,,,9 Rue Gabriel Mercier,,,Mozac,
-9 Rue Gabriel Mercier,3.089202,45.885324,,9 Rue Gabriel Mercier,,,,63200
-1 Chemin des Patureaux Orcines,,,,1 Chemin des Patureaux,,,,63870
-1 Chemin des Patureaux 63870,,,,1 Chemin des Patureaux,,,Orcines,
-1 Chemin des Patureaux,3.001297,45.767041,,1 Chemin des Patureaux,,,,63870
-5 Rue du College Pionsat,,,,5 Rue du Collège,,,,63330
-5 Rue du College 63330,,,,5 Rue du Collège,,,Pionsat,
-5 Rue du College,2.694346,46.110744,,5 Rue du Collège,,,,63330
-11 Route d'Issoire Les Pradeaux,,,,11 Route d'Issoire,,,,63500
-11 Route d'Issoire 63500,,,,11 Route d'Issoire,,,Les Pradeaux,
-11 Route d'Issoire,3.291097,45.510355,,11 Route d'Issoire,,,,63500
-12 Rue Jean-Baptiste Clément Riom,,,,12 Rue Jean-Baptiste Clément,,,,63200
-12 Rue Jean-Baptiste Clément 63200,,,,12 Rue Jean-Baptiste Clément,,,Riom,
-12 Rue Jean-Baptiste Clément,3.086635,45.905239,,12 Rue Jean-Baptiste Clément,,,,63200
-69 Avenue de Clémensat Romagnat,,,,69 Avenue de Clémensat,,,,63540
-69 Avenue de Clémensat 63540,,,,69 Avenue de Clémensat,,,Romagnat,
-69 Avenue de Clémensat,3.082450,45.723140,,69 Avenue de Clémensat,,,,63540
-8 Rue George Sand Saint-Beauzire,,,,8 Rue George Sand,,,,63360
-8 Rue George Sand 63360,,,,8 Rue George Sand,,,Saint-Beauzire,
-8 Rue George Sand,3.175700,45.851386,,8 Rue George Sand,,,,63360
-15 Rue de Montfoulhoux Saint-Georges-sur-Allier,,,,15 Rue de Montfoulhoux,,,,63800
-15 Rue de Montfoulhoux 63800,,,,15 Rue de Montfoulhoux,,,Saint-Georges-sur-Allier,
-15 Rue de Montfoulhoux,3.243462,45.709963,,15 Rue de Montfoulhoux,,,,63800
-3 Rue du Sabotier Saurier,,,,3 Rue du Sabotier,,,,63320
-3 Rue du Sabotier 63320,,,,3 Rue du Sabotier,,,Saurier,
-3 Rue du Sabotier,3.044664,45.538395,,3 Rue du Sabotier,,,,63320
-62 Rue de la Fraternité Thiers,,,,62 Rue de la Fraternité,,,,63300
-62 Rue de la Fraternité 63300,,,,62 Rue de la Fraternité,,,Thiers,
-62 Rue de la Fraternité,3.550064,45.861050,,62 Rue de la Fraternité,,,,63300
-14 Rue du Verger Vertaizon,,,,14 Rue du Verger,,,,63910
-14 Rue du Verger 63910,,,,14 Rue du Verger,,,Vertaizon,
-14 Rue du Verger,3.286366,45.769143,,14 Rue du Verger,,,,63910
-2 Allée de la Forêt Marcenat Volvic,,,,2 Allée de la Forêt Marcenat,,,,63530
-2 Allée de la Forêt Marcenat 63530,,,,2 Allée de la Forêt Marcenat,,,Volvic,
-2 Allée de la Forêt Marcenat,2.992565,45.878299,,2 Allée de la Forêt Marcenat,,,,63530
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+19 Avenue Fernand Auberger Bellerive-sur-Allier,,,,19,Avenue Fernand Auberger,,3700
+19 Avenue Fernand Auberger 03700,,,,19,Avenue Fernand Auberger,Bellerive-sur-Allier,
+19 Avenue Fernand Auberger,3.411255,46.113456,,19,Avenue Fernand Auberger,,3700
+31 Avenue de l'Europe Brugheas,,,,31,Avenue de l'Europe,,3700
+31 Avenue de l'Europe 03700,,,,31,Avenue de l'Europe,Brugheas,
+31 Avenue de l'Europe,3.392669,46.093357,,31,Avenue de l'Europe,,3700
+17 Avenue Marx Dormoy Commentry,,,,17,Avenue Marx Dormoy,,3600
+17 Avenue Marx Dormoy 03600,,,,17,Avenue Marx Dormoy,Commentry,
+17 Avenue Marx Dormoy,2.739995,46.294358,,17,Avenue Marx Dormoy,,3600
+18 Avenue du Drapeau Cusset,,,,18,Avenue du Drapeau,,3300
+18 Avenue du Drapeau 03300,,,,18,Avenue du Drapeau,Cusset,
+18 Avenue du Drapeau,3.456709,46.133141,,18,Avenue du Drapeau,,3300
+19 Rue Henri Martin Désertines,,,,19,Rue Henri Martin,,3630
+19 Rue Henri Martin 03630,,,,19,Rue Henri Martin,Désertines,
+19 Rue Henri Martin,2.627281,46.354071,,19,Rue Henri Martin,,3630
+70 Rue des Pensées Domérat,,,,70,Rue des Pensées,,3410
+70 Rue des Pensées 03410,,,,70,Rue des Pensées,Domérat,
+70 Rue des Pensées,2.570733,46.348857,,70,Rue des Pensées,,3410
+114 Route de Vozelle Espinasse-Vozelle,,,,114,Route de Vozelle,,3110
+114 Route de Vozelle 03110,,,,114,Route de Vozelle,Espinasse-Vozelle,
+114 Route de Vozelle,3.344051,46.131371,,114,Route de Vozelle,,3110
+49 Route des Nautes Magnet,,,,49,Route des Nautes,,3260
+49 Route des Nautes 03260,,,,49,Route des Nautes,Magnet,
+49 Route des Nautes,3.526694,46.221292,,49,Route des Nautes,,3260
+19 Rue Charles Hennecart Montluçon,,,,19,Rue Charles Hennecart,,3100
+19 Rue Charles Hennecart 03100,,,,19,Rue Charles Hennecart,Montluçon,
+19 Rue Charles Hennecart,2.598946,46.351143,,19,Rue Charles Hennecart,,3100
+50 Avenue Jean Macé Montluçon,,,,50,Avenue Jean Macé,,3100
+50 Avenue Jean Macé 03100,,,,50,Avenue Jean Macé,Montluçon,
+50 Avenue Jean Macé,2.581927,46.356544,,50,Avenue Jean Macé,,3100
+106 Rue de Rimard Montluçon,,,,106,Rue de Rimard,,3100
+106 Rue de Rimard 03100,,,,106,Rue de Rimard,Montluçon,
+106 Rue de Rimard,2.614397,46.331381,,106,Rue de Rimard,,3100
+7 Rue de la Font Vinée Moulins,,,,7,Rue de la Font Vinée,,3000
+7 Rue de la Font Vinée 03000,,,,7,Rue de la Font Vinée,Moulins,
+7 Rue de la Font Vinée,3.331822,46.554214,,7,Rue de la Font Vinée,,3000
+30 Rue Paul Constans Néris-les-Bains,,,,30,Rue Paul Constans,,3310
+30 Rue Paul Constans 03310,,,,30,Rue Paul Constans,Néris-les-Bains,
+30 Rue Paul Constans,2.665203,46.280492,,30,Rue Paul Constans,,3310
+1 Rue Romaine Saint-Martinien,,,,1,Rue Romaine,,3380
+1 Rue Romaine 03380,,,,1,Rue Romaine,Saint-Martinien,
+1 Rue Romaine,2.469318,46.336477,,1,Rue Romaine,,3380
+32 Rue des Bernachets Toulon-sur-Allier,,,,32,Rue des Bernachets,,3400
+32 Rue des Bernachets 03400,,,,32,Rue des Bernachets,Toulon-sur-Allier,
+32 Rue des Bernachets,3.367714,46.513695,,32,Rue des Bernachets,,3400
+1 Rue de Chamonix Vichy,,,,1,Rue de Chamonix,,3200
+1 Rue de Chamonix 03200,,,,1,Rue de Chamonix,Vichy,
+1 Rue de Chamonix,3.428307,46.135747,,1,Rue de Chamonix,,3200
+2 Rue de Pont-à-Mousson Vichy,,,,2,Rue de Pont-à-Mousson,,3200
+2 Rue de Pont-à-Mousson 03200,,,,2,Rue de Pont-à-Mousson,Vichy,
+2 Rue de Pont-à-Mousson,3.440982,46.116797,,2,Rue de Pont-à-Mousson,,3200
+8 Chemin Dela Croix de la Faloterie Yzeure,,,,8,Chemin de la Croix de la Faloterie,,3400
+8 Chemin Dela Croix de la Faloterie 03400,,,,8,Chemin de la Croix de la Faloterie,Yzeure,
+8 Chemin Dela Croix de la Faloterie,3.353359,46.577369,,8,Chemin de la Croix de la Faloterie,,3400
+8 Rue Fontaine de l'Aumone Aurillac,,,,8,Rue Fontaine de l'Aumone,,15000
+8 Rue Fontaine de l'Aumone 15000,,,,8,Rue Fontaine de l'Aumone,Aurillac,
+8 Rue Fontaine de l'Aumone,2.448989,44.93124,,8,Rue Fontaine de l'Aumone,,15000
+8 Rue de la Courtille Crandelles,,,,8,Rue de la Courtille,,15250
+8 Rue de la Courtille 15250,,,,8,Rue de la Courtille,Crandelles,
+8 Rue de la Courtille,2.347828,44.959103,,8,Rue de la Courtille,,15250
+46 Route de Varet Naucelles,,,,46,Route de Varet,,15250
+46 Route de Varet 15250,,,,46,Route de Varet,Naucelles,
+46 Route de Varet,2.404563,44.958991,,46,Route de Varet,,15250
+30 Rue des Lacs Saint-Flour,,,,30,Rue des Lacs,,15100
+30 Rue des Lacs 15100,,,,30,Rue des Lacs,Saint-Flour,
+30 Rue des Lacs,3.089826,45.032924,,30,Rue des Lacs,,15100
+1 Impasse Martial Lapeyre Ydes,,,,1,Impasse Martial Lapeyre,,15210
+1 Impasse Martial Lapeyre 15210,,,,1,Impasse Martial Lapeyre,Ydes,
+1 Impasse Martial Lapeyre,2.441995,45.348398,,1,Impasse Martial Lapeyre,,15210
+9 Place de Laufen Brioude,,,,9,Place de Laufen,,43100
+9 Place de Laufen 43100,,,,9,Place de Laufen,Brioude,
+9 Place de Laufen,3.382916,45.293457,,9,Place de Laufen,,43100
+21 Avenue du Gévaudan Langeac,,,,21,Avenue du Gévaudan,,43300
+21 Avenue du Gévaudan 43300,,,,21,Avenue du Gévaudan,Langeac,
+21 Avenue du Gévaudan,3.505075,45.091996,,21,Avenue du Gévaudan,,43300
+20 Rue du Château Le Puy-en-Velay,,,,20,Rue du Château,,43750
+20 Rue du Château 43750,,,,20,Rue du Château,Le Puy-en-Velay,
+20 Rue du Château,3.893231,45.020288,,20,Rue du Château,,43750
+34 Rue d'Armois Sainte-Florine,,,,34,Rue d'Armois,,43250
+34 Rue d'Armois 43250,,,,34,Rue d'Armois,Sainte-Florine,
+34 Rue d'Armois,3.314876,45.410372,,34,Rue d'Armois,,43250
+25 Le Suc Saint-Pal-de-Mons,,,,25,Le Suc,,43620
+25 Le Suc 43620,,,,25,Le Suc,Saint-Pal-de-Mons,
+25 Le Suc,4.273248,45.250445,,25,Le Suc,,43620
+59 Rue Clovis Chirin Aubière,,,,59,Rue Clovis Chirin,,63170
+59 Rue Clovis Chirin 63170,,,,59,Rue Clovis Chirin,Aubière,
+59 Rue Clovis Chirin,3.105888,45.745978,,59,Rue Clovis Chirin,,63170
+22 Avenue de la Croix Morand Auzat-la-Combelle,,,,22,Avenue de la Croix Morand,,63570
+22 Avenue de la Croix Morand 63570,,,,22,Avenue de la Croix Morand,Auzat-la-Combelle,
+22 Avenue de la Croix Morand,3.309161,45.438491,,22,Avenue de la Croix Morand,,63570
+72 Rue Nationale Beaumont,,,,72,Rue Nationale,,63110
+72 Rue Nationale 63110,,,,72,Rue Nationale,Beaumont,
+72 Rue Nationale,3.084244,45.750439,,72,Rue Nationale,,63110
+163 Rue du Clos Blanzat,,,,163,Rue du Clos,,63112
+163 Rue du Clos 63112,,,,163,Rue du Clos,Blanzat,
+163 Rue du Clos,3.078353,45.83111,,163,Rue du Clos,,63112
+1 Traverse des Sagnes Le Broc,,,,1,Traverse des Sagnes,,63500
+1 Traverse des Sagnes 63500,,,,1,Traverse des Sagnes,Le Broc,
+1 Traverse des Sagnes,3.241032,45.500459,,1,Traverse des Sagnes,,63500
+18 Rue de Gergovie Le Cendre,,,,18,Rue de Gergovie,,63670
+18 Rue de Gergovie 63670,,,,18,Rue de Gergovie,Le Cendre,
+18 Rue de Gergovie,3.193774,45.725774,,18,Rue de Gergovie,,63670
+31 Avenue de la Gare Chamalières,,,,31,Avenue de la Gare,,63400
+31 Avenue de la Gare 63400,,,,31,Avenue de la Gare,Chamalières,
+31 Avenue de la Gare,3.06012,45.767723,,31,Avenue de la Gare,,63400
+54 Route de Volvic - Paugnat Charbonnières-les-Varennes,,,,54,Route de Volvic - Paugnat,,63410
+54 Route de Volvic - Paugnat 63410,,,,54,Route de Volvic - Paugnat,Charbonnières-les-Varennes,
+54 Route de Volvic - Paugnat,2.984622,45.883453,,54,Route de Volvic - Paugnat,,63410
+7 Rue des Plantades Chauriat,,,,7,Rue des Plantades,,63117
+7 Rue des Plantades 63117,,,,7,Rue des Plantades,Chauriat,
+7 Rue des Plantades,3.27948,45.749446,,7,Rue des Plantades,,63117
+32 Rue de la Cartoucherie Clermont-Ferrand,,,,32,Rue de la Cartoucherie,,63100
+32 Rue de la Cartoucherie 63100,,,,32,Rue de la Cartoucherie,Clermont-Ferrand,
+32 Rue de la Cartoucherie,3.100016,45.775061,,32,Rue de la Cartoucherie,,63100
+3 Rue Flameng Clermont-Ferrand,,,,3,Rue Flameng,,63100
+3 Rue Flameng 63100,,,,3,Rue Flameng,Clermont-Ferrand,
+3 Rue Flameng,3.095798,45.758707,,3,Rue Flameng,,63100
+18 Allée des Marronniers Clermont-Ferrand,,,,18,Allée des Marronniers,,63100
+18 Allée des Marronniers 63100,,,,18,Allée des Marronniers,Clermont-Ferrand,
+18 Allée des Marronniers,3.11178,45.787719,,18,Allée des Marronniers,,63100
+33 Rue Saint-Antoine Clermont-Ferrand,,,,33,Rue Saint-Antoine,,63100
+33 Rue Saint-Antoine 63100,,,,33,Rue Saint-Antoine,Clermont-Ferrand,
+33 Rue Saint-Antoine,3.116173,45.79226,,33,Rue Saint-Antoine,,63100
+1 Rue Aristide Briand Cournon-d'Auvergne,,,,1,Rue Aristide Briand,,63800
+1 Rue Aristide Briand 63800,,,,1,Rue Aristide Briand,Cournon-d'Auvergne,
+1 Rue Aristide Briand,3.186222,45.73151,,1,Rue Aristide Briand,,63800
+14 Impasse de la Roseraie Cournon-d'Auvergne,,,,14,Impasse de la Roseraie,,63800
+14 Impasse de la Roseraie 63800,,,,14,Impasse de la Roseraie,Cournon-d'Auvergne,
+14 Impasse de la Roseraie,3.198639,45.727507,,14,Impasse de la Roseraie,,63800
+28 Rue de la Grave Durtol,,,,28,Rue de la Grave,,63830
+28 Rue de la Grave 63830,,,,28,Rue de la Grave,Durtol,
+28 Rue de la Grave,3.058386,45.795515,,28,Rue de la Grave,,63830
+21 Rue Moulin du Roy Gerzat,,,,21,Rue Moulin du Roy,,63360
+21 Rue Moulin du Roy 63360,,,,21,Rue Moulin du Roy,Gerzat,
+21 Rue Moulin du Roy,3.152813,45.826178,,21,Rue Moulin du Roy,,63360
+40 Rue du Pont Issoire,,,,40,Rue du Pont,,63500
+40 Rue du Pont 63500,,,,40,Rue du Pont,Issoire,
+40 Rue du Pont,3.248942,45.541879,,40,Rue du Pont,,63500
+28 Rue Bernard Roquefeuil Lezoux,,,,28,Rue Bernard Roquefeuil,,63190
+28 Rue Bernard Roquefeuil 63190,,,,28,Rue Bernard Roquefeuil,Lezoux,
+28 Rue Bernard Roquefeuil,3.391867,45.820026,,28,Rue Bernard Roquefeuil,,63190
+4 Place de la Petite Charme Maringues,,,,4,Place de la Petite Charme,,63350
+4 Place de la Petite Charme 63350,,,,4,Place de la Petite Charme,Maringues,
+4 Place de la Petite Charme,3.330262,45.922831,,4,Place de la Petite Charme,,63350
+6152 Rue Célestin Tourres Mezel,,,,6152,Rue Célestin Tourres,,63115
+6152 Rue Célestin Tourres 63115,,,,6152,Rue Célestin Tourres,Mezel,
+6152 Rue Célestin Tourres,3.238716,45.757945,,6152,Rue Célestin Tourres,,63115
+9 Rue Gabriel Mercier Mozac,,,,9,Rue Gabriel Mercier,,63200
+9 Rue Gabriel Mercier 63200,,,,9,Rue Gabriel Mercier,Mozac,
+9 Rue Gabriel Mercier,3.089202,45.885324,,9,Rue Gabriel Mercier,,63200
+1 Chemin des Patureaux Orcines,,,,1,Chemin des Patureaux,,63870
+1 Chemin des Patureaux 63870,,,,1,Chemin des Patureaux,Orcines,
+1 Chemin des Patureaux,3.001297,45.767041,,1,Chemin des Patureaux,,63870
+5 Rue du College Pionsat,,,,5,Rue du Collège,,63330
+5 Rue du College 63330,,,,5,Rue du Collège,Pionsat,
+5 Rue du College,2.694346,46.110744,,5,Rue du Collège,,63330
+11 Route d'Issoire Les Pradeaux,,,,11,Route d'Issoire,,63500
+11 Route d'Issoire 63500,,,,11,Route d'Issoire,Les Pradeaux,
+11 Route d'Issoire,3.291097,45.510355,,11,Route d'Issoire,,63500
+12 Rue Jean-Baptiste Clément Riom,,,,12,Rue Jean-Baptiste Clément,,63200
+12 Rue Jean-Baptiste Clément 63200,,,,12,Rue Jean-Baptiste Clément,Riom,
+12 Rue Jean-Baptiste Clément,3.086635,45.905239,,12,Rue Jean-Baptiste Clément,,63200
+69 Avenue de Clémensat Romagnat,,,,69,Avenue de Clémensat,,63540
+69 Avenue de Clémensat 63540,,,,69,Avenue de Clémensat,Romagnat,
+69 Avenue de Clémensat,3.08245,45.72314,,69,Avenue de Clémensat,,63540
+8 Rue George Sand Saint-Beauzire,,,,8,Rue George Sand,,63360
+8 Rue George Sand 63360,,,,8,Rue George Sand,Saint-Beauzire,
+8 Rue George Sand,3.1757,45.851386,,8,Rue George Sand,,63360
+15 Rue de Montfoulhoux Saint-Georges-sur-Allier,,,,15,Rue de Montfoulhoux,,63800
+15 Rue de Montfoulhoux 63800,,,,15,Rue de Montfoulhoux,Saint-Georges-sur-Allier,
+15 Rue de Montfoulhoux,3.243462,45.709963,,15,Rue de Montfoulhoux,,63800
+3 Rue du Sabotier Saurier,,,,3,Rue du Sabotier,,63320
+3 Rue du Sabotier 63320,,,,3,Rue du Sabotier,Saurier,
+3 Rue du Sabotier,3.044664,45.538395,,3,Rue du Sabotier,,63320
+62 Rue de la Fraternité Thiers,,,,62,Rue de la Fraternité,,63300
+62 Rue de la Fraternité 63300,,,,62,Rue de la Fraternité,Thiers,
+62 Rue de la Fraternité,3.550064,45.86105,,62,Rue de la Fraternité,,63300
+14 Rue du Verger Vertaizon,,,,14,Rue du Verger,,63910
+14 Rue du Verger 63910,,,,14,Rue du Verger,Vertaizon,
+14 Rue du Verger,3.286366,45.769143,,14,Rue du Verger,,63910
+2 Allée de la Forêt Marcenat Volvic,,,,2,Allée de la Forêt Marcenat,,63530
+2 Allée de la Forêt Marcenat 63530,,,,2,Allée de la Forêt Marcenat,Volvic,
+2 Allée de la Forêt Marcenat,2.992565,45.878299,,2,Allée de la Forêt Marcenat,,63530

--- a/geocoder_tester/world/france/bassenormandie/test_addresses.csv
+++ b/geocoder_tester/world/france/bassenormandie/test_addresses.csv
@@ -1,229 +1,229 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-18 Rue Saint-Marc Aunay-sur-Odon,,,,18 Rue Saint-Marc,,,,14260
-18 Rue Saint-Marc 14260,,,,18 Rue Saint-Marc,,,Aunay-sur-Odon,
-18 Rue Saint-Marc,-0.627101,49.021805,,18 Rue Saint-Marc,,,,14260
-9 Passage Michel Béziers Bayeux,,,,9 Passage Michel Béziers,,,,14400
-9 Passage Michel Béziers 14400,,,,9 Passage Michel Béziers,,,Bayeux,
-9 Passage Michel Béziers,-0.713213,49.277722,,9 Passage Michel Béziers,,,,14400
-86 Rue du Rgt de la Chaudiere Bernières-sur-Mer,,,,86 Rue du Rgt de la Chaudiere,,,,14990
-86 Rue du Rgt de la Chaudiere 14990,,,,86 Rue du Rgt de la Chaudiere,,,Bernières-sur-Mer,
-86 Rue du Rgt de la Chaudiere,-0.422321,49.332500,,86 Rue du Rgt de la Chaudiere,,,,14990
-89 Route d'Ussy Bons-Tassilly,,,,89 Route d'Ussy,,,,14420
-89 Route d'Ussy 14420,,,,89 Route d'Ussy,,,Bons-Tassilly,
-89 Route d'Ussy,-0.243054,48.955145,,89 Route d'Ussy,,,,14420
-33 Avenue des Drakkars Cabourg,,,,33 Avenue des Drakkars,,,,14390
-33 Avenue des Drakkars 14390,,,,33 Avenue des Drakkars,,,Cabourg,
-33 Avenue des Drakkars,-0.133886,49.282587,,33 Avenue des Drakkars,,,,14390
-7 Rue des Champs Saint-Michel Caen,,,,7 Rue des Champs Saint-Michel,,,,14000
-7 Rue des Champs Saint-Michel 14000,,,,7 Rue des Champs Saint-Michel,,,Caen,
-7 Rue des Champs Saint-Michel,-0.392564,49.189438,,7 Rue des Champs Saint-Michel,,,,14000
-17 Rue Hélène Boucher Caen,,,,17 Rue Hélène Boucher,,,,14000
-17 Rue Hélène Boucher 14000,,,,17 Rue Hélène Boucher,,,Caen,
-17 Rue Hélène Boucher,-0.395184,49.176706,,17 Rue Hélène Boucher,,,,14000
-24 Place Reine Mathilde Caen,,,,24 Place Reine Mathilde,,,,14000
-24 Place Reine Mathilde 14000,,,,24 Place Reine Mathilde,,,Caen,
-24 Place Reine Mathilde,-0.353216,49.187424,,24 Place Reine Mathilde,,,,14000
-3760 Route d'Englesqueville Cambremer,,,,3760 Route d'Englesqueville,,,,14340
-3760 Route d'Englesqueville 14340,,,,3760 Route d'Englesqueville,,,Cambremer,
-3760 Route d'Englesqueville,0.019266,49.163252,,3760 Route d'Englesqueville,,,,14340
-5 Impasse Maupassant Colombelles,,,,5 Impasse Maupassant,,,,14460
-5 Impasse Maupassant 14460,,,,5 Impasse Maupassant,,,Colombelles,
-5 Impasse Maupassant,-0.288755,49.207755,,5 Impasse Maupassant,,,,14460
-9 Allée de la Brise Courseulles-sur-Mer,,,,9 Allée de la Brise,,,,14470
-9 Allée de la Brise 14470,,,,9 Allée de la Brise,,,Courseulles-sur-Mer,
-9 Allée de la Brise,-0.452680,49.334418,,9 Allée de la Brise,,,,14470
-32 Rue Jean Mermoz Deauville,,,,32 Rue Jean Mermoz,,,,14800
-32 Rue Jean Mermoz 14800,,,,32 Rue Jean Mermoz,,,Deauville,
-32 Rue Jean Mermoz,0.072366,49.360433,,32 Rue Jean Mermoz,,,,14800
-11 Rue du Berry Douvres-la-Délivrande,,,,11 Rue du Berry,,,,14440
-11 Rue du Berry 14440,,,,11 Rue du Berry,,,Douvres-la-Délivrande,
-11 Rue du Berry,-0.371878,49.293598,,11 Rue du Berry,,,,14440
-33 Rue de la Pillardière Évrecy,,,,33 Rue de la Pillardière,,,,14210
-33 Rue de la Pillardière 14210,,,,33 Rue de la Pillardière,,,Évrecy,
-33 Rue de la Pillardière,-0.496321,49.104357,,33 Rue de la Pillardière,,,,14210
-10 Rue des Sources Fontaine-Étoupefour,,,,10 Rue des Sources,,,,14790
-10 Rue des Sources 14790,,,,10 Rue des Sources,,,Fontaine-Étoupefour,
-10 Rue des Sources,-0.464679,49.138912,,10 Rue des Sources,,,,14790
-1 Rue Saint-Laurent Glos,,,,1 Rue Saint-Laurent,,,,14100
-1 Rue Saint-Laurent 14100,,,,1 Rue Saint-Laurent,,,Glos,
-1 Rue Saint-Laurent,0.275892,49.124347,,1 Rue Saint-Laurent,,,,14100
-1002 Boulevard du Grand Parc Hérouville-Saint-Clair,,,,1002 Boulevard du Grand Parc,,,,14200
-1002 Boulevard du Grand Parc 14200,,,,1002 Boulevard du Grand Parc,,,Hérouville-Saint-Clair,
-1002 Boulevard du Grand Parc,-0.335811,49.198851,,1002 Boulevard du Grand Parc,,,,14200
-143 Rue des Bains Houlgate,,,,143 Rue des Bains,,,,14510
-143 Rue des Bains 14510,,,,143 Rue des Bains,,,Houlgate,
-143 Rue des Bains,-0.084596,49.298742,,143 Rue des Bains,,,,14510
-52 Rue Lieutenant Paul Duhomme Jort,,,,52 Rue Lieutenant Paul Duhomme,,,,14170
-52 Rue Lieutenant Paul Duhomme 14170,,,,52 Rue Lieutenant Paul Duhomme,,,Jort,
-52 Rue Lieutenant Paul Duhomme,-0.080118,48.972326,,52 Rue Lieutenant Paul Duhomme,,,,14170
-50 Rue du Général Leclerc Lisieux,,,,50 Rue du Général Leclerc,,,,14100
-50 Rue du Général Leclerc 14100,,,,50 Rue du Général Leclerc,,,Lisieux,
-50 Rue du Général Leclerc,0.224186,49.151151,,50 Rue du Général Leclerc,,,,14100
-443 Rue des Flaguais Le Molay-Littry,,,,443 Rue des Flaguais,,,,14330
-443 Rue des Flaguais 14330,,,,443 Rue des Flaguais,,,Le Molay-Littry,
-443 Rue des Flaguais,-0.883137,49.229209,,443 Rue des Flaguais,,,,14330
-12 Rue de l'Église Maltot,,,,12 Rue de l'Église,,,,14930
-12 Rue de l'Église 14930,,,,12 Rue de l'Église,,,Maltot,
-12 Rue de l'Église,-0.433676,49.125541,,12 Rue de l'Église,,,,14930
-6 Rue des Lilas Mézidon-Canon,,,,6 Rue des Lilas,,,,14270
-6 Rue des Lilas 14270,,,,6 Rue des Lilas,,,,14270
-6 Rue des Lilas,-0.070416,49.075957,,6 Rue des Lilas,,,,14270
-17 Rue Pierre Cingal Moult,,,,17 Rue Pierre Cingal,,,,14370
-17 Rue Pierre Cingal 14370,,,,17 Rue Pierre Cingal,,,,14370
-17 Rue Pierre Cingal,-0.164475,49.113356,,17 Rue Pierre Cingal,,,,14370
-95 Boulevard du Maréchal Joffre Ouistreham,,,,95 Boulevard du Maréchal Joffre,,,,14150
-95 Boulevard du Maréchal Joffre 14150,,,,95 Boulevard du Maréchal Joffre,,,Ouistreham,
-95 Boulevard du Maréchal Joffre,-0.275063,49.291441,,95 Boulevard du Maréchal Joffre,,,,14150
-980 Route du Coupe Gorge Le Pré-d'Auge,,,,980 Route du Coupe Gorge,,,,14340
-980 Route du Coupe Gorge 14340,,,,980 Route du Coupe Gorge,,,Le Pré-d'Auge,
-980 Route du Coupe Gorge,0.114970,49.137527,,980 Route du Coupe Gorge,,,,14340
-60 Rue Gustave Canet Saint-Aubin-sur-Mer,,,,60 Rue Gustave Canet,,,,14750
-60 Rue Gustave Canet 14750,,,,60 Rue Gustave Canet,,,Saint-Aubin-sur-Mer,
-60 Rue Gustave Canet,-0.394122,49.331963,,60 Rue Gustave Canet,,,,14750
-5 Rue du Clos de la Folie Sainte-Honorine-des-Pertes,,,,5 Rue du Clos de la Folie,,,,14520
-5 Rue du Clos de la Folie 14520,,,,5 Rue du Clos de la Folie,,,,14520
-5 Rue du Clos de la Folie,-0.805685,49.348463,,5 Rue du Clos de la Folie,,,,14520
-97 Boulevard Churchill Saint-Pierre-sur-Dives,,,,97 Boulevard Churchill,,,,14170
-97 Boulevard Churchill 14170,,,,97 Boulevard Churchill,,,,14170
-97 Boulevard Churchill,-0.031209,49.012303,,97 Boulevard Churchill,,,,14170
-48 Rue Saint-Pierre Sommervieu,,,,48 Rue Saint-Pierre,,,,14400
-48 Rue Saint-Pierre 14400,,,,48 Rue Saint-Pierre,,,Sommervieu,
-48 Rue Saint-Pierre,-0.655822,49.290097,,48 Rue Saint-Pierre,,,,14400
-3 Route du Molay-Littry Trévières,,,,3 Route du Molay-Littry,,,,14710
-3 Route du Molay-Littry 14710,,,,3 Route du Molay-Littry,,,Trévières,
-3 Route du Molay-Littry,-0.905015,49.304517,,3 Route du Molay-Littry,,,,14710
-9 Rue de Chatillon Varaville,,,,9 Rue de Chatillon,,,,14390
-9 Rue de Chatillon 14390,,,,9 Rue de Chatillon,,,Varaville,
-9 Rue de Chatillon,-0.140725,49.287847,,9 Rue de Chatillon,,,,14390
-9 Rue Auguste Briard Villers-Bocage,,,,9 Rue Auguste Briard,,,,14310
-9 Rue Auguste Briard 14310,,,,9 Rue Auguste Briard,,,Villers-Bocage,
-9 Rue Auguste Briard,-0.652023,49.078749,,9 Rue Auguste Briard,,,,14310
-38 Rue de la Delotière Vire,,,,38 Rue de la Delotière,,,,14500
-38 Rue de la Delotière 14500,,,,38 Rue de la Delotière,,,Vire,
-38 Rue de la Delotière,-0.890560,48.831757,,38 Rue de la Delotière,,,,14500
-33 Rue de l'Église Airel,,,,33 Rue de l'Église,,,,50680
-33 Rue de l'Église 50680,,,,33 Rue de l'Église,,,Airel,
-33 Rue de l'Église,-1.079203,49.223226,,33 Rue de l'Église,,,,50680
-247A Rue des Écoles Barfleur,,,,247A Rue des Écoles,,,,50760
-247A Rue des Écoles 50760,,,,247A Rue des Écoles,,,Barfleur,
-247A Rue des Écoles,-1.263517,49.673195,,247A Rue des Écoles,,,,50760
-61 Route de la Louverie Blainville-sur-Mer,,,,61 Route de la Louverie,,,,50560
-61 Route de la Louverie 50560,,,,61 Route de la Louverie,,,Blainville-sur-Mer,
-61 Route de la Louverie,-1.573924,49.067923,,61 Route de la Louverie,,,,50560
-29 Avenue de Lydney Bréhal,,,,29 Avenue de Lydney,,,,50290
-29 Avenue de Lydney 50290,,,,29 Avenue de Lydney,,,Bréhal,
-29 Avenue de Lydney,-1.506618,48.901296,,29 Avenue de Lydney,,,,50290
-28 L Hôtel Corbet Camprond,,,,28 L Hôtel Corbet,,,,50210
-28 L Hôtel Corbet 50210,,,,28 L Hôtel Corbet,,,Camprond,
-28 L Hôtel Corbet,-1.336652,49.083834,,28 L Hôtel Corbet,,,,50210
-6E Route de la Pierre Champeaux,,,,6E Route de la Pierre,,,,50530
-6E Route de la Pierre 50530,,,,6E Route de la Pierre,,,Champeaux,
-6E Route de la Pierre,-1.507455,48.735623,,6E Route de la Pierre,,,,50530
-13BIS Rue des Moulins Cherbourg-Octeville,,,,13BIS Rue des Moulins,,,,50100
-13BIS Rue des Moulins 50100,,,,13BIS Rue des Moulins,,,Cherbourg-Octeville,
-13BIS Rue des Moulins,-1.622949,49.641577,,13BIS Rue des Moulins,,,,50100
-10 Route de la Croix Faucon Chérencé-le-Héron,,,,10 Route de la Croix Faucon,,,,50800
-10 Route de la Croix Faucon 50800,,,,10 Route de la Croix Faucon,,,Chérencé-le-Héron,
-10 Route de la Croix Faucon,-1.199837,48.801555,,10 Route de la Croix Faucon,,,,50800
-2 Rue du Tram Coutances,,,,2 Rue du Tram,,,,50200
-2 Rue du Tram 50200,,,,2 Rue du Tram,,,Coutances,
-2 Rue du Tram,-1.442964,49.035526,,2 Rue du Tram,,,,50200
-6 Rue de la Corniche Donville-les-Bains,,,,6 Rue de la Corniche,,,,50350
-6 Rue de la Corniche 50350,,,,6 Rue de la Corniche,,,Donville-les-Bains,
-6 Rue de la Corniche,-1.584717,48.847264,,6 Rue de la Corniche,,,,50350
-1BIS Rue de la Hougue Équeurdreville-Hainneville,,,,1BIS Rue de la Hougue,,,,50120
-1BIS Rue de la Hougue 50120,,,,1BIS Rue de la Hougue,,,Équeurdreville-Hainneville,
-1BIS Rue de la Hougue,-1.659285,49.653833,,1BIS Rue de la Hougue,,,,50120
-19 Route du Mesnil Garnier Fleury,,,,19 Route du Mesnil Garnier,,,,50800
-19 Route du Mesnil Garnier 50800,,,,19 Route du Mesnil Garnier,,,Fleury,
-19 Route du Mesnil Garnier,-1.256316,48.847291,,19 Route du Mesnil Garnier,,,,50800
-10 Rue de la Lande Gourfaleur,,,,10 Rue de la Lande,,,,50750
-10 Rue de la Lande 50750,,,,10 Rue de la Lande,,,Gourfaleur,
-10 Rue de la Lande,-1.117736,49.065309,,10 Rue de la Lande,,,,50750
-40 Rue des Prairies Granville,,,,40 Rue des Prairies,,,,50400
-40 Rue des Prairies 50400,,,,40 Rue des Prairies,,,Granville,
-40 Rue des Prairies,-1.577940,48.840580,,40 Rue des Prairies,,,,50400
-4 Rue des Planquettes La Haye-du-Puits,,,,4 Rue des Planquettes,,,,50250
-4 Rue des Planquettes 50250,,,,4 Rue des Planquettes,,,La Haye-du-Puits,
-4 Rue des Planquettes,-1.548115,49.289565,,4 Rue des Planquettes,,,,50250
-19 Rue de la Lande Lozon,,,,19 Rue de la Lande,,,,50570
-19 Rue de la Lande 50570,,,,19 Rue de la Lande,,,Lozon,
-19 Rue de la Lande,-1.282685,49.142136,,19 Rue de la Lande,,,,50570
-10 Impasse de l'Arguilliere Montmartin-sur-Mer,,,,10 Impasse de l'Arguilliere,,,,50590
-10 Impasse de l'Arguilliere 50590,,,,10 Impasse de l'Arguilliere,,,Montmartin-sur-Mer,
-10 Impasse de l'Arguilliere,-1.537870,48.987487,,10 Impasse de l'Arguilliere,,,,50590
-1 Rue du Hamel au Doyen Percy,,,,1 Rue du Hamel au Doyen,,,,50410
-1 Rue du Hamel au Doyen 50410,,,,1 Rue du Hamel au Doyen,,,Percy,
-1 Rue du Hamel au Doyen,-1.194251,48.916643,,1 Rue du Hamel au Doyen,,,,50410
-7 Rue Monseigneur Aubry Pont-Hébert,,,,7 Rue Monseigneur Aubry,,,,50880
-7 Rue Monseigneur Aubry 50880,,,,7 Rue Monseigneur Aubry,,,Pont-Hébert,
-7 Rue Monseigneur Aubry,-1.127774,49.165112,,7 Rue Monseigneur Aubry,,,,50880
-23 Rue Vieille Rue Querqueville,,,,23 Rue Vieille Rue,,,,50460
-23 Rue Vieille Rue 50460,,,,23 Rue Vieille Rue,,,Querqueville,
-23 Rue Vieille Rue,-1.693933,49.665743,,23 Rue Vieille Rue,,,,50460
-15A Le Chouquee Saint-Amand,,,,15A Le Chouquee,,,,50160
-15A Le Chouquee 50160,,,,15A Le Chouquee,,,Saint-Amand,
-15A Le Chouquee,-0.993074,49.051137,,15A Le Chouquee,,,,50160
-124 Rue Lucien Lelièvre Saint-Hilaire-du-Harcouët,,,,124 Rue Lucien Lelièvre,,,,50600
-124 Rue Lucien Lelièvre 50600,,,,124 Rue Lucien Lelièvre,,,Saint-Hilaire-du-Harcouët,
-124 Rue Lucien Lelièvre,-1.095365,48.571679,,124 Rue Lucien Lelièvre,,,,50600
-140 Rue de Christchurch Saint-Lô,,,,140 Rue de Christchurch,,,,50000
-140 Rue de Christchurch 50000,,,,140 Rue de Christchurch,,,Saint-Lô,
-140 Rue de Christchurch,-1.084042,49.103318,,140 Rue de Christchurch,,,,50000
-10 Rue de la Vanne Saint-Martin-de-Cenilly,,,,10 Rue de la Vanne,,,,50210
-10 Rue de la Vanne 50210,,,,10 Rue de la Vanne,,,Saint-Martin-de-Cenilly,
-10 Rue de la Vanne,-1.277440,48.972670,,10 Rue de la Vanne,,,,50210
-80 Rue du Seuil Marin Saint-Pair-sur-Mer,,,,80 Rue du Seuil Marin,,,,50380
-80 Rue du Seuil Marin 50380,,,,80 Rue du Seuil Marin,,,Saint-Pair-sur-Mer,
-80 Rue du Seuil Marin,-1.569000,48.790993,,80 Rue du Seuil Marin,,,,50380
-5 Rue des Charmilles Saint-Senier-sous-Avranches,,,,5 Rue des Charmilles,,,,50300
-5 Rue des Charmilles 50300,,,,5 Rue des Charmilles,,,Saint-Senier-sous-Avranches,
-5 Rue des Charmilles,-1.338815,48.682223,,5 Rue des Charmilles,,,,50300
-49 Cité Beauséjour Sourdeval,,,,49 Cité Beauséjour,,,,50150
-49 Cité Beauséjour 50150,,,,49 Cité Beauséjour,,,Sourdeval,
-49 Cité Beauséjour,-0.934331,48.724459,,49 Cité Beauséjour,,,,50150
-1 Rue du Bois Tourlaville,,,,1 Rue du Bois,,,,50110
-1 Rue du Bois 50110,,,,1 Rue du Bois,,,,50110
-1 Rue du Bois,-1.603478,49.637369,,1 Rue du Bois,,,,50110
-380 Rue au Bon Tourville-sur-Sienne,,,,380 Rue au Bon,,,,50200
-380 Rue au Bon 50200,,,,380 Rue au Bon,,,Tourville-sur-Sienne,
-380 Rue au Bon,-1.549687,49.049394,,380 Rue au Bon,,,,50200
-2 Rue de la Grande Vallée Vauville,,,,2 Rue de la Grande Vallée,,,,50440
-2 Rue de la Grande Vallée 50440,,,,2 Rue de la Grande Vallée,,,,50440
-2 Rue de la Grande Vallée,-1.845956,49.636883,,2 Rue de la Grande Vallée,,,,50440
-8 Rue Landon Alençon,,,,8 Rue Landon,,,,61000
-8 Rue Landon 61000,,,,8 Rue Landon,,,Alençon,
-8 Rue Landon,0.090141,48.420447,,8 Rue Landon,,,,61000
-13 Rue de L'Île de France Argentan,,,,13 Rue de L'Île de France,,,,61200
-13 Rue de L'Île de France 61200,,,,13 Rue de L'Île de France,,,Argentan,
-13 Rue de L'Île de France,-0.025680,48.749541,,13 Rue de L'Île de France,,,,61200
-16 Place de la République Bellême,,,,16 Place de la République,,,,61130
-16 Place de la République 61130,,,,16 Place de la République,,,Bellême,
-16 Place de la République,0.560025,48.376618,,16 Place de la République,,,,61130
-2 Rue des Écoles La Chapelle-Montligeon,,,,2 Rue des Écoles,,,,61400
-2 Rue des Écoles 61400,,,,2 Rue des Écoles,,,La Chapelle-Montligeon,
-2 Rue des Écoles,0.653781,48.483731,,2 Rue des Écoles,,,,61400
-3BIS Rue du Mont Margantin Domfront,,,,3BIS Rue du Mont Margantin,,,,61700
-3BIS Rue du Mont Margantin 61700,,,,3BIS Rue du Mont Margantin,,,,61700
-3BIS Rue du Mont Margantin,-0.646376,48.591039,,3BIS Rue du Mont Margantin,,,,61700
-10 Rue de la Chaussée Flers,,,,10 Rue de la Chaussée,,,,61100
-10 Rue de la Chaussée 61100,,,,10 Rue de la Chaussée,,,Flers,
-10 Rue de la Chaussée,-0.570136,48.746542,,10 Rue de la Chaussée,,,,61100
-26 Rue du Carrouge Le Gué-de-la-Chaîne,,,,26 Rue du Carrouge,,,,61130
-26 Rue du Carrouge 61130,,,,26 Rue du Carrouge,,,,61130
-26 Rue du Carrouge,0.520481,48.378791,,26 Rue du Carrouge,,,,61130
-2 Rue des Rosiers Lonrai,,,,2 Rue des Rosiers,,,,61250
-2 Rue des Rosiers 61250,,,,2 Rue des Rosiers,,,Lonrai,
-2 Rue des Rosiers,0.040771,48.460925,,2 Rue des Rosiers,,,,61250
-9 Route de Sees Nonant-le-Pin,,,,9 Route de Sees,,,,61240
-9 Route de Sees 61240,,,,9 Route de Sees,,,Nonant-le-Pin,
-9 Route de Sees,0.221824,48.704743,,9 Route de Sees,,,,61240
-25 Rue des Groseillers Saint-Georges-des-Groseillers,,,,25 Rue des Groseillers,,,,61100
-25 Rue des Groseillers 61100,,,,25 Rue des Groseillers,,,Saint-Georges-des-Groseillers,
-25 Rue des Groseillers,-0.563678,48.772614,,25 Rue des Groseillers,,,,61100
-3 Rue Louis Hamel Saint-Ouen-sur-Iton,,,,3 Rue Louis Hamel,,,,61300
-3 Rue Louis Hamel 61300,,,,3 Rue Louis Hamel,,,Saint-Ouen-sur-Iton,
-3 Rue Louis Hamel,0.693262,48.736242,,3 Rue Louis Hamel,,,,61300
-15 Rue de la Chesnaie Bagnoles-de-l'Orne,,,,15 Rue de la Chesnaie,,,,61140
-15 Rue de la Chesnaie 61140,,,,15 Rue de la Chesnaie,,,Bagnoles-de-l'Orne,
-15 Rue de la Chesnaie,-0.429536,48.547443,,15 Rue de la Chesnaie,,,,61140
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+18 Rue Saint-Marc Aunay-sur-Odon,,,,18,Rue Saint-Marc,,14260
+18 Rue Saint-Marc 14260,,,,18,Rue Saint-Marc,Aunay-sur-Odon,
+18 Rue Saint-Marc,-0.627101,49.021805,,18,Rue Saint-Marc,,14260
+9 Passage Michel Béziers Bayeux,,,,9,Passage Michel Béziers,,14400
+9 Passage Michel Béziers 14400,,,,9,Passage Michel Béziers,Bayeux,
+9 Passage Michel Béziers,-0.713213,49.277722,,9,Passage Michel Béziers,,14400
+86 Rue du Rgt de la Chaudiere Bernières-sur-Mer,,,,86,Rue du Rgt de la Chaudiere,,14990
+86 Rue du Rgt de la Chaudiere 14990,,,,86,Rue du Rgt de la Chaudiere,Bernières-sur-Mer,
+86 Rue du Rgt de la Chaudiere,-0.422321,49.3325,,86,Rue du Rgt de la Chaudiere,,14990
+89 Route d'Ussy Bons-Tassilly,,,,89,Route d'Ussy,,14420
+89 Route d'Ussy 14420,,,,89,Route d'Ussy,Bons-Tassilly,
+89 Route d'Ussy,-0.243054,48.955145,,89,Route d'Ussy,,14420
+33 Avenue des Drakkars Cabourg,,,,33,Avenue des Drakkars,,14390
+33 Avenue des Drakkars 14390,,,,33,Avenue des Drakkars,Cabourg,
+33 Avenue des Drakkars,-0.133886,49.282587,,33,Avenue des Drakkars,,14390
+7 Rue des Champs Saint-Michel Caen,,,,7,Rue des Champs Saint-Michel,,14000
+7 Rue des Champs Saint-Michel 14000,,,,7,Rue des Champs Saint-Michel,Caen,
+7 Rue des Champs Saint-Michel,-0.392564,49.189438,,7,Rue des Champs Saint-Michel,,14000
+17 Rue Hélène Boucher Caen,,,,17,Rue Hélène Boucher,,14000
+17 Rue Hélène Boucher 14000,,,,17,Rue Hélène Boucher,Caen,
+17 Rue Hélène Boucher,-0.395184,49.176706,,17,Rue Hélène Boucher,,14000
+24 Place Reine Mathilde Caen,,,,24,Place Reine Mathilde,,14000
+24 Place Reine Mathilde 14000,,,,24,Place Reine Mathilde,Caen,
+24 Place Reine Mathilde,-0.353216,49.187424,,24,Place Reine Mathilde,,14000
+3760 Route d'Englesqueville Cambremer,,,,3760,Route d'Englesqueville,,14340
+3760 Route d'Englesqueville 14340,,,,3760,Route d'Englesqueville,Cambremer,
+3760 Route d'Englesqueville,0.019266,49.163252,,3760,Route d'Englesqueville,,14340
+5 Impasse Maupassant Colombelles,,,,5,Impasse Maupassant,,14460
+5 Impasse Maupassant 14460,,,,5,Impasse Maupassant,Colombelles,
+5 Impasse Maupassant,-0.288755,49.207755,,5,Impasse Maupassant,,14460
+9 Allée de la Brise Courseulles-sur-Mer,,,,9,Allée de la Brise,,14470
+9 Allée de la Brise 14470,,,,9,Allée de la Brise,Courseulles-sur-Mer,
+9 Allée de la Brise,-0.45268,49.334418,,9,Allée de la Brise,,14470
+32 Rue Jean Mermoz Deauville,,,,32,Rue Jean Mermoz,,14800
+32 Rue Jean Mermoz 14800,,,,32,Rue Jean Mermoz,Deauville,
+32 Rue Jean Mermoz,0.072366,49.360433,,32,Rue Jean Mermoz,,14800
+11 Rue du Berry Douvres-la-Délivrande,,,,11,Rue du Berry,,14440
+11 Rue du Berry 14440,,,,11,Rue du Berry,Douvres-la-Délivrande,
+11 Rue du Berry,-0.371878,49.293598,,11,Rue du Berry,,14440
+33 Rue de la Pillardière Évrecy,,,,33,Rue de la Pillardière,,14210
+33 Rue de la Pillardière 14210,,,,33,Rue de la Pillardière,Évrecy,
+33 Rue de la Pillardière,-0.496321,49.104357,,33,Rue de la Pillardière,,14210
+10 Rue des Sources Fontaine-Étoupefour,,,,10,Rue des Sources,,14790
+10 Rue des Sources 14790,,,,10,Rue des Sources,Fontaine-Étoupefour,
+10 Rue des Sources,-0.464679,49.138912,,10,Rue des Sources,,14790
+1 Rue Saint-Laurent Glos,,,,1,Rue Saint-Laurent,,14100
+1 Rue Saint-Laurent 14100,,,,1,Rue Saint-Laurent,Glos,
+1 Rue Saint-Laurent,0.275892,49.124347,,1,Rue Saint-Laurent,,14100
+1002 Boulevard du Grand Parc Hérouville-Saint-Clair,,,,1002,Boulevard du Grand Parc,,14200
+1002 Boulevard du Grand Parc 14200,,,,1002,Boulevard du Grand Parc,Hérouville-Saint-Clair,
+1002 Boulevard du Grand Parc,-0.335811,49.198851,,1002,Boulevard du Grand Parc,,14200
+143 Rue des Bains Houlgate,,,,143,Rue des Bains,,14510
+143 Rue des Bains 14510,,,,143,Rue des Bains,Houlgate,
+143 Rue des Bains,-0.084596,49.298742,,143,Rue des Bains,,14510
+52 Rue Lieutenant Paul Duhomme Jort,,,,52,Rue Lieutenant Paul Duhomme,,14170
+52 Rue Lieutenant Paul Duhomme 14170,,,,52,Rue Lieutenant Paul Duhomme,Jort,
+52 Rue Lieutenant Paul Duhomme,-0.080118,48.972326,,52,Rue Lieutenant Paul Duhomme,,14170
+50 Rue du Général Leclerc Lisieux,,,,50,Rue du Général Leclerc,,14100
+50 Rue du Général Leclerc 14100,,,,50,Rue du Général Leclerc,Lisieux,
+50 Rue du Général Leclerc,0.224186,49.151151,,50,Rue du Général Leclerc,,14100
+443 Rue des Flaguais Le Molay-Littry,,,,443,Rue des Flaguais,,14330
+443 Rue des Flaguais 14330,,,,443,Rue des Flaguais,Le Molay-Littry,
+443 Rue des Flaguais,-0.883137,49.229209,,443,Rue des Flaguais,,14330
+12 Rue de l'Église Maltot,,,,12,Rue de l'Église,,14930
+12 Rue de l'Église 14930,,,,12,Rue de l'Église,Maltot,
+12 Rue de l'Église,-0.433676,49.125541,,12,Rue de l'Église,,14930
+6 Rue des Lilas Mézidon-Canon,,,,6,Rue des Lilas,,14270
+6 Rue des Lilas 14270,,,,6,Rue des Lilas,,14270
+6 Rue des Lilas,-0.070416,49.075957,,6,Rue des Lilas,,14270
+17 Rue Pierre Cingal Moult,,,,17,Rue Pierre Cingal,,14370
+17 Rue Pierre Cingal 14370,,,,17,Rue Pierre Cingal,,14370
+17 Rue Pierre Cingal,-0.164475,49.113356,,17,Rue Pierre Cingal,,14370
+95 Boulevard du Maréchal Joffre Ouistreham,,,,95,Boulevard du Maréchal Joffre,,14150
+95 Boulevard du Maréchal Joffre 14150,,,,95,Boulevard du Maréchal Joffre,Ouistreham,
+95 Boulevard du Maréchal Joffre,-0.275063,49.291441,,95,Boulevard du Maréchal Joffre,,14150
+980 Route du Coupe Gorge Le Pré-d'Auge,,,,980,Route du Coupe Gorge,,14340
+980 Route du Coupe Gorge 14340,,,,980,Route du Coupe Gorge,Le Pré-d'Auge,
+980 Route du Coupe Gorge,0.11497,49.137527,,980,Route du Coupe Gorge,,14340
+60 Rue Gustave Canet Saint-Aubin-sur-Mer,,,,60,Rue Gustave Canet,,14750
+60 Rue Gustave Canet 14750,,,,60,Rue Gustave Canet,Saint-Aubin-sur-Mer,
+60 Rue Gustave Canet,-0.394122,49.331963,,60,Rue Gustave Canet,,14750
+5 Rue du Clos de la Folie Sainte-Honorine-des-Pertes,,,,5,Rue du Clos de la Folie,,14520
+5 Rue du Clos de la Folie 14520,,,,5,Rue du Clos de la Folie,,14520
+5 Rue du Clos de la Folie,-0.805685,49.348463,,5,Rue du Clos de la Folie,,14520
+97 Boulevard Churchill Saint-Pierre-sur-Dives,,,,97,Boulevard Churchill,,14170
+97 Boulevard Churchill 14170,,,,97,Boulevard Churchill,,14170
+97 Boulevard Churchill,-0.031209,49.012303,,97,Boulevard Churchill,,14170
+48 Rue Saint-Pierre Sommervieu,,,,48,Rue Saint-Pierre,,14400
+48 Rue Saint-Pierre 14400,,,,48,Rue Saint-Pierre,Sommervieu,
+48 Rue Saint-Pierre,-0.655822,49.290097,,48,Rue Saint-Pierre,,14400
+3 Route du Molay-Littry Trévières,,,,3,Route du Molay-Littry,,14710
+3 Route du Molay-Littry 14710,,,,3,Route du Molay-Littry,Trévières,
+3 Route du Molay-Littry,-0.905015,49.304517,,3,Route du Molay-Littry,,14710
+9 Rue de Chatillon Varaville,,,,9,Rue de Chatillon,,14390
+9 Rue de Chatillon 14390,,,,9,Rue de Chatillon,Varaville,
+9 Rue de Chatillon,-0.140725,49.287847,,9,Rue de Chatillon,,14390
+9 Rue Auguste Briard Villers-Bocage,,,,9,Rue Auguste Briard,,14310
+9 Rue Auguste Briard 14310,,,,9,Rue Auguste Briard,Villers-Bocage,
+9 Rue Auguste Briard,-0.652023,49.078749,,9,Rue Auguste Briard,,14310
+38 Rue de la Delotière Vire,,,,38,Rue de la Delotière,,14500
+38 Rue de la Delotière 14500,,,,38,Rue de la Delotière,Vire,
+38 Rue de la Delotière,-0.89056,48.831757,,38,Rue de la Delotière,,14500
+33 Rue de l'Église Airel,,,,33,Rue de l'Église,,50680
+33 Rue de l'Église 50680,,,,33,Rue de l'Église,Airel,
+33 Rue de l'Église,-1.079203,49.223226,,33,Rue de l'Église,,50680
+247A Rue des Écoles Barfleur,,,,247A,Rue des Écoles,,50760
+247A Rue des Écoles 50760,,,,247A,Rue des Écoles,Barfleur,
+247A Rue des Écoles,-1.263517,49.673195,,247A,Rue des Écoles,,50760
+61 Route de la Louverie Blainville-sur-Mer,,,,61,Route de la Louverie,,50560
+61 Route de la Louverie 50560,,,,61,Route de la Louverie,Blainville-sur-Mer,
+61 Route de la Louverie,-1.573924,49.067923,,61,Route de la Louverie,,50560
+29 Avenue de Lydney Bréhal,,,,29,Avenue de Lydney,,50290
+29 Avenue de Lydney 50290,,,,29,Avenue de Lydney,Bréhal,
+29 Avenue de Lydney,-1.506618,48.901296,,29,Avenue de Lydney,,50290
+28 L Hôtel Corbet Camprond,,,,28,Hôtel Corbet,,50210
+28 L Hôtel Corbet 50210,,,,28,Hôtel Corbet,Camprond,
+28 L Hôtel Corbet,-1.336652,49.083834,,28,Hôtel Corbet,,50210
+6E Route de la Pierre Champeaux,,,,6E,Route de la Pierre,,50530
+6E Route de la Pierre 50530,,,,6E,Route de la Pierre,Champeaux,
+6E Route de la Pierre,-1.507455,48.735623,,6E,Route de la Pierre,,50530
+13BIS Rue des Moulins Cherbourg-Octeville,,,,13BIS,Rue des Moulins,,50100
+13BIS Rue des Moulins 50100,,,,13BIS,Rue des Moulins,Cherbourg-Octeville,
+13BIS Rue des Moulins,-1.622949,49.641577,,13BIS,Rue des Moulins,,50100
+10 Route de la Croix Faucon Chérencé-le-Héron,,,,10,Route de la Croix Faucon,,50800
+10 Route de la Croix Faucon 50800,,,,10,Route de la Croix Faucon,Chérencé-le-Héron,
+10 Route de la Croix Faucon,-1.199837,48.801555,,10,Route de la Croix Faucon,,50800
+2 Rue du Tram Coutances,,,,2,Rue du Tram,,50200
+2 Rue du Tram 50200,,,,2,Rue du Tram,Coutances,
+2 Rue du Tram,-1.442964,49.035526,,2,Rue du Tram,,50200
+6 Rue de la Corniche Donville-les-Bains,,,,6,Rue de la Corniche,,50350
+6 Rue de la Corniche 50350,,,,6,Rue de la Corniche,Donville-les-Bains,
+6 Rue de la Corniche,-1.584717,48.847264,,6,Rue de la Corniche,,50350
+1BIS Rue de la Hougue Équeurdreville-Hainneville,,,,1BIS,Rue de la Hougue,,50120
+1BIS Rue de la Hougue 50120,,,,1BIS,Rue de la Hougue,Équeurdreville-Hainneville,
+1BIS Rue de la Hougue,-1.659285,49.653833,,1BIS,Rue de la Hougue,,50120
+19 Route du Mesnil Garnier Fleury,,,,19,Route du Mesnil Garnier,,50800
+19 Route du Mesnil Garnier 50800,,,,19,Route du Mesnil Garnier,Fleury,
+19 Route du Mesnil Garnier,-1.256316,48.847291,,19,Route du Mesnil Garnier,,50800
+10 Rue de la Lande Gourfaleur,,,,10,Rue de la Lande,,50750
+10 Rue de la Lande 50750,,,,10,Rue de la Lande,Gourfaleur,
+10 Rue de la Lande,-1.117736,49.065309,,10,Rue de la Lande,,50750
+40 Rue des Prairies Granville,,,,40,Rue des Prairies,,50400
+40 Rue des Prairies 50400,,,,40,Rue des Prairies,Granville,
+40 Rue des Prairies,-1.57794,48.84058,,40,Rue des Prairies,,50400
+4 Rue des Planquettes La Haye-du-Puits,,,,4,Rue des Planquettes,,50250
+4 Rue des Planquettes 50250,,,,4,Rue des Planquettes,La Haye-du-Puits,
+4 Rue des Planquettes,-1.548115,49.289565,,4,Rue des Planquettes,,50250
+19 Rue de la Lande Lozon,,,,19,Rue de la Lande,,50570
+19 Rue de la Lande 50570,,,,19,Rue de la Lande,Lozon,
+19 Rue de la Lande,-1.282685,49.142136,,19,Rue de la Lande,,50570
+10 Impasse de l'Arguilliere Montmartin-sur-Mer,,,,10,Impasse de l'Arguilliere,,50590
+10 Impasse de l'Arguilliere 50590,,,,10,Impasse de l'Arguilliere,Montmartin-sur-Mer,
+10 Impasse de l'Arguilliere,-1.53787,48.987487,,10,Impasse de l'Arguilliere,,50590
+1 Rue du Hamel au Doyen Percy,,,,1,Rue du Hamel au Doyen,,50410
+1 Rue du Hamel au Doyen 50410,,,,1,Rue du Hamel au Doyen,Percy,
+1 Rue du Hamel au Doyen,-1.194251,48.916643,,1,Rue du Hamel au Doyen,,50410
+7 Rue Monseigneur Aubry Pont-Hébert,,,,7,Rue Monseigneur Aubry,,50880
+7 Rue Monseigneur Aubry 50880,,,,7,Rue Monseigneur Aubry,Pont-Hébert,
+7 Rue Monseigneur Aubry,-1.127774,49.165112,,7,Rue Monseigneur Aubry,,50880
+23 Rue Vieille Rue Querqueville,,,,23,Rue Vieille Rue,,50460
+23 Rue Vieille Rue 50460,,,,23,Rue Vieille Rue,Querqueville,
+23 Rue Vieille Rue,-1.693933,49.665743,,23,Rue Vieille Rue,,50460
+15A Le Chouquee Saint-Amand,,,,15A,Le Chouquee,,50160
+15A Le Chouquee 50160,,,,15A,Le Chouquee,Saint-Amand,
+15A Le Chouquee,-0.993074,49.051137,,15A,Le Chouquee,,50160
+124 Rue Lucien Lelièvre Saint-Hilaire-du-Harcouët,,,,124,Rue Lucien Lelièvre,,50600
+124 Rue Lucien Lelièvre 50600,,,,124,Rue Lucien Lelièvre,Saint-Hilaire-du-Harcouët,
+124 Rue Lucien Lelièvre,-1.095365,48.571679,,124,Rue Lucien Lelièvre,,50600
+140 Rue de Christchurch Saint-Lô,,,,140,Rue de Christchurch,,50000
+140 Rue de Christchurch 50000,,,,140,Rue de Christchurch,Saint-Lô,
+140 Rue de Christchurch,-1.084042,49.103318,,140,Rue de Christchurch,,50000
+10 Rue de la Vanne Saint-Martin-de-Cenilly,,,,10,Rue de la Vanne,,50210
+10 Rue de la Vanne 50210,,,,10,Rue de la Vanne,Saint-Martin-de-Cenilly,
+10 Rue de la Vanne,-1.27744,48.97267,,10,Rue de la Vanne,,50210
+80 Rue du Seuil Marin Saint-Pair-sur-Mer,,,,80,Rue du Seuil Marin,,50380
+80 Rue du Seuil Marin 50380,,,,80,Rue du Seuil Marin,Saint-Pair-sur-Mer,
+80 Rue du Seuil Marin,-1.569,48.790993,,80,Rue du Seuil Marin,,50380
+5 Rue des Charmilles Saint-Senier-sous-Avranches,,,,5,Rue des Charmilles,,50300
+5 Rue des Charmilles 50300,,,,5,Rue des Charmilles,Saint-Senier-sous-Avranches,
+5 Rue des Charmilles,-1.338815,48.682223,,5,Rue des Charmilles,,50300
+49 Cité Beauséjour Sourdeval,,,,49,Cité Beauséjour,,50150
+49 Cité Beauséjour 50150,,,,49,Cité Beauséjour,Sourdeval,
+49 Cité Beauséjour,-0.934331,48.724459,,49,Cité Beauséjour,,50150
+1 Rue du Bois Tourlaville,,,,1,Rue du Bois,,50110
+1 Rue du Bois 50110,,,,1,Rue du Bois,,50110
+1 Rue du Bois,-1.603478,49.637369,,1,Rue du Bois,,50110
+380 Rue au Bon Tourville-sur-Sienne,,,,380,Rue au Bon,,50200
+380 Rue au Bon 50200,,,,380,Rue au Bon,Tourville-sur-Sienne,
+380 Rue au Bon,-1.549687,49.049394,,380,Rue au Bon,,50200
+2 Rue de la Grande Vallée Vauville,,,,2,Rue de la Grande Vallée,,50440
+2 Rue de la Grande Vallée 50440,,,,2,Rue de la Grande Vallée,,50440
+2 Rue de la Grande Vallée,-1.845956,49.636883,,2,Rue de la Grande Vallée,,50440
+8 Rue Landon Alençon,,,,8,Rue Landon,,61000
+8 Rue Landon 61000,,,,8,Rue Landon,Alençon,
+8 Rue Landon,0.090141,48.420447,,8,Rue Landon,,61000
+13 Rue de L'Île de France Argentan,,,,13,Rue de L'Île de France,,61200
+13 Rue de L'Île de France 61200,,,,13,Rue de L'Île de France,Argentan,
+13 Rue de L'Île de France,-0.02568,48.749541,,13,Rue de L'Île de France,,61200
+16 Place de la République Bellême,,,,16,Place de la République,,61130
+16 Place de la République 61130,,,,16,Place de la République,Bellême,
+16 Place de la République,0.560025,48.376618,,16,Place de la République,,61130
+2 Rue des Écoles La Chapelle-Montligeon,,,,2,Rue des Écoles,,61400
+2 Rue des Écoles 61400,,,,2,Rue des Écoles,La Chapelle-Montligeon,
+2 Rue des Écoles,0.653781,48.483731,,2,Rue des Écoles,,61400
+3BIS Rue du Mont Margantin Domfront,,,,3BIS,Rue du Mont Margantin,,61700
+3BIS Rue du Mont Margantin 61700,,,,3BIS,Rue du Mont Margantin,,61700
+3BIS Rue du Mont Margantin,-0.646376,48.591039,,3BIS,Rue du Mont Margantin,,61700
+10 Rue de la Chaussée Flers,,,,10,Rue de la Chaussée,,61100
+10 Rue de la Chaussée 61100,,,,10,Rue de la Chaussée,Flers,
+10 Rue de la Chaussée,-0.570136,48.746542,,10,Rue de la Chaussée,,61100
+26 Rue du Carrouge Le Gué-de-la-Chaîne,,,,26,Rue du Carrouge,,61130
+26 Rue du Carrouge 61130,,,,26,Rue du Carrouge,,61130
+26 Rue du Carrouge,0.520481,48.378791,,26,Rue du Carrouge,,61130
+2 Rue des Rosiers Lonrai,,,,2,Rue des Rosiers,,61250
+2 Rue des Rosiers 61250,,,,2,Rue des Rosiers,Lonrai,
+2 Rue des Rosiers,0.040771,48.460925,,2,Rue des Rosiers,,61250
+9 Route de Sees Nonant-le-Pin,,,,9,Route de Sees,,61240
+9 Route de Sees 61240,,,,9,Route de Sees,Nonant-le-Pin,
+9 Route de Sees,0.221824,48.704743,,9,Route de Sees,,61240
+25 Rue des Groseillers Saint-Georges-des-Groseillers,,,,25,Rue des Groseillers,,61100
+25 Rue des Groseillers 61100,,,,25,Rue des Groseillers,Saint-Georges-des-Groseillers,
+25 Rue des Groseillers,-0.563678,48.772614,,25,Rue des Groseillers,,61100
+3 Rue Louis Hamel Saint-Ouen-sur-Iton,,,,3,Rue Louis Hamel,,61300
+3 Rue Louis Hamel 61300,,,,3,Rue Louis Hamel,Saint-Ouen-sur-Iton,
+3 Rue Louis Hamel,0.693262,48.736242,,3,Rue Louis Hamel,,61300
+15 Rue de la Chesnaie Bagnoles-de-l'Orne,,,,15,Rue de la Chesnaie,,61140
+15 Rue de la Chesnaie 61140,,,,15,Rue de la Chesnaie,Bagnoles-de-l'Orne,
+15 Rue de la Chesnaie,-0.429536,48.547443,,15,Rue de la Chesnaie,,61140

--- a/geocoder_tester/world/france/bourgogne/test_addresses.csv
+++ b/geocoder_tester/world/france/bourgogne/test_addresses.csv
@@ -1,298 +1,298 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-24 Grande Rue Athie,,,,24 Grande Rue,,,,21500
-24 Grande Rue 21500,,,,24 Grande Rue,,,Athie,
-24 Grande Rue,4.253269,47.566787,,24 Grande Rue,,,,21500
-4 Rue du Collège Beaune,,,,4 Rue du Collège,,,,21200
-4 Rue du Collège 21200,,,,4 Rue du Collège,,,Beaune,
-4 Rue du Collège,4.838783,47.026356,,4 Rue du Collège,,,,21200
-13 Rue Saint-Vincent Bellefond,,,,13 Rue Saint-Vincent,,,,21490
-13 Rue Saint-Vincent 21490,,,,13 Rue Saint-Vincent,,,Bellefond,
-13 Rue Saint-Vincent,5.074413,47.381875,,13 Rue Saint-Vincent,,,,21490
-156BIS Route de Dijon Brazey-en-Plaine,,,,156BIS Route de Dijon,,,,21470
-156BIS Route de Dijon 21470,,,,156BIS Route de Dijon,,,Brazey-en-Plaine,
-156BIS Route de Dijon,5.204185,47.148796,,156BIS Route de Dijon,,,,21470
-3 Rue Sainte-Anne Chanceaux,,,,3 Rue Sainte-Anne,,,,21440
-3 Rue Sainte-Anne 21440,,,,3 Rue Sainte-Anne,,,Chanceaux,
-3 Rue Sainte-Anne,4.715233,47.520151,,3 Rue Sainte-Anne,,,,21440
-1 Rue des Tulipes Chenôve,,,,1 Rue des Tulipes,,,,21300
-1 Rue des Tulipes 21300,,,,1 Rue des Tulipes,,,Chenôve,
-1 Rue des Tulipes,5.008249,47.301763,,1 Rue des Tulipes,,,,21300
-5 Rue du Lavoir Corcelles-lès-Cîteaux,,,,5 Rue du Lavoir,,,,21910
-5 Rue du Lavoir 21910,,,,5 Rue du Lavoir,,,Corcelles-lès-Cîteaux,
-5 Rue du Lavoir,5.078406,47.172034,,5 Rue du Lavoir,,,,21910
-1 Rue de l'Aviation Darois,,,,1 Rue de l'Aviation,,,,21121
-1 Rue de l'Aviation 21121,,,,1 Rue de l'Aviation,,,Darois,
-1 Rue de l'Aviation,4.942688,47.389129,,1 Rue de l'Aviation,,,,21121
-4 Impasse Chanoine Henri Latour Dijon,,,,4 Impasse Chanoine Henri Latour,,,,21000
-4 Impasse Chanoine Henri Latour 21000,,,,4 Impasse Chanoine Henri Latour,,,Dijon,
-4 Impasse Chanoine Henri Latour,5.000011,47.309527,,4 Impasse Chanoine Henri Latour,,,,21000
-9 Rue Ernest Bouteiller Dijon,,,,9 Rue Ernest Bouteiller,,,,21000
-9 Rue Ernest Bouteiller 21000,,,,9 Rue Ernest Bouteiller,,,Dijon,
-9 Rue Ernest Bouteiller,5.071487,47.326336,,9 Rue Ernest Bouteiller,,,,21000
-13 Rue Joliet Dijon,,,,13 Rue Joliet,,,,21000
-13 Rue Joliet 21000,,,,13 Rue Joliet,,,Dijon,
-13 Rue Joliet,5.028789,47.319177,,13 Rue Joliet,,,,21000
-6 Rue Mozart Dijon,,,,6 Rue Mozart,,,,21000
-6 Rue Mozart 21000,,,,6 Rue Mozart,,,Dijon,
-6 Rue Mozart,5.034097,47.313372,,6 Rue Mozart,,,,21000
-28 Boulevard Thiers Dijon,,,,28 Boulevard Thiers,,,,21000
-28 Boulevard Thiers 21000,,,,28 Boulevard Thiers,,,Dijon,
-28 Boulevard Thiers,5.051525,47.321987,,28 Boulevard Thiers,,,,21000
-3 Rue Marie-Louise May Fénay,,,,3 Rue Marie-Louise May,,,,21600
-3 Rue Marie-Louise May 21600,,,,3 Rue Marie-Louise May,,,Fénay,
-3 Rue Marie-Louise May,5.062533,47.234678,,3 Rue Marie-Louise May,,,,21600
-15 Route de Fontaine-Française Fontenelle,,,,15 Route de Fontaine-Française,,,,21610
-15 Route de Fontaine-Française 21610,,,,15 Route de Fontaine-Française,,,Fontenelle,
-15 Route de Fontaine-Française,5.372210,47.502951,,15 Route de Fontaine-Française,,,,21610
-17 Rue de l'Hotel de Ville Grancey-sur-Ource,,,,17 Rue de l'Hotel de Ville,,,,21570
-17 Rue de l'Hotel de Ville 21570,,,,17 Rue de l'Hotel de Ville,,,Grancey-sur-Ource,
-17 Rue de l'Hotel de Ville,4.587953,48.006944,,17 Rue de l'Hotel de Ville,,,,21570
-44 Rue de Bourgogne Lamarche-sur-Saône,,,,44 Rue de Bourgogne,,,,21760
-44 Rue de Bourgogne 21760,,,,44 Rue de Bourgogne,,,Lamarche-sur-Saône,
-44 Rue de Bourgogne,5.386350,47.263203,,44 Rue de Bourgogne,,,,21760
-17 Quai de la Hutte Losne,,,,17 Quai de la Hutte,,,,21170
-17 Quai de la Hutte 21170,,,,17 Quai de la Hutte,,,Losne,
-17 Quai de la Hutte,5.261214,47.099622,,17 Quai de la Hutte,,,,21170
-24 Route des Grands Crus Marsannay-la-Côte,,,,24 Route des Grands Crus,,,,21160
-24 Route des Grands Crus 21160,,,,24 Route des Grands Crus,,,Marsannay-la-Côte,
-24 Route des Grands Crus,4.994218,47.276745,,24 Route des Grands Crus,,,,21160
-11 Allée Paul Jeannin Mirebeau-sur-Bèze,,,,11 Allée Paul Jeannin,,,,21310
-11 Allée Paul Jeannin 21310,,,,11 Allée Paul Jeannin,,,Mirebeau-sur-Bèze,
-11 Allée Paul Jeannin,5.324462,47.399248,,11 Allée Paul Jeannin,,,,21310
-1 Route Départementale 108 (Thil) Nan-sous-Thil,,,,1 Route Départementale 108 (Thil),,,,21390
-1 Route Départementale 108 (Thil) 21390,,,,1 Route Départementale 108 (Thil),,,Nan-sous-Thil,
-1 Route Départementale 108 (Thil),4.354976,47.393448,,1 Route Départementale 108 (Thil),,,,21390
-6 Rue de la Houblonnière Orgeux,,,,6 Rue de la Houblonnière,,,,21490
-6 Rue de la Houblonnière 21490,,,,6 Rue de la Houblonnière,,,Orgeux,
-6 Rue de la Houblonnière,5.151066,47.359584,,6 Rue de la Houblonnière,,,,21490
-81 Rue du Lac Pont-et-Massène,,,,81 Rue du Lac,,,,21140
-81 Rue du Lac 21140,,,,81 Rue du Lac,,,Pont-et-Massène,
-81 Rue du Lac,4.350314,47.461973,,81 Rue du Lac,,,,21140
-3 Rue-des-Prés Remilly-en-Montagne,,,,3 Rue-des-Prés,,,,21540
-3 Rue-des-Prés 21540,,,,3 Rue-des-Prés,,,Remilly-en-Montagne,
-3 Rue-des-Prés,4.733800,47.292970,,3 Rue-des-Prés,,,,21540
-1 Route de Dijon Saint-Broing-les-Moines,,,,1 Route de Dijon,,,,21290
-1 Route de Dijon 21290,,,,1 Route de Dijon,,,Saint-Broing-les-Moines,
-1 Route de Dijon,4.843186,47.694492,,1 Route de Dijon,,,,21290
-27 Avenue de la Gare Saulieu,,,,27 Avenue de la Gare,,,,21210
-27 Avenue de la Gare 21210,,,,27 Avenue de la Gare,,,Saulieu,
-27 Avenue de la Gare,4.235228,47.282311,,27 Avenue de la Gare,,,,21210
-11 Rue du Lycée Semur-en-Auxois,,,,11 Rue du Lycée,,,,21140
-11 Rue du Lycée 21140,,,,11 Rue du Lycée,,,Semur-en-Auxois,
-11 Rue du Lycée,4.334649,47.493159,,11 Rue du Lycée,,,,21140
-16 Rue Édouard Herriot Talant,,,,16 Rue Édouard Herriot,,,,21240
-16 Rue Édouard Herriot 21240,,,,16 Rue Édouard Herriot,,,Talant,
-16 Rue Édouard Herriot,5.012036,47.338432,,16 Rue Édouard Herriot,,,,21240
-1C Grande Rue Trouhaut,,,,1C Grande Rue,,,,21440
-1C Grande Rue 21440,,,,1C Grande Rue,,,Trouhaut,
-1C Grande Rue,4.760961,47.389819,,1C Grande Rue,,,,21440
-4 Place du Creux Bleu Villecomte,,,,4 Place du Creux Bleu,,,,21120
-4 Place du Creux Bleu 21120,,,,4 Place du Creux Bleu,,,Villecomte,
-4 Place du Creux Bleu,5.034470,47.511141,,4 Place du Creux Bleu,,,,21120
-24 Rue des Bertranges La Charité-sur-Loire,,,,24 Rue des Bertranges,,,,58400
-24 Rue des Bertranges 58400,,,,24 Rue des Bertranges,,,La Charité-sur-Loire,
-24 Rue des Bertranges,3.031383,47.179550,,24 Rue des Bertranges,,,,58400
-4 Rue J F Fremillon Chaulgnes,,,,4 Rue J F Fremillon,,,,58400
-4 Rue J F Fremillon 58400,,,,4 Rue J F Fremillon,,,Chaulgnes,
-4 Rue J F Fremillon,3.103273,47.129348,,4 Rue J F Fremillon,,,,58400
-12 Rue de l'Est Cosne-Cours-sur-Loire,,,,12 Rue de l'Est,,,,58200
-12 Rue de l'Est 58200,,,,12 Rue de l'Est,,,Cosne-Cours-sur-Loire,
-12 Rue de l'Est,2.924009,47.404667,,12 Rue de l'Est,,,,58200
-17 Rue de Villecourt Coulanges-lès-Nevers,,,,17 Rue de Villecourt,,,,58660
-17 Rue de Villecourt 58660,,,,17 Rue de Villecourt,,,Coulanges-lès-Nevers,
-17 Rue de Villecourt,3.174468,47.012787,,17 Rue de Villecourt,,,,58660
-16 Rue du 11 Novembre Entrains-sur-Nohain,,,,16 Rue du 11 Novembre,,,,58410
-16 Rue du 11 Novembre 58410,,,,16 Rue du 11 Novembre,,,Entrains-sur-Nohain,
-16 Rue du 11 Novembre,3.262848,47.470686,,16 Rue du 11 Novembre,,,,58410
-21 Rue des Bertranges Guérigny,,,,21 Rue des Bertranges,,,,58130
-21 Rue des Bertranges 58130,,,,21 Rue des Bertranges,,,Guérigny,
-21 Rue des Bertranges,3.198042,47.097949,,21 Rue des Bertranges,,,,58130
-12 Rue Saint-André Luzy,,,,12 Rue Saint-André,,,,58170
-12 Rue Saint-André 58170,,,,12 Rue Saint-André,,,Luzy,
-12 Rue Saint-André,3.966893,46.784338,,12 Rue Saint-André,,,,58170
-33BIS Rue du Château de Mouron Mesves-sur-Loire,,,,33BIS Rue du Château de Mouron,,,,58400
-33BIS Rue du Château de Mouron 58400,,,,33BIS Rue du Château de Mouron,,,Mesves-sur-Loire,
-33BIS Rue du Château de Mouron,2.993473,47.239763,,33BIS Rue du Château de Mouron,,,,58400
-52BIS Rue des Chauvelles Nevers,,,,52BIS Rue des Chauvelles,,,,58000
-52BIS Rue des Chauvelles 58000,,,,52BIS Rue des Chauvelles,,,Nevers,
-52BIS Rue des Chauvelles,3.158502,46.997534,,52BIS Rue des Chauvelles,,,,58000
-75 Rue de Nievre Nevers,,,,75 Rue de Nievre,,,,58000
-75 Rue de Nievre 58000,,,,75 Rue de Nievre,,,Nevers,
-75 Rue de Nievre,3.163578,46.989696,,75 Rue de Nievre,,,,58000
-15 Rue des Vièvres Pougues-les-Eaux,,,,15 Rue des Vièvres,,,,58320
-15 Rue des Vièvres 58320,,,,15 Rue des Vièvres,,,Pougues-les-Eaux,
-15 Rue des Vièvres,3.096560,47.072665,,15 Rue des Vièvres,,,,58320
-14 Rue des Hortensias Saint-Éloi,,,,14 Rue des Hortensias,,,,58000
-14 Rue des Hortensias 58000,,,,14 Rue des Hortensias,,,Saint-Éloi,
-14 Rue des Hortensias,3.224584,46.978799,,14 Rue des Hortensias,,,,58000
-40 Rue de Paris Saint-Pierre-le-Moûtier,,,,40 Rue de Paris,,,,58240
-40 Rue de Paris 58240,,,,40 Rue de Paris,,,Saint-Pierre-le-Moûtier,
-40 Rue de Paris,3.118768,46.790789,,40 Rue de Paris,,,,58240
-1121 Rue des Vannes Urzy,,,,1121 Rue des Vannes,,,,58130
-1121 Rue des Vannes 58130,,,,1121 Rue des Vannes,,,Urzy,
-1121 Rue des Vannes,3.217883,47.063581,,1121 Rue des Vannes,,,,58130
-23 Rue de l'Hôtel de Ville Varzy,,,,23 Rue de l'Hôtel de Ville,,,,58210
-23 Rue de l'Hôtel de Ville 58210,,,,23 Rue de l'Hôtel de Ville,,,Varzy,
-23 Rue de l'Hôtel de Ville,3.388507,47.359084,,23 Rue de l'Hôtel de Ville,,,,58210
-4 Rue des Violettes Autun,,,,4 Rue des Violettes,,,,71400
-4 Rue des Violettes 71400,,,,4 Rue des Violettes,,,Autun,
-4 Rue des Violettes,4.310056,46.967358,,4 Rue des Violettes,,,,71400
-12 Rue d'Autun Bourbon-Lancy,,,,12 Rue d'Autun,,,,71140
-12 Rue d'Autun 71140,,,,12 Rue d'Autun,,,Bourbon-Lancy,
-12 Rue d'Autun,3.773894,46.625257,,12 Rue d'Autun,,,,71140
-10 Rue du Bourg Broye,,,,10 Rue du Bourg,,,,71190
-10 Rue du Bourg 71190,,,,10 Rue du Bourg,,,Broye,
-10 Rue du Bourg,4.291076,46.872049,,10 Rue du Bourg,,,,71190
-17 Rue du 56e Régiment d'Infanterie Chalon-sur-Saône,,,,17 Rue du 56e Régiment d'Infanterie,,,,71100
-17 Rue du 56e Régiment d'Infanterie 71100,,,,17 Rue du 56e Régiment d'Infanterie,,,Chalon-sur-Saône,
-17 Rue du 56e Régiment d'Infanterie,4.852113,46.791946,,17 Rue du 56e Régiment d'Infanterie,,,,71100
-7 Place Saint-Jean de Maizel Chalon-sur-Saône,,,,7 Place Saint-Jean de Maizel,,,,71100
-7 Place Saint-Jean de Maizel 71100,,,,7 Place Saint-Jean de Maizel,,,Chalon-sur-Saône,
-7 Place Saint-Jean de Maizel,4.851335,46.779107,,7 Place Saint-Jean de Maizel,,,,71100
-65 Chemin des Gérards Charnay-lès-Mâcon,,,,65 Chemin des Gérards,,,,71850
-65 Chemin des Gérards 71850,,,,65 Chemin des Gérards,,,Charnay-lès-Mâcon,
-65 Chemin des Gérards,4.793601,46.320406,,65 Chemin des Gérards,,,,71850
-16 Rue de L'Église Chaudenay,,,,16 Rue de L'Église,,,,71150
-16 Rue de L'Église 71150,,,,16 Rue de L'Église,,,Chaudenay,
-16 Rue de L'Église,4.791164,46.914744,,16 Rue de L'Église,,,,71150
-5 Rue de la Petite Rivière Cluny,,,,5 Rue de la Petite Rivière,,,,71250
-5 Rue de la Petite Rivière 71250,,,,5 Rue de la Petite Rivière,,,Cluny,
-5 Rue de la Petite Rivière,4.661548,46.432432,,5 Rue de la Petite Rivière,,,,71250
-28 Rue de Madagascar Le Creusot,,,,28 Rue de Madagascar,,,,71200
-28 Rue de Madagascar 71200,,,,28 Rue de Madagascar,,,Le Creusot,
-28 Rue de Madagascar,4.457958,46.801965,,28 Rue de Madagascar,,,,71200
-3 Impasse des Troënes Cuiseaux,,,,3 Impasse des Troënes,,,,71480
-3 Impasse des Troënes 71480,,,,3 Impasse des Troënes,,,Cuiseaux,
-3 Impasse des Troënes,5.379804,46.493779,,3 Impasse des Troënes,,,,71480
-56 Rue du Verdier Digoin,,,,56 Rue du Verdier,,,,71160
-56 Rue du Verdier 71160,,,,56 Rue du Verdier,,,Digoin,
-56 Rue du Verdier,3.990858,46.500649,,56 Rue du Verdier,,,,71160
-4 Rue des Saules Fontaines,,,,4 Rue des Saules,,,,71150
-4 Rue des Saules 71150,,,,4 Rue des Saules,,,Fontaines,
-4 Rue des Saules,4.773386,46.850065,,4 Rue des Saules,,,,71150
-24 Route de Saint-Martin Guerfand,,,,24 Route de Saint-Martin,,,,71620
-24 Route de Saint-Martin 71620,,,,24 Route de Saint-Martin,,,Guerfand,
-24 Route de Saint-Martin,5.036003,46.790758,,24 Route de Saint-Martin,,,,71620
-4 Route de Saint-Vallerin Jully-lès-Buxy,,,,4 Route de Saint-Vallerin,,,,71390
-4 Route de Saint-Vallerin 71390,,,,4 Route de Saint-Vallerin,,,Jully-lès-Buxy,
-4 Route de Saint-Vallerin,4.688681,46.689391,,4 Route de Saint-Vallerin,,,,71390
-1109 Route de Tournus Lugny,,,,1109 Route de Tournus,,,,71260
-1109 Route de Tournus 71260,,,,1109 Route de Tournus,,,Lugny,
-1109 Route de Tournus,4.823467,46.489877,,1109 Route de Tournus,,,,71260
-14 Rue Poitevin Mâcon,,,,14 Rue Poitevin,,,,71000
-14 Rue Poitevin 71000,,,,14 Rue Poitevin,,,Mâcon,
-14 Rue Poitevin,4.823572,46.306242,,14 Rue Poitevin,,,,71000
-37BIS Route de Louhans Mervans,,,,37BIS Route de Louhans,,,,71310
-37BIS Route de Louhans 71310,,,,37BIS Route de Louhans,,,Mervans,
-37BIS Route de Louhans,5.184382,46.795166,,37BIS Route de Louhans,,,,71310
-42 Rue de la Loge Montceau-les-Mines,,,,42 Rue de la Loge,,,,71300
-42 Rue de la Loge 71300,,,,42 Rue de la Loge,,,Montceau-les-Mines,
-42 Rue de la Loge,4.380076,46.679128,,42 Rue de la Loge,,,,71300
-58 Avenue de la République Montchanin,,,,58 Avenue de la République,,,,71210
-58 Avenue de la République 71210,,,,58 Avenue de la République,,,Montchanin,
-58 Avenue de la République,4.468646,46.749520,,58 Avenue de la République,,,,71210
-14 Rue des Deux Ponts Paray-le-Monial,,,,14 Rue des Deux Ponts,,,,71600
-14 Rue des Deux Ponts 71600,,,,14 Rue des Deux Ponts,,,Paray-le-Monial,
-14 Rue des Deux Ponts,4.118971,46.449980,,14 Rue des Deux Ponts,,,,71600
-206 Chemin des Loureaux Ratte,,,,206 Chemin des Loureaux,,,,71500
-206 Chemin des Loureaux 71500,,,,206 Chemin des Loureaux,,,Ratte,
-206 Chemin des Loureaux,5.299614,46.626826,,206 Chemin des Loureaux,,,,71500
-430 Route de Tronchy Saint-Étienne-en-Bresse,,,,430 Route de Tronchy,,,,71370
-430 Route de Tronchy 71370,,,,430 Route de Tronchy,,,Saint-Étienne-en-Bresse,
-430 Route de Tronchy,5.054819,46.709305,,430 Route de Tronchy,,,,71370
-12 Rue des Chavannes Saint-Marcel,,,,12 Rue des Chavannes,,,,71380
-12 Rue des Chavannes 71380,,,,12 Rue des Chavannes,,,Saint-Marcel,
-12 Rue des Chavannes,4.870054,46.778206,,12 Rue des Chavannes,,,,71380
-3 Impasse Mon Calme Saint-Rémy,,,,3 Impasse Mon Calme,,,,71100
-3 Impasse Mon Calme 71100,,,,3 Impasse Mon Calme,,,Saint-Rémy,
-3 Impasse Mon Calme,4.821576,46.765561,,3 Impasse Mon Calme,,,,71100
-44 Rue Jean Moulin Saint-Vallier,,,,44 Rue Jean Moulin,,,,71230
-44 Rue Jean Moulin 71230,,,,44 Rue Jean Moulin,,,Saint-Vallier,
-44 Rue Jean Moulin,4.328327,46.633568,,44 Rue Jean Moulin,,,,71230
-4124 Rue de Saint-Eugène Sanvignes-les-Mines,,,,4124 Rue de Saint-Eugène,,,,71410
-4124 Rue de Saint-Eugène 71410,,,,4124 Rue de Saint-Eugène,,,Sanvignes-les-Mines,
-4124 Rue de Saint-Eugène,4.247602,46.680129,,4124 Rue de Saint-Eugène,,,,71410
-10 Hameau Grand Cerisier Simard,,,,10 Hameau Grand Cerisier,,,,71330
-10 Hameau Grand Cerisier 71330,,,,10 Hameau Grand Cerisier,,,Simard,
-10 Hameau Grand Cerisier,5.159487,46.731799,,10 Hameau Grand Cerisier,,,,71330
-17BIS Grande Rue Tramayes,,,,17BIS Grande Rue,,,,71520
-17BIS Grande Rue 71520,,,,17BIS Grande Rue,,,Tramayes,
-17BIS Grande Rue,4.601749,46.308017,,17BIS Grande Rue,,,,71520
-7X Rue du Gué Arcy-sur-Cure,,,,7X Rue du Gué,,,,89270
-7X Rue du Gué 89270,,,,7X Rue du Gué,,,Arcy-sur-Cure,
-7X Rue du Gué,3.758783,47.602710,,7X Rue du Gué,,,,89270
-7 Rue de l'Egalite Auxerre,,,,7 Rue de l'Egalite,,,,89000
-7 Rue de l'Egalite 89000,,,,7 Rue de l'Egalite,,,Auxerre,
-7 Rue de l'Egalite,3.566932,47.795060,,7 Rue de l'Egalite,,,,89000
-1BIS Avenue de la Puisaye Auxerre,,,,1BIS Avenue de la Puisaye,,,,89000
-1BIS Avenue de la Puisaye 89000,,,,1BIS Avenue de la Puisaye,,,Auxerre,
-1BIS Avenue de la Puisaye,3.565595,47.789647,,1BIS Avenue de la Puisaye,,,,89000
-2BIS Rue de la Résistance Bassou,,,,2BIS Rue de la Résistance,,,,89400
-2BIS Rue de la Résistance 89400,,,,2BIS Rue de la Résistance,,,Bassou,
-2BIS Rue de la Résistance,3.516142,47.921069,,2BIS Rue de la Résistance,,,,89400
-16 Rue Palériau Brienon-sur-Armançon,,,,16 Rue Palériau,,,,89210
-16 Rue Palériau 89210,,,,16 Rue Palériau,,,Brienon-sur-Armançon,
-16 Rue Palériau,3.615113,47.986431,,16 Rue Palériau,,,,89210
-7 Rue des Baudons Champignelles,,,,7 Rue des Baudons,,,,89350
-7 Rue des Baudons 89350,,,,7 Rue des Baudons,,,Champignelles,
-7 Rue des Baudons,3.079963,47.779630,,7 Rue des Baudons,,,,89350
-14 Rue du Cedec Charny,,,,14 Rue du Cedec,,,,89120
-14 Rue du Cedec 89120,,,,14 Rue du Cedec,,,Charny,
-14 Rue du Cedec,3.096112,47.877677,,14 Rue du Cedec,,,,89120
-40 Rue de l'Étang Jussier Chevannes,,,,40 Rue de l'Étang Jussier,,,,89240
-40 Rue de l'Étang Jussier 89240,,,,40 Rue de l'Étang Jussier,,,Chevannes,
-40 Rue de l'Étang Jussier,3.489512,47.771753,,40 Rue de l'Étang Jussier,,,,89240
-10 Rue des Ecossais Cravant,,,,10 Rue des Ecossais,,,,89460
-10 Rue des Ecossais 89460,,,,10 Rue des Ecossais,,,Cravant,
-10 Rue des Ecossais,3.691448,47.682661,,10 Rue des Ecossais,,,,89460
-30 Route de Vaux Escolives-Sainte-Camille,,,,30 Route de Vaux,,,,89290
-30 Route de Vaux 89290,,,,30 Route de Vaux,,,Escolives-Sainte-Camille,
-30 Route de Vaux,3.596056,47.733201,,30 Route de Vaux,,,,89290
-2 Rue Haute Gron,,,,2 Rue Haute,,,,89100
-2 Rue Haute 89100,,,,2 Rue Haute,,,Gron,
-2 Rue Haute,3.262000,48.160868,,2 Rue Haute,,,,89100
-3 RUE MARCELIN BERTHELOT Joigny,,,,3 RUE MARCELIN BERTHELOT,,,,89300
-3 RUE MARCELIN BERTHELOT 89300,,,,3 RUE MARCELIN BERTHELOT,,,Joigny,
-3 RUE MARCELIN BERTHELOT,3.416979,47.980896,,3 RUE MARCELIN BERTHELOT,,,,89300
-2 Grande Rue Looze,,,,2 Grande Rue,,,,89300
-2 Grande Rue 89300,,,,2 Grande Rue,,,Looze,
-2 Grande Rue,3.440687,47.992249,,2 Grande Rue,,,,89300
-17 Avenue Edouard Branly Migennes,,,,17 Avenue Edouard Branly,,,,89400
-17 Avenue Edouard Branly 89400,,,,17 Avenue Edouard Branly,,,Migennes,
-17 Avenue Edouard Branly,3.524378,47.965564,,17 Avenue Edouard Branly,,,,89400
-16 Rue d'Argenteuil Moulins-en-Tonnerrois,,,,16 Rue d'Argenteuil,,,,89310
-16 Rue d'Argenteuil 89310,,,,16 Rue d'Argenteuil,,,Moulins-en-Tonnerrois,
-16 Rue d'Argenteuil,4.036176,47.731363,,16 Rue d'Argenteuil,,,,89310
-13 Rue du Bas de Bréandes Perrigny,,,,13 Rue du Bas de Bréandes,,,,89000
-13 Rue du Bas de Bréandes 89000,,,,13 Rue du Bas de Bréandes,,,Perrigny,
-13 Rue du Bas de Bréandes,3.541638,47.825559,,13 Rue du Bas de Bréandes,,,,89000
-7 Rue André Henriat Rogny-les-Sept-Écluses,,,,7 Rue André Henriat,,,,89220
-7 Rue André Henriat 89220,,,,7 Rue André Henriat,,,Rogny-les-Sept-Écluses,
-7 Rue André Henriat,2.881517,47.743506,,7 Rue André Henriat,,,,89220
-38 Rue de la Maladrerie Saint-Florentin,,,,38 Rue de la Maladrerie,,,,89600
-38 Rue de la Maladrerie 89600,,,,38 Rue de la Maladrerie,,,Saint-Florentin,
-38 Rue de la Maladrerie,3.722243,47.996211,,38 Rue de la Maladrerie,,,,89600
-4 Rue du Vieux Poux Saint-Maurice-Thizouaille,,,,4 Rue du Vieux Poux,,,,89110
-4 Rue du Vieux Poux 89110,,,,4 Rue du Vieux Poux,,,Saint-Maurice-Thizouaille,
-4 Rue du Vieux Poux,3.366185,47.833027,,4 Rue du Vieux Poux,,,,89110
-83BIS Rue Bellocier Sens,,,,83BIS Rue Bellocier,,,,89100
-83BIS Rue Bellocier 89100,,,,83BIS Rue Bellocier,,,Sens,
-83BIS Rue Bellocier,3.268558,48.202523,,83BIS Rue Bellocier,,,,89100
-127 Avenue de Sénigallia Sens,,,,127 Avenue de Sénigallia,,,,89100
-127 Avenue de Sénigallia 89100,,,,127 Avenue de Sénigallia,,,Sens,
-127 Avenue de Sénigallia,3.284523,48.189124,,127 Avenue de Sénigallia,,,,89100
-3 Grande Rue Saint-Martin Thorigny-sur-Oreuse,,,,3 Grande Rue Saint-Martin,,,,89260
-3 Grande Rue Saint-Martin 89260,,,,3 Grande Rue Saint-Martin,,,Thorigny-sur-Oreuse,
-3 Grande Rue Saint-Martin,3.331917,48.293328,,3 Grande Rue Saint-Martin,,,,89260
-28 Rue du Chemin Vert Vareilles,,,,28 Rue du Chemin Vert,,,,89320
-28 Rue du Chemin Vert 89320,,,,28 Rue du Chemin Vert,,,Vareilles,
-28 Rue du Chemin Vert,3.474266,48.173335,,28 Rue du Chemin Vert,,,,89320
-75 Rue du Port Villeblevin,,,,75 Rue du Port,,,,89340
-75 Rue du Port 89340,,,,75 Rue du Port,,,Villeblevin,
-75 Rue du Port,3.092251,48.325781,,75 Rue du Port,,,,89340
-40 Rue du Grain d'Anis Villeneuve-sur-Yonne,,,,40 Rue du Grain d'Anis,,,,89500
-40 Rue du Grain d'Anis 89500,,,,40 Rue du Grain d'Anis,,,Villeneuve-sur-Yonne,
-40 Rue du Grain d'Anis,3.284952,48.079943,,40 Rue du Grain d'Anis,,,,89500
-114 Rue des Arcys Volgré,,,,114 Rue des Arcys,,,,89710
-114 Rue des Arcys 89710,,,,114 Rue des Arcys,,,,89710
-114 Rue des Arcys,3.328024,47.920675,,114 Rue des Arcys,,,,89710
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+24 Grande Rue Athie,,,,24,Grande Rue,,21500
+24 Grande Rue 21500,,,,24,Grande Rue,Athie,
+24 Grande Rue,4.253269,47.566787,,24,Grande Rue,,21500
+4 Rue du Collège Beaune,,,,4,Rue du Collège,,21200
+4 Rue du Collège 21200,,,,4,Rue du Collège,Beaune,
+4 Rue du Collège,4.838783,47.026356,,4,Rue du Collège,,21200
+13 Rue Saint-Vincent Bellefond,,,,13,Rue Saint-Vincent,,21490
+13 Rue Saint-Vincent 21490,,,,13,Rue Saint-Vincent,Bellefond,
+13 Rue Saint-Vincent,5.074413,47.381875,,13,Rue Saint-Vincent,,21490
+156BIS Route de Dijon Brazey-en-Plaine,,,,156BIS,Route de Dijon,,21470
+156BIS Route de Dijon 21470,,,,156BIS,Route de Dijon,Brazey-en-Plaine,
+156BIS Route de Dijon,5.204185,47.148796,,156BIS,Route de Dijon,,21470
+3 Rue Sainte-Anne Chanceaux,,,,3,Rue Sainte-Anne,,21440
+3 Rue Sainte-Anne 21440,,,,3,Rue Sainte-Anne,Chanceaux,
+3 Rue Sainte-Anne,4.715233,47.520151,,3,Rue Sainte-Anne,,21440
+1 Rue des Tulipes Chenôve,,,,1,Rue des Tulipes,,21300
+1 Rue des Tulipes 21300,,,,1,Rue des Tulipes,Chenôve,
+1 Rue des Tulipes,5.008249,47.301763,,1,Rue des Tulipes,,21300
+5 Rue du Lavoir Corcelles-lès-Cîteaux,,,,5,Rue du Lavoir,,21910
+5 Rue du Lavoir 21910,,,,5,Rue du Lavoir,Corcelles-lès-Cîteaux,
+5 Rue du Lavoir,5.078406,47.172034,,5,Rue du Lavoir,,21910
+1 Rue de l'Aviation Darois,,,,1,Rue de l'Aviation,,21121
+1 Rue de l'Aviation 21121,,,,1,Rue de l'Aviation,Darois,
+1 Rue de l'Aviation,4.942688,47.389129,,1,Rue de l'Aviation,,21121
+4 Impasse Chanoine Henri Latour Dijon,,,,4,Impasse Chanoine Henri Latour,,21000
+4 Impasse Chanoine Henri Latour 21000,,,,4,Impasse Chanoine Henri Latour,Dijon,
+4 Impasse Chanoine Henri Latour,5.000011,47.309527,,4,Impasse Chanoine Henri Latour,,21000
+9 Rue Ernest Bouteiller Dijon,,,,9,Rue Ernest Bouteiller,,21000
+9 Rue Ernest Bouteiller 21000,,,,9,Rue Ernest Bouteiller,Dijon,
+9 Rue Ernest Bouteiller,5.071487,47.326336,,9,Rue Ernest Bouteiller,,21000
+13 Rue Joliet Dijon,,,,13,Rue Joliet,,21000
+13 Rue Joliet 21000,,,,13,Rue Joliet,Dijon,
+13 Rue Joliet,5.028789,47.319177,,13,Rue Joliet,,21000
+6 Rue Mozart Dijon,,,,6,Rue Mozart,,21000
+6 Rue Mozart 21000,,,,6,Rue Mozart,Dijon,
+6 Rue Mozart,5.034097,47.313372,,6,Rue Mozart,,21000
+28 Boulevard Thiers Dijon,,,,28,Boulevard Thiers,,21000
+28 Boulevard Thiers 21000,,,,28,Boulevard Thiers,Dijon,
+28 Boulevard Thiers,5.051525,47.321987,,28,Boulevard Thiers,,21000
+3 Rue Marie-Louise May Fénay,,,,3,Rue Marie-Louise May,,21600
+3 Rue Marie-Louise May 21600,,,,3,Rue Marie-Louise May,Fénay,
+3 Rue Marie-Louise May,5.062533,47.234678,,3,Rue Marie-Louise May,,21600
+15 Route de Fontaine-Française Fontenelle,,,,15,Route de Fontaine-Française,,21610
+15 Route de Fontaine-Française 21610,,,,15,Route de Fontaine-Française,Fontenelle,
+15 Route de Fontaine-Française,5.37221,47.502951,,15,Route de Fontaine-Française,,21610
+17 Rue de l'Hotel de Ville Grancey-sur-Ource,,,,17,Rue de l'Hotel de Ville,,21570
+17 Rue de l'Hotel de Ville 21570,,,,17,Rue de l'Hotel de Ville,Grancey-sur-Ource,
+17 Rue de l'Hotel de Ville,4.587953,48.006944,,17,Rue de l'Hotel de Ville,,21570
+44 Rue de Bourgogne Lamarche-sur-Saône,,,,44,Rue de Bourgogne,,21760
+44 Rue de Bourgogne 21760,,,,44,Rue de Bourgogne,Lamarche-sur-Saône,
+44 Rue de Bourgogne,5.38635,47.263203,,44,Rue de Bourgogne,,21760
+17 Quai de la Hutte Losne,,,,17,Quai de la Hutte,,21170
+17 Quai de la Hutte 21170,,,,17,Quai de la Hutte,Losne,
+17 Quai de la Hutte,5.261214,47.099622,,17,Quai de la Hutte,,21170
+24 Route des Grands Crus Marsannay-la-Côte,,,,24,Route des Grands Crus,,21160
+24 Route des Grands Crus 21160,,,,24,Route des Grands Crus,Marsannay-la-Côte,
+24 Route des Grands Crus,4.994218,47.276745,,24,Route des Grands Crus,,21160
+11 Allée Paul Jeannin Mirebeau-sur-Bèze,,,,11,Allée Paul Jeannin,,21310
+11 Allée Paul Jeannin 21310,,,,11,Allée Paul Jeannin,Mirebeau-sur-Bèze,
+11 Allée Paul Jeannin,5.324462,47.399248,,11,Allée Paul Jeannin,,21310
+1 Route Départementale 108 (Thil) Nan-sous-Thil,,,,1,Route Départementale 108 (Thil),,21390
+1 Route Départementale 108 (Thil) 21390,,,,1,Route Départementale 108 (Thil),Nan-sous-Thil,
+1 Route Départementale 108 (Thil),4.354976,47.393448,,1,Route Départementale 108 (Thil),,21390
+6 Rue de la Houblonnière Orgeux,,,,6,Rue de la Houblonnière,,21490
+6 Rue de la Houblonnière 21490,,,,6,Rue de la Houblonnière,Orgeux,
+6 Rue de la Houblonnière,5.151066,47.359584,,6,Rue de la Houblonnière,,21490
+81 Rue du Lac Pont-et-Massène,,,,81,Rue du Lac,,21140
+81 Rue du Lac 21140,,,,81,Rue du Lac,Pont-et-Massène,
+81 Rue du Lac,4.350314,47.461973,,81,Rue du Lac,,21140
+3 Rue-des-Prés Remilly-en-Montagne,,,,3,Rue-des-Prés,,21540
+3 Rue-des-Prés 21540,,,,3,Rue-des-Prés,Remilly-en-Montagne,
+3 Rue-des-Prés,4.7338,47.29297,,3,Rue-des-Prés,,21540
+1 Route de Dijon Saint-Broing-les-Moines,,,,1,Route de Dijon,,21290
+1 Route de Dijon 21290,,,,1,Route de Dijon,Saint-Broing-les-Moines,
+1 Route de Dijon,4.843186,47.694492,,1,Route de Dijon,,21290
+27 Avenue de la Gare Saulieu,,,,27,Avenue de la Gare,,21210
+27 Avenue de la Gare 21210,,,,27,Avenue de la Gare,Saulieu,
+27 Avenue de la Gare,4.235228,47.282311,,27,Avenue de la Gare,,21210
+11 Rue du Lycée Semur-en-Auxois,,,,11,Rue du Lycée,,21140
+11 Rue du Lycée 21140,,,,11,Rue du Lycée,Semur-en-Auxois,
+11 Rue du Lycée,4.334649,47.493159,,11,Rue du Lycée,,21140
+16 Rue Édouard Herriot Talant,,,,16,Rue Édouard Herriot,,21240
+16 Rue Édouard Herriot 21240,,,,16,Rue Édouard Herriot,Talant,
+16 Rue Édouard Herriot,5.012036,47.338432,,16,Rue Édouard Herriot,,21240
+1C Grande Rue Trouhaut,,,,1C,Grande Rue,,21440
+1C Grande Rue 21440,,,,1C,Grande Rue,Trouhaut,
+1C Grande Rue,4.760961,47.389819,,1C,Grande Rue,,21440
+4 Place du Creux Bleu Villecomte,,,,4,Place du Creux Bleu,,21120
+4 Place du Creux Bleu 21120,,,,4,Place du Creux Bleu,Villecomte,
+4 Place du Creux Bleu,5.03447,47.511141,,4,Place du Creux Bleu,,21120
+24 Rue des Bertranges La Charité-sur-Loire,,,,24,Rue des Bertranges,,58400
+24 Rue des Bertranges 58400,,,,24,Rue des Bertranges,La Charité-sur-Loire,
+24 Rue des Bertranges,3.031383,47.17955,,24,Rue des Bertranges,,58400
+4 Rue J F Fremillon Chaulgnes,,,,4,Rue J F Fremillon,,58400
+4 Rue J F Fremillon 58400,,,,4,Rue J F Fremillon,Chaulgnes,
+4 Rue J F Fremillon,3.103273,47.129348,,4,Rue J F Fremillon,,58400
+12 Rue de l'Est Cosne-Cours-sur-Loire,,,,12,Rue de l'Est,,58200
+12 Rue de l'Est 58200,,,,12,Rue de l'Est,Cosne-Cours-sur-Loire,
+12 Rue de l'Est,2.924009,47.404667,,12,Rue de l'Est,,58200
+17 Rue de Villecourt Coulanges-lès-Nevers,,,,17,Rue de Villecourt,,58660
+17 Rue de Villecourt 58660,,,,17,Rue de Villecourt,Coulanges-lès-Nevers,
+17 Rue de Villecourt,3.174468,47.012787,,17,Rue de Villecourt,,58660
+16 Rue du 11 Novembre Entrains-sur-Nohain,,,,16,Rue du 11 Novembre,,58410
+16 Rue du 11 Novembre 58410,,,,16,Rue du 11 Novembre,Entrains-sur-Nohain,
+16 Rue du 11 Novembre,3.262848,47.470686,,16,Rue du 11 Novembre,,58410
+21 Rue des Bertranges Guérigny,,,,21,Rue des Bertranges,,58130
+21 Rue des Bertranges 58130,,,,21,Rue des Bertranges,Guérigny,
+21 Rue des Bertranges,3.198042,47.097949,,21,Rue des Bertranges,,58130
+12 Rue Saint-André Luzy,,,,12,Rue Saint-André,,58170
+12 Rue Saint-André 58170,,,,12,Rue Saint-André,Luzy,
+12 Rue Saint-André,3.966893,46.784338,,12,Rue Saint-André,,58170
+33BIS Rue du Château de Mouron Mesves-sur-Loire,,,,33BIS,Rue du Château de Mouron,,58400
+33BIS Rue du Château de Mouron 58400,,,,33BIS,Rue du Château de Mouron,Mesves-sur-Loire,
+33BIS Rue du Château de Mouron,2.993473,47.239763,,33BIS,Rue du Château de Mouron,,58400
+52BIS Rue des Chauvelles Nevers,,,,52BIS,Rue des Chauvelles,,58000
+52BIS Rue des Chauvelles 58000,,,,52BIS,Rue des Chauvelles,Nevers,
+52BIS Rue des Chauvelles,3.158502,46.997534,,52BIS,Rue des Chauvelles,,58000
+75 Rue de Nievre Nevers,,,,75,Rue de Nievre,,58000
+75 Rue de Nievre 58000,,,,75,Rue de Nievre,Nevers,
+75 Rue de Nievre,3.163578,46.989696,,75,Rue de Nievre,,58000
+15 Rue des Vièvres Pougues-les-Eaux,,,,15,Rue des Vièvres,,58320
+15 Rue des Vièvres 58320,,,,15,Rue des Vièvres,Pougues-les-Eaux,
+15 Rue des Vièvres,3.09656,47.072665,,15,Rue des Vièvres,,58320
+14 Rue des Hortensias Saint-Éloi,,,,14,Rue des Hortensias,,58000
+14 Rue des Hortensias 58000,,,,14,Rue des Hortensias,Saint-Éloi,
+14 Rue des Hortensias,3.224584,46.978799,,14,Rue des Hortensias,,58000
+40 Rue de Paris Saint-Pierre-le-Moûtier,,,,40,Rue de Paris,,58240
+40 Rue de Paris 58240,,,,40,Rue de Paris,Saint-Pierre-le-Moûtier,
+40 Rue de Paris,3.118768,46.790789,,40,Rue de Paris,,58240
+1121 Rue des Vannes Urzy,,,,1121,Rue des Vannes,,58130
+1121 Rue des Vannes 58130,,,,1121,Rue des Vannes,Urzy,
+1121 Rue des Vannes,3.217883,47.063581,,1121,Rue des Vannes,,58130
+23 Rue de l'Hôtel de Ville Varzy,,,,23,Rue de l'Hôtel de Ville,,58210
+23 Rue de l'Hôtel de Ville 58210,,,,23,Rue de l'Hôtel de Ville,Varzy,
+23 Rue de l'Hôtel de Ville,3.388507,47.359084,,23,Rue de l'Hôtel de Ville,,58210
+4 Rue des Violettes Autun,,,,4,Rue des Violettes,,71400
+4 Rue des Violettes 71400,,,,4,Rue des Violettes,Autun,
+4 Rue des Violettes,4.310056,46.967358,,4,Rue des Violettes,,71400
+12 Rue d'Autun Bourbon-Lancy,,,,12,Rue d'Autun,,71140
+12 Rue d'Autun 71140,,,,12,Rue d'Autun,Bourbon-Lancy,
+12 Rue d'Autun,3.773894,46.625257,,12,Rue d'Autun,,71140
+10 Rue du Bourg Broye,,,,10,Rue du Bourg,,71190
+10 Rue du Bourg 71190,,,,10,Rue du Bourg,Broye,
+10 Rue du Bourg,4.291076,46.872049,,10,Rue du Bourg,,71190
+17 Rue du 56e Régiment d'Infanterie Chalon-sur-Saône,,,,17,Rue du 56e Régiment d'Infanterie,,71100
+17 Rue du 56e Régiment d'Infanterie 71100,,,,17,Rue du 56e Régiment d'Infanterie,Chalon-sur-Saône,
+17 Rue du 56e Régiment d'Infanterie,4.852113,46.791946,,17,Rue du 56e Régiment d'Infanterie,,71100
+7 Place Saint-Jean de Maizel Chalon-sur-Saône,,,,7,Place Saint-Jean de Maizel,,71100
+7 Place Saint-Jean de Maizel 71100,,,,7,Place Saint-Jean de Maizel,Chalon-sur-Saône,
+7 Place Saint-Jean de Maizel,4.851335,46.779107,,7,Place Saint-Jean de Maizel,,71100
+65 Chemin des Gérards Charnay-lès-Mâcon,,,,65,Chemin des Gérards,,71850
+65 Chemin des Gérards 71850,,,,65,Chemin des Gérards,Charnay-lès-Mâcon,
+65 Chemin des Gérards,4.793601,46.320406,,65,Chemin des Gérards,,71850
+16 Rue de L'Église Chaudenay,,,,16,Rue de L'Église,,71150
+16 Rue de L'Église 71150,,,,16,Rue de L'Église,Chaudenay,
+16 Rue de L'Église,4.791164,46.914744,,16,Rue de L'Église,,71150
+5 Rue de la Petite Rivière Cluny,,,,5,Rue de la Petite Rivière,,71250
+5 Rue de la Petite Rivière 71250,,,,5,Rue de la Petite Rivière,Cluny,
+5 Rue de la Petite Rivière,4.661548,46.432432,,5,Rue de la Petite Rivière,,71250
+28 Rue de Madagascar Le Creusot,,,,28,Rue de Madagascar,,71200
+28 Rue de Madagascar 71200,,,,28,Rue de Madagascar,Le Creusot,
+28 Rue de Madagascar,4.457958,46.801965,,28,Rue de Madagascar,,71200
+3 Impasse des Troënes Cuiseaux,,,,3,Impasse des Troënes,,71480
+3 Impasse des Troënes 71480,,,,3,Impasse des Troënes,Cuiseaux,
+3 Impasse des Troënes,5.379804,46.493779,,3,Impasse des Troënes,,71480
+56 Rue du Verdier Digoin,,,,56,Rue du Verdier,,71160
+56 Rue du Verdier 71160,,,,56,Rue du Verdier,Digoin,
+56 Rue du Verdier,3.990858,46.500649,,56,Rue du Verdier,,71160
+4 Rue des Saules Fontaines,,,,4,Rue des Saules,,71150
+4 Rue des Saules 71150,,,,4,Rue des Saules,Fontaines,
+4 Rue des Saules,4.773386,46.850065,,4,Rue des Saules,,71150
+24 Route de Saint-Martin Guerfand,,,,24,Route de Saint-Martin,,71620
+24 Route de Saint-Martin 71620,,,,24,Route de Saint-Martin,Guerfand,
+24 Route de Saint-Martin,5.036003,46.790758,,24,Route de Saint-Martin,,71620
+4 Route de Saint-Vallerin Jully-lès-Buxy,,,,4,Route de Saint-Vallerin,,71390
+4 Route de Saint-Vallerin 71390,,,,4,Route de Saint-Vallerin,Jully-lès-Buxy,
+4 Route de Saint-Vallerin,4.688681,46.689391,,4,Route de Saint-Vallerin,,71390
+1109 Route de Tournus Lugny,,,,1109,Route de Tournus,,71260
+1109 Route de Tournus 71260,,,,1109,Route de Tournus,Lugny,
+1109 Route de Tournus,4.823467,46.489877,,1109,Route de Tournus,,71260
+14 Rue Poitevin Mâcon,,,,14,Rue Poitevin,,71000
+14 Rue Poitevin 71000,,,,14,Rue Poitevin,Mâcon,
+14 Rue Poitevin,4.823572,46.306242,,14,Rue Poitevin,,71000
+37BIS Route de Louhans Mervans,,,,37BIS,Route de Louhans,,71310
+37BIS Route de Louhans 71310,,,,37BIS,Route de Louhans,Mervans,
+37BIS Route de Louhans,5.184382,46.795166,,37BIS,Route de Louhans,,71310
+42 Rue de la Loge Montceau-les-Mines,,,,42,Rue de la Loge,,71300
+42 Rue de la Loge 71300,,,,42,Rue de la Loge,Montceau-les-Mines,
+42 Rue de la Loge,4.380076,46.679128,,42,Rue de la Loge,,71300
+58 Avenue de la République Montchanin,,,,58,Avenue de la République,,71210
+58 Avenue de la République 71210,,,,58,Avenue de la République,Montchanin,
+58 Avenue de la République,4.468646,46.74952,,58,Avenue de la République,,71210
+14 Rue des Deux Ponts Paray-le-Monial,,,,14,Rue des Deux Ponts,,71600
+14 Rue des Deux Ponts 71600,,,,14,Rue des Deux Ponts,Paray-le-Monial,
+14 Rue des Deux Ponts,4.118971,46.44998,,14,Rue des Deux Ponts,,71600
+206 Chemin des Loureaux Ratte,,,,206,Chemin des Loureaux,,71500
+206 Chemin des Loureaux 71500,,,,206,Chemin des Loureaux,Ratte,
+206 Chemin des Loureaux,5.299614,46.626826,,206,Chemin des Loureaux,,71500
+430 Route de Tronchy Saint-Étienne-en-Bresse,,,,430,Route de Tronchy,,71370
+430 Route de Tronchy 71370,,,,430,Route de Tronchy,Saint-Étienne-en-Bresse,
+430 Route de Tronchy,5.054819,46.709305,,430,Route de Tronchy,,71370
+12 Rue des Chavannes Saint-Marcel,,,,12,Rue des Chavannes,,71380
+12 Rue des Chavannes 71380,,,,12,Rue des Chavannes,Saint-Marcel,
+12 Rue des Chavannes,4.870054,46.778206,,12,Rue des Chavannes,,71380
+3 Impasse Mon Calme Saint-Rémy,,,,3,Impasse Mon Calme,,71100
+3 Impasse Mon Calme 71100,,,,3,Impasse Mon Calme,Saint-Rémy,
+3 Impasse Mon Calme,4.821576,46.765561,,3,Impasse Mon Calme,,71100
+44 Rue Jean Moulin Saint-Vallier,,,,44,Rue Jean Moulin,,71230
+44 Rue Jean Moulin 71230,,,,44,Rue Jean Moulin,Saint-Vallier,
+44 Rue Jean Moulin,4.328327,46.633568,,44,Rue Jean Moulin,,71230
+4124 Rue de Saint-Eugène Sanvignes-les-Mines,,,,4124,Rue de Saint-Eugène,,71410
+4124 Rue de Saint-Eugène 71410,,,,4124,Rue de Saint-Eugène,Sanvignes-les-Mines,
+4124 Rue de Saint-Eugène,4.247602,46.680129,,4124,Rue de Saint-Eugène,,71410
+10 Hameau Grand Cerisier Simard,,,,10,Hameau Grand Cerisier,,71330
+10 Hameau Grand Cerisier 71330,,,,10,Hameau Grand Cerisier,Simard,
+10 Hameau Grand Cerisier,5.159487,46.731799,,10,Hameau Grand Cerisier,,71330
+17BIS Grande Rue Tramayes,,,,17BIS,Grande Rue,,71520
+17BIS Grande Rue 71520,,,,17BIS,Grande Rue,Tramayes,
+17BIS Grande Rue,4.601749,46.308017,,17BIS,Grande Rue,,71520
+7X Rue du Gué Arcy-sur-Cure,,,,7X,Rue du Gué,,89270
+7X Rue du Gué 89270,,,,7X,Rue du Gué,Arcy-sur-Cure,
+7X Rue du Gué,3.758783,47.60271,,7X,Rue du Gué,,89270
+7 Rue de l'Egalite Auxerre,,,,7,Rue de l'Egalite,,89000
+7 Rue de l'Egalite 89000,,,,7,Rue de l'Egalite,Auxerre,
+7 Rue de l'Egalite,3.566932,47.79506,,7,Rue de l'Egalite,,89000
+1BIS Avenue de la Puisaye Auxerre,,,,1BIS,Avenue de la Puisaye,,89000
+1BIS Avenue de la Puisaye 89000,,,,1BIS,Avenue de la Puisaye,Auxerre,
+1BIS Avenue de la Puisaye,3.565595,47.789647,,1BIS,Avenue de la Puisaye,,89000
+2BIS Rue de la Résistance Bassou,,,,2BIS,Rue de la Résistance,,89400
+2BIS Rue de la Résistance 89400,,,,2BIS,Rue de la Résistance,Bassou,
+2BIS Rue de la Résistance,3.516142,47.921069,,2BIS,Rue de la Résistance,,89400
+16 Rue Palériau Brienon-sur-Armançon,,,,16,Rue Palériau,,89210
+16 Rue Palériau 89210,,,,16,Rue Palériau,Brienon-sur-Armançon,
+16 Rue Palériau,3.615113,47.986431,,16,Rue Palériau,,89210
+7 Rue des Baudons Champignelles,,,,7,Rue des Baudons,,89350
+7 Rue des Baudons 89350,,,,7,Rue des Baudons,Champignelles,
+7 Rue des Baudons,3.079963,47.77963,,7,Rue des Baudons,,89350
+14 Rue du Cedec Charny,,,,14,Rue du Cedec,,89120
+14 Rue du Cedec 89120,,,,14,Rue du Cedec,Charny,
+14 Rue du Cedec,3.096112,47.877677,,14,Rue du Cedec,,89120
+40 Rue de l'Étang Jussier Chevannes,,,,40,Rue de l'Étang Jussier,,89240
+40 Rue de l'Étang Jussier 89240,,,,40,Rue de l'Étang Jussier,Chevannes,
+40 Rue de l'Étang Jussier,3.489512,47.771753,,40,Rue de l'Étang Jussier,,89240
+10 Rue des Ecossais Cravant,,,,10,Rue des Ecossais,,89460
+10 Rue des Ecossais 89460,,,,10,Rue des Ecossais,Cravant,
+10 Rue des Ecossais,3.691448,47.682661,,10,Rue des Ecossais,,89460
+30 Route de Vaux Escolives-Sainte-Camille,,,,30,Route de Vaux,,89290
+30 Route de Vaux 89290,,,,30,Route de Vaux,Escolives-Sainte-Camille,
+30 Route de Vaux,3.596056,47.733201,,30,Route de Vaux,,89290
+2 Rue Haute Gron,,,,2,Rue Haute,,89100
+2 Rue Haute 89100,,,,2,Rue Haute,Gron,
+2 Rue Haute,3.262,48.160868,,2,Rue Haute,,89100
+3 RUE MARCELIN BERTHELOT Joigny,,,,3,BERTHELOT,,89300
+3 RUE MARCELIN BERTHELOT 89300,,,,3,BERTHELOT,Joigny,
+3 RUE MARCELIN BERTHELOT,3.416979,47.980896,,3,BERTHELOT,,89300
+2 Grande Rue Looze,,,,2,Grande Rue,,89300
+2 Grande Rue 89300,,,,2,Grande Rue,Looze,
+2 Grande Rue,3.440687,47.992249,,2,Grande Rue,,89300
+17 Avenue Edouard Branly Migennes,,,,17,Avenue Edouard Branly,,89400
+17 Avenue Edouard Branly 89400,,,,17,Avenue Edouard Branly,Migennes,
+17 Avenue Edouard Branly,3.524378,47.965564,,17,Avenue Edouard Branly,,89400
+16 Rue d'Argenteuil Moulins-en-Tonnerrois,,,,16,Rue d'Argenteuil,,89310
+16 Rue d'Argenteuil 89310,,,,16,Rue d'Argenteuil,Moulins-en-Tonnerrois,
+16 Rue d'Argenteuil,4.036176,47.731363,,16,Rue d'Argenteuil,,89310
+13 Rue du Bas de Bréandes Perrigny,,,,13,Rue du Bas de Bréandes,,89000
+13 Rue du Bas de Bréandes 89000,,,,13,Rue du Bas de Bréandes,Perrigny,
+13 Rue du Bas de Bréandes,3.541638,47.825559,,13,Rue du Bas de Bréandes,,89000
+7 Rue André Henriat Rogny-les-Sept-Écluses,,,,7,Rue André Henriat,,89220
+7 Rue André Henriat 89220,,,,7,Rue André Henriat,Rogny-les-Sept-Écluses,
+7 Rue André Henriat,2.881517,47.743506,,7,Rue André Henriat,,89220
+38 Rue de la Maladrerie Saint-Florentin,,,,38,Rue de la Maladrerie,,89600
+38 Rue de la Maladrerie 89600,,,,38,Rue de la Maladrerie,Saint-Florentin,
+38 Rue de la Maladrerie,3.722243,47.996211,,38,Rue de la Maladrerie,,89600
+4 Rue du Vieux Poux Saint-Maurice-Thizouaille,,,,4,Rue du Vieux Poux,,89110
+4 Rue du Vieux Poux 89110,,,,4,Rue du Vieux Poux,Saint-Maurice-Thizouaille,
+4 Rue du Vieux Poux,3.366185,47.833027,,4,Rue du Vieux Poux,,89110
+83BIS Rue Bellocier Sens,,,,83BIS,Rue Bellocier,,89100
+83BIS Rue Bellocier 89100,,,,83BIS,Rue Bellocier,Sens,
+83BIS Rue Bellocier,3.268558,48.202523,,83BIS,Rue Bellocier,,89100
+127 Avenue de Sénigallia Sens,,,,127,Avenue de Sénigallia,,89100
+127 Avenue de Sénigallia 89100,,,,127,Avenue de Sénigallia,Sens,
+127 Avenue de Sénigallia,3.284523,48.189124,,127,Avenue de Sénigallia,,89100
+3 Grande Rue Saint-Martin Thorigny-sur-Oreuse,,,,3,Grande Rue Saint-Martin,,89260
+3 Grande Rue Saint-Martin 89260,,,,3,Grande Rue Saint-Martin,Thorigny-sur-Oreuse,
+3 Grande Rue Saint-Martin,3.331917,48.293328,,3,Grande Rue Saint-Martin,,89260
+28 Rue du Chemin Vert Vareilles,,,,28,Rue du Chemin Vert,,89320
+28 Rue du Chemin Vert 89320,,,,28,Rue du Chemin Vert,Vareilles,
+28 Rue du Chemin Vert,3.474266,48.173335,,28,Rue du Chemin Vert,,89320
+75 Rue du Port Villeblevin,,,,75,Rue du Port,,89340
+75 Rue du Port 89340,,,,75,Rue du Port,Villeblevin,
+75 Rue du Port,3.092251,48.325781,,75,Rue du Port,,89340
+40 Rue du Grain d'Anis Villeneuve-sur-Yonne,,,,40,Rue du Grain d'Anis,,89500
+40 Rue du Grain d'Anis 89500,,,,40,Rue du Grain d'Anis,Villeneuve-sur-Yonne,
+40 Rue du Grain d'Anis,3.284952,48.079943,,40,Rue du Grain d'Anis,,89500
+114 Rue des Arcys Volgré,,,,114,Rue des Arcys,,89710
+114 Rue des Arcys 89710,,,,114,Rue des Arcys,,89710
+114 Rue des Arcys,3.328024,47.920675,,114,Rue des Arcys,,89710

--- a/geocoder_tester/world/france/bretagne/test_addresses.csv
+++ b/geocoder_tester/world/france/bretagne/test_addresses.csv
@@ -1,541 +1,541 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-6 Sentier des Briandais Bobital,,,,6 Sentier des Briandais,,,,22100
-6 Sentier des Briandais 22100,,,,6 Sentier des Briandais,,,Bobital,
-6 Sentier des Briandais,-2.103385,48.413152,,6 Sentier des Briandais,,,,22100
-16 Résidence des Chênes Caulnes,,,,16 Résidence des Chênes,,,,22350
-16 Résidence des Chênes 22350,,,,16 Résidence des Chênes,,,Caulnes,
-16 Résidence des Chênes,-2.149973,48.291864,,16 Résidence des Chênes,,,,22350
-8 Place Duguesclin Dinan,,,,8 Place Duguesclin,,,,22100
-8 Place Duguesclin 22100,,,,8 Place Duguesclin,,,Dinan,
-8 Place Duguesclin,-2.043671,48.450922,,8 Place Duguesclin,,,,22100
-32 Rue de la Mare Ès Loups Erquy,,,,32 Rue de la Mare Ès Loups,,,,22430
-32 Rue de la Mare Ès Loups 22430,,,,32 Rue de la Mare Ès Loups,,,Erquy,
-32 Rue de la Mare Ès Loups,-2.449201,48.628913,,32 Rue de la Mare Ès Loups,,,,22430
-11 Route Kerjaffray Gouarec,,,,11 Route Kerjaffray,,,,22570
-11 Route Kerjaffray 22570,,,,11 Route Kerjaffray,,,Gouarec,
-11 Route Kerjaffray,-3.193388,48.228382,,11 Route Kerjaffray,,,,22570
-1 Rue du Gen de Gaulle Hémonstoir,,,,1 Rue du Gen de Gaulle,,,,22600
-1 Rue du Gen de Gaulle 22600,,,,1 Rue du Gen de Gaulle,,,Hémonstoir,
-1 Rue du Gen de Gaulle,-2.830120,48.159337,,1 Rue du Gen de Gaulle,,,,22600
-24 Rue des Clossiaux Maroue Lamballe,,,,24 Rue des Clossiaux Maroue,,,,22400
-24 Rue des Clossiaux Maroue 22400,,,,24 Rue des Clossiaux Maroue,,,Lamballe,
-24 Rue des Clossiaux Maroue,-2.507481,48.461821,,24 Rue des Clossiaux Maroue,,,,22400
-13 Rue du Sabre Lancieux,,,,13 Rue du Sabre,,,,22770
-13 Rue du Sabre 22770,,,,13 Rue du Sabre,,,Lancieux,
-13 Rue du Sabre,-2.142685,48.589369,,13 Rue du Sabre,,,,22770
-21 Impasse Hent Dall de Kerlabia Lanloup,,,,21 Impasse Hent Dall de Kerlabia,,,,22580
-21 Impasse Hent Dall de Kerlabia 22580,,,,21 Impasse Hent Dall de Kerlabia,,,Lanloup,
-21 Impasse Hent Dall de Kerlabia,-2.964631,48.711541,,21 Impasse Hent Dall de Kerlabia,,,,22580
-18 Rue René Laënnec Lannion,,,,18 Rue René Laënnec,,,,22300
-18 Rue René Laënnec 22300,,,,18 Rue René Laënnec,,,Lannion,
-18 Rue René Laënnec,-3.459777,48.739303,,18 Rue René Laënnec,,,,22300
-2 Avenue de l'Echapt Léhon,,,,2 Avenue de l'Echapt,,,,22100
-2 Avenue de l'Echapt 22100,,,,2 Avenue de l'Echapt,,,Léhon,
-2 Avenue de l'Echapt,-2.049523,48.439123,,2 Avenue de l'Echapt,,,,22100
-18 Rue Neuve Loudéac,,,,18 Rue Neuve,,,,22600
-18 Rue Neuve 22600,,,,18 Rue Neuve,,,Loudéac,
-18 Rue Neuve,-2.752705,48.177182,,18 Rue Neuve,,,,22600
-4 Rue des Epinais La Motte,,,,4 Rue des Epinais,,,,22600
-4 Rue des Epinais 22600,,,,4 Rue des Epinais,,,La Motte,
-4 Rue des Epinais,-2.731693,48.232805,,4 Rue des Epinais,,,,22600
-48 Rue François Le Louarn Paimpol,,,,48 Rue François Le Louarn,,,,22500
-48 Rue François Le Louarn 22500,,,,48 Rue François Le Louarn,,,Paimpol,
-48 Rue François Le Louarn,-2.997629,48.754377,,48 Rue François Le Louarn,,,,22500
-52 Rue des Frères Le Montréer Perros-Guirec,,,,52 Rue des Frères Le Montréer,,,,22700
-52 Rue des Frères Le Montréer 22700,,,,52 Rue des Frères Le Montréer,,,Perros-Guirec,
-52 Rue des Frères Le Montréer,-3.448811,48.812851,,52 Rue des Frères Le Montréer,,,,22700
-18 Les Aires Blanches Plancoët,,,,18 Les Aires Blanches,,,,22130
-18 Les Aires Blanches 22130,,,,18 Les Aires Blanches,,,Plancoët,
-18 Les Aires Blanches,-2.238056,48.520394,,18 Les Aires Blanches,,,,22130
-3 Rue Hent Coz Plélauff,,,,3 Rue Hent Coz,,,,22570
-3 Rue Hent Coz 22570,,,,3 Rue Hent Coz,,,Plélauff,
-3 Rue Hent Coz,-3.210685,48.206661,,3 Rue Hent Coz,,,,22570
-4 Rue des Mouettes Pléneuf-Val-André,,,,4 Rue des Mouettes,,,,22370
-4 Rue des Mouettes 22370,,,,4 Rue des Mouettes,,,Pléneuf-Val-André,
-4 Rue des Mouettes,-2.557191,48.587526,,4 Rue des Mouettes,,,,22370
-10 Rue Pierre Sémard Plérin,,,,10 Rue Pierre Sémard,,,,22190
-10 Rue Pierre Sémard 22190,,,,10 Rue Pierre Sémard,,,Plérin,
-10 Rue Pierre Sémard,-2.758758,48.529967,,10 Rue Pierre Sémard,,,,22190
-3 Impasse Saint-Roch Plestin-les-Grèves,,,,3 Impasse Saint-Roch,,,,22310
-3 Impasse Saint-Roch 22310,,,,3 Impasse Saint-Roch,,,Plestin-les-Grèves,
-3 Impasse Saint-Roch,-3.625051,48.658529,,3 Impasse Saint-Roch,,,,22310
-1 Rue Saint-Geran Plévenon,,,,1 Rue Saint-Geran,,,,22240
-1 Rue Saint-Geran 22240,,,,1 Rue Saint-Geran,,,Plévenon,
-1 Rue Saint-Geran,-2.303649,48.657821,,1 Rue Saint-Geran,,,,22240
-15 Chemin du Paou Ploubazlanec,,,,15 Chemin du Paou,,,,22620
-15 Chemin du Paou 22620,,,,15 Chemin du Paou,,,Ploubazlanec,
-15 Chemin du Paou,-3.013857,48.815575,,15 Chemin du Paou,,,,22620
-12 Rue des Déportés Ploufragan,,,,12 Rue des Déportés,,,,22440
-12 Rue des Déportés 22440,,,,12 Rue des Déportés,,,Ploufragan,
-12 Rue des Déportés,-2.781276,48.500142,,12 Rue des Déportés,,,,22440
-6491A Rue du Gen Leclerc Plouha,,,,6491A Rue du Gen Leclerc,,,,22580
-6491A Rue du Gen Leclerc 22580,,,,6491A Rue du Gen Leclerc,,,Plouha,
-6491A Rue du Gen Leclerc,-2.925709,48.678650,,6491A Rue du Gen Leclerc,,,,22580
-12 Allée des Cerisiers Plourivo,,,,12 Allée des Cerisiers,,,,22860
-12 Allée des Cerisiers 22860,,,,12 Allée des Cerisiers,,,Plourivo,
-12 Allée des Cerisiers,-3.068601,48.744078,,12 Allée des Cerisiers,,,,22860
-1 Rue Chateaubriand Pordic,,,,1 Rue Chateaubriand,,,,22590
-1 Rue Chateaubriand 22590,,,,1 Rue Chateaubriand,,,Pordic,
-1 Rue Chateaubriand,-2.803699,48.574278,,1 Rue Chateaubriand,,,,22590
-14 Rue du Gasset Quintin,,,,14 Rue du Gasset,,,,22800
-14 Rue du Gasset 22800,,,,14 Rue du Gasset,,,Quintin,
-14 Rue du Gasset,-2.914359,48.399785,,14 Rue du Gasset,,,,22800
-4 Rue Anatole France Saint-Brieuc,,,,4 Rue Anatole France,,,,22000
-4 Rue Anatole France 22000,,,,4 Rue Anatole France,,,Saint-Brieuc,
-4 Rue Anatole France,-2.744764,48.505898,,4 Rue Anatole France,,,,22000
-7 Rue du Général Leclerc Saint-Brieuc,,,,7 Rue du Général Leclerc,,,,22000
-7 Rue du Général Leclerc 22000,,,,7 Rue du Général Leclerc,,,Saint-Brieuc,
-7 Rue du Général Leclerc,-2.760220,48.512763,,7 Rue du Général Leclerc,,,,22000
-9 Rue Pierre Loti Saint-Brieuc,,,,9 Rue Pierre Loti,,,,22000
-9 Rue Pierre Loti 22000,,,,9 Rue Pierre Loti,,,Saint-Brieuc,
-9 Rue Pierre Loti,-2.756462,48.511670,,9 Rue Pierre Loti,,,,22000
-43 Boulevard de la Côte d'Émeraude Saint-Cast-le-Guildo,,,,43 Boulevard de la Côte d'Émeraude,,,,22380
-43 Boulevard de la Côte d'Émeraude 22380,,,,43 Boulevard de la Côte d'Émeraude,,,Saint-Cast-le-Guildo,
-43 Boulevard de la Côte d'Émeraude,-2.265858,48.633341,,43 Boulevard de la Côte d'Émeraude,,,,22380
-33 Rue des Fresches Saint-Jacut-de-la-Mer,,,,33 Rue des Fresches,,,,22750
-33 Rue des Fresches 22750,,,,33 Rue des Fresches,,,Saint-Jacut-de-la-Mer,
-33 Rue des Fresches,-2.183134,48.600200,,33 Rue des Fresches,,,,22750
-10 Rue des Korrigans Saint-Quay-Portrieux,,,,10 Rue des Korrigans,,,,22410
-10 Rue des Korrigans 22410,,,,10 Rue des Korrigans,,,Saint-Quay-Portrieux,
-10 Rue des Korrigans,-2.831977,48.646387,,10 Rue des Korrigans,,,,22410
-5 Rue de Garen Bian Trébeurden,,,,5 Rue de Garen Bian,,,,22560
-5 Rue de Garen Bian 22560,,,,5 Rue de Garen Bian,,,Trébeurden,
-5 Rue de Garen Bian,-3.574797,48.768907,,5 Rue de Garen Bian,,,,22560
-1 Allée Poincaré Trégueux,,,,1 Allée Poincaré,,,,22950
-1 Allée Poincaré 22950,,,,1 Allée Poincaré,,,Trégueux,
-1 Allée Poincaré,-2.734380,48.490124,,1 Allée Poincaré,,,,22950
-20 Rue du Port Goret Tréveneuc,,,,20 Rue du Port Goret,,,,22410
-20 Rue du Port Goret 22410,,,,20 Rue du Port Goret,,,Tréveneuc,
-20 Rue du Port Goret,-2.862599,48.669955,,20 Rue du Port Goret,,,,22410
-10 Venelle Notre Dame de la Mer Bénodet,,,,10 Venelle Notre Dame de la Mer,,,,29950
-10 Venelle Notre Dame de la Mer 29950,,,,10 Venelle Notre Dame de la Mer,,,Bénodet,
-10 Venelle Notre Dame de la Mer,-4.103927,47.875185,,10 Venelle Notre Dame de la Mer,,,,29950
-17BIS Rue Amiral Romain Desfossés Brest,,,,17BIS Rue Amiral Romain Desfossés,,,,29200
-17BIS Rue Amiral Romain Desfossés 29200,,,,17BIS Rue Amiral Romain Desfossés,,,Brest,
-17BIS Rue Amiral Romain Desfossés,-4.480860,48.425263,,17BIS Rue Amiral Romain Desfossés,,,,29200
-90 Rue Colette Brest,,,,90 Rue Colette,,,,29200
-90 Rue Colette 29200,,,,90 Rue Colette,,,Brest,
-90 Rue Colette,-4.545725,48.374951,,90 Rue Colette,,,,29200
-4 Rue Frégate la Belle-Poule Brest,,,,4 Rue Frégate la Belle-Poule,,,,29200
-4 Rue Frégate la Belle-Poule 29200,,,,4 Rue Frégate la Belle-Poule,,,Brest,
-4 Rue Frégate la Belle-Poule,-4.484221,48.386129,,4 Rue Frégate la Belle-Poule,,,,29200
-5 Boulevard Jean Moulin Brest,,,,5 Boulevard Jean Moulin,,,,29200
-5 Boulevard Jean Moulin 29200,,,,5 Boulevard Jean Moulin,,,Brest,
-5 Boulevard Jean Moulin,-4.492970,48.386754,,5 Boulevard Jean Moulin,,,,29200
-3 Rue Lumière Brest,,,,3 Rue Lumière,,,,29200
-3 Rue Lumière 29200,,,,3 Rue Lumière,,,Brest,
-3 Rue Lumière,-4.473340,48.404117,,3 Rue Lumière,,,,29200
-50 Rue Poullic Al Lor Brest,,,,50 Rue Poullic Al Lor,,,,29200
-50 Rue Poullic Al Lor 29200,,,,50 Rue Poullic Al Lor,,,Brest,
-50 Rue Poullic Al Lor,-4.471934,48.387116,,50 Rue Poullic Al Lor,,,,29200
-22 Rue Victor Cousin Brest,,,,22 Rue Victor Cousin,,,,29200
-22 Rue Victor Cousin 29200,,,,22 Rue Victor Cousin,,,Brest,
-22 Rue Victor Cousin,-4.537774,48.377049,,22 Rue Victor Cousin,,,,29200
-26 Route de la Grande Grève Carantec,,,,26 Route de la Grande Grève,,,,29660
-26 Route de la Grande Grève 29660,,,,26 Route de la Grande Grève,,,Carantec,
-26 Route de la Grande Grève,-3.923989,48.659955,,26 Route de la Grande Grève,,,,29660
-50 Quai Carnot Châteaulin,,,,50 Quai Carnot,,,,29150
-50 Quai Carnot 29150,,,,50 Quai Carnot,,,Châteaulin,
-50 Quai Carnot,-4.096023,48.195803,,50 Quai Carnot,,,,29150
-8 Rue Paul Sérusier Clohars-Carnoët,,,,8 Rue Paul Sérusier,,,,29360
-8 Rue Paul Sérusier 29360,,,,8 Rue Paul Sérusier,,,Clohars-Carnoët,
-8 Rue Paul Sérusier,-3.555013,47.770193,,8 Rue Paul Sérusier,,,,29360
-4BIS Rue Anatole Le Braz Concarneau,,,,4BIS Rue Anatole Le Braz,,,,29900
-4BIS Rue Anatole Le Braz 29900,,,,4BIS Rue Anatole Le Braz,,,Concarneau,
-4BIS Rue Anatole Le Braz,-3.926054,47.871812,,4BIS Rue Anatole Le Braz,,,,29900
-12 Rue Monet Concarneau,,,,12 Rue Monet,,,,29900
-12 Rue Monet 29900,,,,12 Rue Monet,,,Concarneau,
-12 Rue Monet,-3.898905,47.861193,,12 Rue Monet,,,,29900
-56 Rue de l'Atlantique Crozon,,,,56 Rue de l'Atlantique,,,,29160
-56 Rue de l'Atlantique 29160,,,,56 Rue de l'Atlantique,,,Crozon,
-56 Rue de l'Atlantique,-4.510399,48.222496,,56 Rue de l'Atlantique,,,,29160
-30 Rue Ar Vilin-Goz Douarnenez,,,,30 Rue Ar Vilin-Goz,,,,29100
-30 Rue Ar Vilin-Goz 29100,,,,30 Rue Ar Vilin-Goz,,,Douarnenez,
-30 Rue Ar Vilin-Goz,-4.348851,48.096421,,30 Rue Ar Vilin-Goz,,,,29100
-12 Rue du Pont Douarnenez,,,,12 Rue du Pont,,,,29100
-12 Rue du Pont 29100,,,,12 Rue du Pont,,,Douarnenez,
-12 Rue du Pont,-4.329540,48.090731,,12 Rue du Pont,,,,29100
-7 Allée des Pins Ergué-Gabéric,,,,7 Allée des Pins,,,,29500
-7 Allée des Pins 29500,,,,7 Allée des Pins,,,Ergué-Gabéric,
-7 Allée des Pins,-4.013284,48.017743,,7 Allée des Pins,,,,29500
-8 Route Quimper La Forêt-Fouesnant,,,,8 Route Quimper,,,,29940
-8 Route Quimper 29940,,,,8 Route Quimper,,,La Forêt-Fouesnant,
-8 Route Quimper,-3.964487,47.919462,,8 Route Quimper,,,,29940
-41 Ty Pri Rosnabat Fouesnant,,,,41 Ty Pri Rosnabat,,,,29170
-41 Ty Pri Rosnabat 29170,,,,41 Ty Pri Rosnabat,,,Fouesnant,
-41 Ty Pri Rosnabat,-4.010664,47.910955,,41 Ty Pri Rosnabat,,,,29170
-7 Rue Saint-Gouesnou Gouesnou,,,,7 Rue Saint-Gouesnou,,,,29850
-7 Rue Saint-Gouesnou 29850,,,,7 Rue Saint-Gouesnou,,,Gouesnou,
-7 Rue Saint-Gouesnou,-4.466800,48.452416,,7 Rue Saint-Gouesnou,,,,29850
-16 Rue du Gymnase Guilvinec,,,,16 Rue du Gymnase,,,,29730
-16 Rue du Gymnase 29730,,,,16 Rue du Gymnase,,,Guilvinec,
-16 Rue du Gymnase,-4.282916,47.801967,,16 Rue du Gymnase,,,,29730
-9 Rue Louis Guilloux Guipavas,,,,9 Rue Louis Guilloux,,,,29490
-9 Rue Louis Guilloux 29490,,,,9 Rue Louis Guilloux,,,Guipavas,
-9 Rue Louis Guilloux,-4.431741,48.416497,,9 Rue Louis Guilloux,,,,29490
-3 Place de la Cale Île-Tudy,,,,3 Place de la Cale,,,,29980
-3 Place de la Cale 29980,,,,3 Place de la Cale,,,Île-Tudy,
-3 Place de la Cale,-4.169105,47.841136,,3 Place de la Cale,,,,29980
-1 Rue Anatole Le Braz Landerneau,,,,1 Rue Anatole Le Braz,,,,29800
-1 Rue Anatole Le Braz 29800,,,,1 Rue Anatole Le Braz,,,Landerneau,
-1 Rue Anatole Le Braz,-4.247649,48.454503,,1 Rue Anatole Le Braz,,,,29800
-32A Rue des Ecossais Landerneau,,,,32A Rue des Ecossais,,,,29800
-32A Rue des Ecossais 29800,,,,32A Rue des Ecossais,,,Landerneau,
-32A Rue des Ecossais,-4.235341,48.456678,,32A Rue des Ecossais,,,,29800
-3 Route de Poull-Menoc Landunvez,,,,3 Route de Poull-Menoc,,,,29840
-3 Route de Poull-Menoc 29840,,,,3 Route de Poull-Menoc,,,Landunvez,
-3 Route de Poull-Menoc,-4.720739,48.554438,,3 Route de Poull-Menoc,,,,29840
-12 Rue Alice Coudol Lesneven,,,,12 Rue Alice Coudol,,,,29260
-12 Rue Alice Coudol 29260,,,,12 Rue Alice Coudol,,,Lesneven,
-12 Rue Alice Coudol,-4.320257,48.566925,,12 Rue Alice Coudol,,,,29260
-10 Rue des Aubépines Locquirec,,,,10 Rue des Aubépines,,,,29241
-10 Rue des Aubépines 29241,,,,10 Rue des Aubépines,,,Locquirec,
-10 Rue des Aubépines,-3.666623,48.679845,,10 Rue des Aubépines,,,,29241
-10 Route du Moulin Mer Logonna-Daoulas,,,,10 Route du Moulin Mer,,,,29460
-10 Route du Moulin Mer 29460,,,,10 Route du Moulin Mer,,,Logonna-Daoulas,
-10 Route du Moulin Mer,-4.294897,48.319117,,10 Route du Moulin Mer,,,,29460
-32 Rue de Pont-ar-Laër Moëlan-sur-Mer,,,,32 Rue de Pont-ar-Laër,,,,29350
-32 Rue de Pont-ar-Laër 29350,,,,32 Rue de Pont-ar-Laër,,,Moëlan-sur-Mer,
-32 Rue de Pont-ar-Laër,-3.627645,47.808588,,32 Rue de Pont-ar-Laër,,,,29350
-3 Rue de Ty Dour Morlaix,,,,3 Rue de Ty Dour,,,,29600
-3 Rue de Ty Dour 29600,,,,3 Rue de Ty Dour,,,Morlaix,
-3 Rue de Ty Dour,-3.824510,48.586742,,3 Rue de Ty Dour,,,,29600
-456 Venelle de Quélourn Penmarc'h,,,,456 Venelle de Quélourn,,,,29760
-456 Venelle de Quélourn 29760,,,,456 Venelle de Quélourn,,,Penmarc'h,
-456 Venelle de Quélourn,-4.349843,47.814379,,456 Venelle de Quélourn,,,,29760
-2 Rue D'Argoat Pleyber-Christ,,,,2 Rue D'Argoat,,,,29410
-2 Rue D'Argoat 29410,,,,2 Rue D'Argoat,,,Pleyber-Christ,
-2 Rue D'Argoat,-3.876835,48.498599,,2 Rue D'Argoat,,,,29410
-24 Rue Mein Torret Plomeur,,,,24 Rue Mein Torret,,,,29120
-24 Rue Mein Torret 29120,,,,24 Rue Mein Torret,,,Plomeur,
-24 Rue Mein Torret,-4.286608,47.807693,,24 Rue Mein Torret,,,,29120
-2 Chemin des Amers Ploudalmézeau,,,,2 Chemin des Amers,,,,29830
-2 Chemin des Amers 29830,,,,2 Chemin des Amers,,,Ploudalmézeau,
-2 Chemin des Amers,-4.699781,48.565118,,2 Chemin des Amers,,,,29830
-23 Rue Charles Le Goffic Plouescat,,,,23 Rue Charles Le Goffic,,,,29430
-23 Rue Charles Le Goffic 29430,,,,23 Rue Charles Le Goffic,,,Plouescat,
-23 Rue Charles Le Goffic,-4.178039,48.658930,,23 Rue Charles Le Goffic,,,,29430
-59 Rue du Cléguer Plougastel-Daoulas,,,,59 Rue du Cléguer,,,,29470
-59 Rue du Cléguer 29470,,,,59 Rue du Cléguer,,,Plougastel-Daoulas,
-59 Rue du Cléguer,-4.376045,48.375103,,59 Rue du Cléguer,,,,29470
-24 Rossermeur Plougastel-Daoulas,,,,24 Rossermeur,,,,29470
-24 Rossermeur 29470,,,,24 Rossermeur,,,Plougastel-Daoulas,
-24 Rossermeur,-4.345761,48.349780,,24 Rossermeur,,,,29470
-10 Rue des Fusiliers Marins Plouhinec,,,,10 Rue des Fusiliers Marins,,,,29780
-10 Rue des Fusiliers Marins 29780,,,,10 Rue des Fusiliers Marins,,,Plouhinec,
-10 Rue des Fusiliers Marins,-4.528938,48.013286,,10 Rue des Fusiliers Marins,,,,29780
-529 Rue Saint-Pol Plounéour-Trez,,,,529 Rue Saint-Pol,,,,29890
-529 Rue Saint-Pol 29890,,,,529 Rue Saint-Pol,,,,29890
-529 Rue Saint-Pol,-4.318770,48.651117,,529 Rue Saint-Pol,,,,29890
-7 Allée des Cèdres Plouzané,,,,7 Allée des Cèdres,,,,29280
-7 Allée des Cèdres 29280,,,,7 Allée des Cèdres,,,Plouzané,
-7 Allée des Cèdres,-4.586258,48.375167,,7 Allée des Cèdres,,,,29280
-17BIS RTE DE LEZAVREC Plozévet,,,,17BIS RTE DE LEZAVREC,,,,29710
-17BIS RTE DE LEZAVREC 29710,,,,17BIS RTE DE LEZAVREC,,,Plozévet,
-17BIS RTE DE LEZAVREC,-4.407623,47.973885,,17BIS RTE DE LEZAVREC,,,,29710
-31 Rue Jean Moulin Pont-l'Abbé,,,,31 Rue Jean Moulin,,,,29120
-31 Rue Jean Moulin 29120,,,,31 Rue Jean Moulin,,,Pont-l'Abbé,
-31 Rue Jean Moulin,-4.231055,47.864381,,31 Rue Jean Moulin,,,,29120
-5 Rue Saint-Laurent Quéménéven,,,,5 Rue Saint-Laurent,,,,29180
-5 Rue Saint-Laurent 29180,,,,5 Rue Saint-Laurent,,,Quéménéven,
-5 Rue Saint-Laurent,-4.120979,48.115701,,5 Rue Saint-Laurent,,,,29180
-16 Rue des Douves Quimper,,,,16 Rue des Douves,,,,29000
-16 Rue des Douves 29000,,,,16 Rue des Douves,,,Quimper,
-16 Rue des Douves,-4.101930,47.998592,,16 Rue des Douves,,,,29000
-21 Allée Joséphine Pencalet Quimper,,,,21 Allée Joséphine Pencalet,,,,29000
-21 Allée Joséphine Pencalet 29000,,,,21 Allée Joséphine Pencalet,,,Quimper,
-21 Allée Joséphine Pencalet,-4.132122,47.976205,,21 Allée Joséphine Pencalet,,,,29000
-21 Rue Montaigne Quimper,,,,21 Rue Montaigne,,,,29000
-21 Rue Montaigne 29000,,,,21 Rue Montaigne,,,Quimper,
-21 Rue Montaigne,-4.101233,47.984264,,21 Rue Montaigne,,,,29000
-23 Rue du Sallé Quimper,,,,23 Rue du Sallé,,,,29000
-23 Rue du Sallé 29000,,,,23 Rue du Sallé,,,Quimper,
-23 Rue du Sallé,-4.103760,47.996656,,23 Rue du Sallé,,,,29000
-7 Rue Kerguelen Quimperlé,,,,7 Rue Kerguelen,,,,29300
-7 Rue Kerguelen 29300,,,,7 Rue Kerguelen,,,Quimperlé,
-7 Rue Kerguelen,-3.553074,47.877299,,7 Rue Kerguelen,,,,29300
-211 Rue des Hauts de Kerhorres Le Relecq-Kerhuon,,,,211 Rue des Hauts de Kerhorres,,,,29480
-211 Rue des Hauts de Kerhorres 29480,,,,211 Rue des Hauts de Kerhorres,,,Le Relecq-Kerhuon,
-211 Rue des Hauts de Kerhorres,-4.390051,48.408666,,211 Rue des Hauts de Kerhorres,,,,29480
-42 Rue Peisey Nancroix Roscanvel,,,,42 Rue Peisey Nancroix,,,,29570
-42 Rue Peisey Nancroix 29570,,,,42 Rue Peisey Nancroix,,,Roscanvel,
-42 Rue Peisey Nancroix,-4.547880,48.321216,,42 Rue Peisey Nancroix,,,,29570
-3 Place de l'Église Saint-Évarzec,,,,3 Place de l'Église,,,,29170
-3 Place de l'Église 29170,,,,3 Place de l'Église,,,Saint-Évarzec,
-3 Place de l'Église,-4.020776,47.936276,,3 Place de l'Église,,,,29170
-26 Rue de Ty Arvor Saint-Pabu,,,,26 Rue de Ty Arvor,,,,29830
-26 Rue de Ty Arvor 29830,,,,26 Rue de Ty Arvor,,,Saint-Pabu,
-26 Rue de Ty Arvor,-4.627485,48.570215,,26 Rue de Ty Arvor,,,,29830
-41 Rue des Vosges Saint-Renan,,,,41 Rue des Vosges,,,,29290
-41 Rue des Vosges 29290,,,,41 Rue des Vosges,,,Saint-Renan,
-41 Rue des Vosges,-4.636641,48.433739,,41 Rue des Vosges,,,,29290
-9 RUE LEON BLUM Scaër,,,,9 RUE LEON BLUM,,,,29390
-9 RUE LEON BLUM 29390,,,,9 RUE LEON BLUM,,,Scaër,
-9 RUE LEON BLUM,-3.700026,48.022873,,9 RUE LEON BLUM,,,,29390
-26 Rue Saint Jacques Treffiagat,,,,26 Rue Saint Jacques,,,,29730
-26 Rue Saint Jacques 29730,,,,26 Rue Saint Jacques,,,Treffiagat,
-26 Rue Saint Jacques,-4.273025,47.794064,,26 Rue Saint Jacques,,,,29730
-11 Rue Éric Tabarly Pont-de-Buis-lès-Quimerch,,,,11 Rue Éric Tabarly,,,,29590
-11 Rue Éric Tabarly 29590,,,,11 Rue Éric Tabarly,,,Pont-de-Buis-lès-Quimerch,
-11 Rue Éric Tabarly,-4.083466,48.248724,,11 Rue Éric Tabarly,,,,29590
-6 Allée de l'Europe Bain-de-Bretagne,,,,6 Allée de l'Europe,,,,35470
-6 Allée de l'Europe 35470,,,,6 Allée de l'Europe,,,Bain-de-Bretagne,
-6 Allée de l'Europe,-1.685310,47.849196,,6 Allée de l'Europe,,,,35470
-5 Rue Châteaubriand Bédée,,,,5 Rue Châteaubriand,,,,35137
-5 Rue Châteaubriand 35137,,,,5 Rue Châteaubriand,,,Bédée,
-5 Rue Châteaubriand,-1.947428,48.181676,,5 Rue Châteaubriand,,,,35137
-8 Rue de Bréhat La Bouëxière,,,,8 Rue de Bréhat,,,,35340
-8 Rue de Bréhat 35340,,,,8 Rue de Bréhat,,,La Bouëxière,
-8 Rue de Bréhat,-1.439885,48.185437,,8 Rue de Bréhat,,,,35340
-11 Rue du Houx Breteil,,,,11 Rue du Houx,,,,35160
-11 Rue du Houx 35160,,,,11 Rue du Houx,,,Breteil,
-11 Rue du Houx,-1.902950,48.145552,,11 Rue du Houx,,,,35160
-28 Rue Théodore Botrel Bruz,,,,28 Rue Théodore Botrel,,,,35170
-28 Rue Théodore Botrel 35170,,,,28 Rue Théodore Botrel,,,Bruz,
-28 Rue Théodore Botrel,-1.741993,48.021820,,28 Rue Théodore Botrel,,,,35170
-33 Rue du Couradin Cesson-Sévigné,,,,33 Rue du Couradin,,,,35510
-33 Rue du Couradin 35510,,,,33 Rue du Couradin,,,Cesson-Sévigné,
-33 Rue du Couradin,-1.606872,48.127294,,33 Rue du Couradin,,,,35510
-1 Allée des Genêts Chantepie,,,,1 Allée des Genêts,,,,35135
-1 Allée des Genêts 35135,,,,1 Allée des Genêts,,,Chantepie,
-1 Allée des Genêts,-1.614846,48.082779,,1 Allée des Genêts,,,,35135
-3 Rue d'Armorique Chartres-de-Bretagne,,,,3 Rue d'Armorique,,,,35131
-3 Rue d'Armorique 35131,,,,3 Rue d'Armorique,,,Chartres-de-Bretagne,
-3 Rue d'Armorique,-1.706048,48.036645,,3 Rue d'Armorique,,,,35131
-4 Rue Leprestre de Lézonnet Châteaugiron,,,,4 Rue Leprestre de Lézonnet,,,,35410
-4 Rue Leprestre de Lézonnet 35410,,,,4 Rue Leprestre de Lézonnet,,,Châteaugiron,
-4 Rue Leprestre de Lézonnet,-1.503453,48.049784,,4 Rue Leprestre de Lézonnet,,,,35410
-6 Rue Berthe Morisot Cintré,,,,6 Rue Berthe Morisot,,,,35310
-6 Rue Berthe Morisot 35310,,,,6 Rue Berthe Morisot,,,Cintré,
-6 Rue Berthe Morisot,-1.875814,48.101999,,6 Rue Berthe Morisot,,,,35310
-10 Impasse Chauchat Dinard,,,,10 Impasse Chauchat,,,,35800
-10 Impasse Chauchat 35800,,,,10 Impasse Chauchat,,,Dinard,
-10 Impasse Chauchat,-2.060471,48.633501,,10 Impasse Chauchat,,,,35800
-3 Rue du Clos Lupin Dol-de-Bretagne,,,,3 Rue du Clos Lupin,,,,35120
-3 Rue du Clos Lupin 35120,,,,3 Rue du Clos Lupin,,,Dol-de-Bretagne,
-3 Rue du Clos Lupin,-1.743187,48.546469,,3 Rue du Clos Lupin,,,,35120
-1 Rue de la Champagne Étrelles,,,,1 Rue de la Champagne,,,,35370
-1 Rue de la Champagne 35370,,,,1 Rue de la Champagne,,,Étrelles,
-1 Rue de la Champagne,-1.197284,48.057428,,1 Rue de la Champagne,,,,35370
-13 Rue du Père Maunoir Fougères,,,,13 Rue du Père Maunoir,,,,35300
-13 Rue du Père Maunoir 35300,,,,13 Rue du Père Maunoir,,,Fougères,
-13 Rue du Père Maunoir,-1.190344,48.351868,,13 Rue du Père Maunoir,,,,35300
-3 Rue Simone Veil Gévezé,,,,3 Rue Simone Veil,,,,35850
-3 Rue Simone Veil 35850,,,,3 Rue Simone Veil,,,Gévezé,
-3 Rue Simone Veil,-1.804097,48.224109,,3 Rue Simone Veil,,,,35850
-32 Rue du Maréchal de Lattre de Tassigny Guichen,,,,32 Rue du Maréchal de Lattre de Tassigny,,,,35580
-32 Rue du Maréchal de Lattre de Tassigny 35580,,,,32 Rue du Maréchal de Lattre de Tassigny,,,Guichen,
-32 Rue du Maréchal de Lattre de Tassigny,-1.794726,47.974108,,32 Rue du Maréchal de Lattre de Tassigny,,,,35580
-1 Impasse des Bruyères Irodouër,,,,1 Impasse des Bruyères,,,,35850
-1 Impasse des Bruyères 35850,,,,1 Impasse des Bruyères,,,Irodouër,
-1 Impasse des Bruyères,-1.950843,48.244717,,1 Impasse des Bruyères,,,,35850
-8 le Ruel Laillé,,,,8 le Ruel,,,,35890
-8 le Ruel 35890,,,,8 le Ruel,,,Laillé,
-8 le Ruel,-1.714623,48.001487,,8 le Ruel,,,,35890
-12 Allée des Sternes Liffré,,,,12 Allée des Sternes,,,,35340
-12 Allée des Sternes 35340,,,,12 Allée des Sternes,,,Liffré,
-12 Allée des Sternes,-1.513746,48.208444,,12 Allée des Sternes,,,,35340
-12 Rue de Dinan Médréac,,,,12 Rue de Dinan,,,,35360
-12 Rue de Dinan 35360,,,,12 Rue de Dinan,,,Médréac,
-12 Rue de Dinan,-2.066663,48.268468,,12 Rue de Dinan,,,,35360
-5 la Pommardière Miniac-sous-Bécherel,,,,5 la Pommardière,,,,35190
-5 la Pommardière 35190,,,,5 la Pommardière,,,Miniac-sous-Bécherel,
-5 la Pommardière,-1.921621,48.300397,,5 la Pommardière,,,,35190
-27B Rue de la Rébunière Montgermont,,,,27B Rue de la Rébunière,,,,35760
-27B Rue de la Rébunière 35760,,,,27B Rue de la Rébunière,,,Montgermont,
-27B Rue de la Rébunière,-1.723916,48.162736,,27B Rue de la Rébunière,,,,35760
-8 Rue Paul Verlaine Nouvoitou,,,,8 Rue Paul Verlaine,,,,35410
-8 Rue Paul Verlaine 35410,,,,8 Rue Paul Verlaine,,,Nouvoitou,
-8 Rue Paul Verlaine,-1.552305,48.039910,,8 Rue Paul Verlaine,,,,35410
-51 la Rochelle Orgères,,,,51 la Rochelle,,,,35230
-51 la Rochelle 35230,,,,51 la Rochelle,,,Orgères,
-51 la Rochelle,-1.653896,47.983919,,51 la Rochelle,,,,35230
-114 Le Vil Le Petit-Fougeray,,,,114 Le Vil,,,,35320
-114 Le Vil 35320,,,,114 Le Vil,,,Le Petit-Fougeray,
-114 Le Vil,-1.605625,47.921359,,114 Le Vil,,,,35320
-2E Rue de l'Aéroport Pleurtuit,,,,2E Rue de l'Aéroport,,,,35730
-2E Rue de l'Aéroport 35730,,,,2E Rue de l'Aéroport,,,Pleurtuit,
-2E Rue de l'Aéroport,-2.059630,48.584326,,2E Rue de l'Aéroport,,,,35730
-8 Rue des Lièvries Redon,,,,8 Rue des Lièvries,,,,35600
-8 Rue des Lièvries 35600,,,,8 Rue des Lièvries,,,Redon,
-8 Rue des Lièvries,-2.087540,47.655778,,8 Rue des Lièvries,,,,35600
-4 Allée Bernard Josse Rennes,,,,4 Allée Bernard Josse,,,,35000
-4 Allée Bernard Josse 35000,,,,4 Allée Bernard Josse,,,Rennes,
-4 Allée Bernard Josse,-1.691285,48.099290,,4 Allée Bernard Josse,,,,35000
-8 Rue du Docteur Regnault Rennes,,,,8 Rue du Docteur Regnault,,,,35000
-8 Rue du Docteur Regnault 35000,,,,8 Rue du Docteur Regnault,,,Rennes,
-8 Rue du Docteur Regnault,-1.675601,48.111663,,8 Rue du Docteur Regnault,,,,35000
-9 Rue Hamon Rennes,,,,9 Rue Hamon,,,,35000
-9 Rue Hamon 35000,,,,9 Rue Hamon,,,Rennes,
-9 Rue Hamon,-1.703077,48.113379,,9 Rue Hamon,,,,35000
-8 Rue Louis Blériot Rennes,,,,8 Rue Louis Blériot,,,,35000
-8 Rue Louis Blériot 35000,,,,8 Rue Louis Blériot,,,Rennes,
-8 Rue Louis Blériot,-1.678040,48.101790,,8 Rue Louis Blériot,,,,35000
-5 Rue Philippe Nordmann Rennes,,,,5 Rue Philippe Nordmann,,,,35000
-5 Rue Philippe Nordmann 35000,,,,5 Rue Philippe Nordmann,,,Rennes,
-5 Rue Philippe Nordmann,-1.657406,48.107582,,5 Rue Philippe Nordmann,,,,35000
-28 Avenue Sir Winston Churchill Rennes,,,,28 Avenue Sir Winston Churchill,,,,35000
-28 Avenue Sir Winston Churchill 35000,,,,28 Avenue Sir Winston Churchill,,,Rennes,
-28 Avenue Sir Winston Churchill,-1.708682,48.122861,,28 Avenue Sir Winston Churchill,,,,35000
-7 Rue de la Haie de Terre Le Rheu,,,,7 Rue de la Haie de Terre,,,,35650
-7 Rue de la Haie de Terre 35650,,,,7 Rue de la Haie de Terre,,,Le Rheu,
-7 Rue de la Haie de Terre,-1.785236,48.095231,,7 Rue de la Haie de Terre,,,,35650
-17 Rue de Rennes Saint-Aubin-d'Aubigné,,,,17 Rue de Rennes,,,,35250
-17 Rue de Rennes 35250,,,,17 Rue de Rennes,,,Saint-Aubin-d'Aubigné,
-17 Rue de Rennes,-1.606008,48.261010,,17 Rue de Rennes,,,,35250
-16 Rue de l'Orme Saint-Broladre,,,,16 Rue de l'Orme,,,,35120
-16 Rue de l'Orme 35120,,,,16 Rue de l'Orme,,,Saint-Broladre,
-16 Rue de l'Orme,-1.661524,48.584266,,16 Rue de l'Orme,,,,35120
-3 Rue Alphonse Milon Saint-Grégoire,,,,3 Rue Alphonse Milon,,,,35760
-3 Rue Alphonse Milon 35760,,,,3 Rue Alphonse Milon,,,Saint-Grégoire,
-3 Rue Alphonse Milon,-1.684788,48.152535,,3 Rue Alphonse Milon,,,,35760
-33 Rue Pierre Brossolette Saint-Jacques-de-la-Lande,,,,33 Rue Pierre Brossolette,,,,35136
-33 Rue Pierre Brossolette 35136,,,,33 Rue Pierre Brossolette,,,Saint-Jacques-de-la-Lande,
-33 Rue Pierre Brossolette,-1.694338,48.091726,,33 Rue Pierre Brossolette,,,,35136
-16 Rue du Chanoine Édouard Lainé Saint-Malo,,,,16 Rue du Chanoine Édouard Lainé,,,,35400
-16 Rue du Chanoine Édouard Lainé 35400,,,,16 Rue du Chanoine Édouard Lainé,,,Saint-Malo,
-16 Rue du Chanoine Édouard Lainé,-1.996150,48.656199,,16 Rue du Chanoine Édouard Lainé,,,,35400
-29 Avenue du Président John Kennedy Saint-Malo,,,,29 Avenue du Président John Kennedy,,,,35400
-29 Avenue du Président John Kennedy 35400,,,,29 Avenue du Président John Kennedy,,,Saint-Malo,
-29 Avenue du Président John Kennedy,-1.987465,48.665875,,29 Avenue du Président John Kennedy,,,,35400
-1 Chaussée du Sillon Saint-Malo,,,,1 Chaussée du Sillon,,,,35400
-1 Chaussée du Sillon 35400,,,,1 Chaussée du Sillon,,,Saint-Malo,
-1 Chaussée du Sillon,-2.009486,48.654209,,1 Chaussée du Sillon,,,,35400
-18 Rue Saint-Georges Saint-Père,,,,18 Rue Saint-Georges,,,,35430
-18 Rue Saint-Georges 35430,,,,18 Rue Saint-Georges,,,Saint-Père,
-18 Rue Saint-Georges,-1.940984,48.579598,,18 Rue Saint-Georges,,,,35430
-5 Rue de Brocéliande Sixt-sur-Aff,,,,5 Rue de Brocéliande,,,,35550
-5 Rue de Brocéliande 35550,,,,5 Rue de Brocéliande,,,Sixt-sur-Aff,
-5 Rue de Brocéliande,-2.080183,47.773913,,5 Rue de Brocéliande,,,,35550
-3 Rue Xavier Grall Tinténiac,,,,3 Rue Xavier Grall,,,,35190
-3 Rue Xavier Grall 35190,,,,3 Rue Xavier Grall,,,Tinténiac,
-3 Rue Xavier Grall,-1.840169,48.332720,,3 Rue Xavier Grall,,,,35190
-5 les Ponts Poiriers Vern-sur-Seiche,,,,5 les Ponts Poiriers,,,,35770
-5 les Ponts Poiriers 35770,,,,5 les Ponts Poiriers,,,Vern-sur-Seiche,
-5 les Ponts Poiriers,-1.624988,48.069700,,5 les Ponts Poiriers,,,,35770
-139 Boulevard de Laval Vitré,,,,139 Boulevard de Laval,,,,35500
-139 Boulevard de Laval 35500,,,,139 Boulevard de Laval,,,Vitré,
-139 Boulevard de Laval,-1.187754,48.122264,,139 Boulevard de Laval,,,,35500
-6 Rue de la Pte de Kerners Arzon,,,,6 Rue de la Pte de Kerners,,,,56640
-6 Rue de la Pte de Kerners 56640,,,,6 Rue de la Pte de Kerners,,,Arzon,
-6 Rue de la Pte de Kerners,-2.880081,47.555487,,6 Rue de la Pte de Kerners,,,,56640
-20 Rue An Alre Baden,,,,20 Rue An Alre,,,,56870
-20 Rue An Alre 56870,,,,20 Rue An Alre,,,Baden,
-20 Rue An Alre,-2.922821,47.622552,,20 Rue An Alre,,,,56870
-20 Rue de Manegroven Belz,,,,20 Rue de Manegroven,,,,56550
-20 Rue de Manegroven 56550,,,,20 Rue de Manegroven,,,Belz,
-20 Rue de Manegroven,-3.184733,47.680799,,20 Rue de Manegroven,,,,56550
-14 Rue Jean de Beaumanoir Bréhan,,,,14 Rue Jean de Beaumanoir,,,,56580
-14 Rue Jean de Beaumanoir 56580,,,,14 Rue Jean de Beaumanoir,,,Bréhan,
-14 Rue Jean de Beaumanoir,-2.687628,48.059786,,14 Rue Jean de Beaumanoir,,,,56580
-6 Impasse des Goémons Carnac,,,,6 Impasse des Goémons,,,,56340
-6 Impasse des Goémons 56340,,,,6 Impasse des Goémons,,,Carnac,
-6 Impasse des Goémons,-3.056878,47.577451,,6 Impasse des Goémons,,,,56340
-13 Rue Boquelen Cléguérec,,,,13 Rue Boquelen,,,,56480
-13 Rue Boquelen 56480,,,,13 Rue Boquelen,,,Cléguérec,
-13 Rue Boquelen,-3.006142,48.091749,,13 Rue Boquelen,,,,56480
-6 Rue du Meunier Damgan,,,,6 Rue du Meunier,,,,56750
-6 Rue du Meunier 56750,,,,6 Rue du Meunier,,,Damgan,
-6 Rue du Meunier,-2.585269,47.520248,,6 Rue du Meunier,,,,56750
-9 Rue du Champ Vert Le Faouët,,,,9 Rue du Champ Vert,,,,56320
-9 Rue du Champ Vert 56320,,,,9 Rue du Champ Vert,,,Le Faouët,
-9 Rue du Champ Vert,-3.486882,48.034917,,9 Rue du Champ Vert,,,,56320
-16 Rue Jean Louis Kergaravat Gourin,,,,16 Rue Jean Louis Kergaravat,,,,56110
-16 Rue Jean Louis Kergaravat 56110,,,,16 Rue Jean Louis Kergaravat,,,Gourin,
-16 Rue Jean Louis Kergaravat,-3.609035,48.138322,,16 Rue Jean Louis Kergaravat,,,,56110
-38BIS Route de la Ruézie Guer,,,,38BIS Route de la Ruézie,,,,56380
-38BIS Route de la Ruézie 56380,,,,38BIS Route de la Ruézie,,,Guer,
-38BIS Route de la Ruézie,-2.126470,47.951612,,38BIS Route de la Ruézie,,,,56380
-5 Rue Marie-Anne Collot Hennebont,,,,5 Rue Marie-Anne Collot,,,,56700
-5 Rue Marie-Anne Collot 56700,,,,5 Rue Marie-Anne Collot,,,Hennebont,
-5 Rue Marie-Anne Collot,-3.247926,47.816511,,5 Rue Marie-Anne Collot,,,,56700
-8 Rue Arthur Rimbaud Inzinzac-Lochrist,,,,8 Rue Arthur Rimbaud,,,,56650
-8 Rue Arthur Rimbaud 56650,,,,8 Rue Arthur Rimbaud,,,Inzinzac-Lochrist,
-8 Rue Arthur Rimbaud,-3.263289,47.824413,,8 Rue Arthur Rimbaud,,,,56650
-2 Rue Adolphe Beaufrere Lanester,,,,2 Rue Adolphe Beaufrere,,,,56600
-2 Rue Adolphe Beaufrere 56600,,,,2 Rue Adolphe Beaufrere,,,Lanester,
-2 Rue Adolphe Beaufrere,-3.329200,47.762099,,2 Rue Adolphe Beaufrere,,,,56600
-1 Rue de la Paix Lanester,,,,1 Rue de la Paix,,,,56600
-1 Rue de la Paix 56600,,,,1 Rue de la Paix,,,Lanester,
-1 Rue de la Paix,-3.341975,47.757099,,1 Rue de la Paix,,,,56600
-46 Rue des Fleurs Larmor-Plage,,,,46 Rue des Fleurs,,,,56260
-46 Rue des Fleurs 56260,,,,46 Rue des Fleurs,,,Larmor-Plage,
-46 Rue des Fleurs,-3.377173,47.713411,,46 Rue des Fleurs,,,,56260
-7 Rue Ernest Renan Locminé,,,,7 Rue Ernest Renan,,,,56500
-7 Rue Ernest Renan 56500,,,,7 Rue Ernest Renan,,,Locminé,
-7 Rue Ernest Renan,-2.831214,47.891179,,7 Rue Ernest Renan,,,,56500
-5 Impasse Berthe Morisot Lorient,,,,5 Impasse Berthe Morisot,,,,56100
-5 Impasse Berthe Morisot 56100,,,,5 Impasse Berthe Morisot,,,Lorient,
-5 Impasse Berthe Morisot,-3.382847,47.761769,,5 Impasse Berthe Morisot,,,,56100
-9 Rue Jules Le Grand Lorient,,,,9 Rue Jules Le Grand,,,,56100
-9 Rue Jules Le Grand 56100,,,,9 Rue Jules Le Grand,,,Lorient,
-9 Rue Jules Le Grand,-3.359382,47.750646,,9 Rue Jules Le Grand,,,,56100
-8 Rue Roger Le Bloa Lorient,,,,8 Rue Roger Le Bloa,,,,56100
-8 Rue Roger Le Bloa 56100,,,,8 Rue Roger Le Bloa,,,Lorient,
-8 Rue Roger Le Bloa,-3.377312,47.755901,,8 Rue Roger Le Bloa,,,,56100
-18 Rue d'Armor Ménéac,,,,18 Rue d'Armor,,,,56490
-18 Rue d'Armor 56490,,,,18 Rue d'Armor,,,Ménéac,
-18 Rue d'Armor,-2.458412,48.141601,,18 Rue d'Armor,,,,56490
-7 Rue des Lavandières Muzillac,,,,7 Rue des Lavandières,,,,56190
-7 Rue des Lavandières 56190,,,,7 Rue des Lavandières,,,Muzillac,
-7 Rue des Lavandières,-2.487385,47.553834,,7 Rue des Lavandières,,,,56190
-736 Impasse Landrin Pénestin,,,,736 Impasse Landrin,,,,56760
-736 Impasse Landrin 56760,,,,736 Impasse Landrin,,,Pénestin,
-736 Impasse Landrin,-2.483480,47.467474,,736 Impasse Landrin,,,,56760
-16 Rue du Docteur Laënnec Ploemeur,,,,16 Rue du Docteur Laënnec,,,,56270
-16 Rue du Docteur Laënnec 56270,,,,16 Rue du Docteur Laënnec,,,Ploemeur,
-16 Rue du Docteur Laënnec,-3.402496,47.741704,,16 Rue du Docteur Laënnec,,,,56270
-3 Rue de la Bellevue Ploërdut,,,,3 Rue de la Bellevue,,,,56160
-3 Rue de la Bellevue 56160,,,,3 Rue de la Bellevue,,,Ploërdut,
-3 Rue de la Bellevue,-3.282802,48.088320,,3 Rue de la Bellevue,,,,56160
-87 Rue du Val Ploërmel,,,,87 Rue du Val,,,,56800
-87 Rue du Val 56800,,,,87 Rue du Val,,,Ploërmel,
-87 Rue du Val,-2.398261,47.938237,,87 Rue du Val,,,,56800
-3 Rue du Clos du pré Pluherlin,,,,3 Rue du Clos du pré,,,,56220
-3 Rue du Clos du pré 56220,,,,3 Rue du Clos du pré,,,Pluherlin,
-3 Rue du Clos du pré,-2.359453,47.695888,,3 Rue du Clos du pré,,,,56220
-12 Place du Marché Pluvigner,,,,12 Place du Marché,,,,56330
-12 Place du Marché 56330,,,,12 Place du Marché,,,Pluvigner,
-12 Place du Marché,-3.010056,47.775239,,12 Place du Marché,,,,56330
-5 Rue du Paradis Pontivy,,,,5 Rue du Paradis,,,,56300
-5 Rue du Paradis 56300,,,,5 Rue du Paradis,,,Pontivy,
-5 Rue du Paradis,-2.964661,48.067146,,5 Rue du Paradis,,,,56300
-1 Impasse de la Forge Questembert,,,,1 Impasse de la Forge,,,,56230
-1 Impasse de la Forge 56230,,,,1 Impasse de la Forge,,,Questembert,
-1 Impasse de la Forge,-2.465397,47.641671,,1 Impasse de la Forge,,,,56230
-25 Rue de la Croix Quiberon,,,,25 Rue de la Croix,,,,56170
-25 Rue de la Croix 56170,,,,25 Rue de la Croix,,,Quiberon,
-25 Rue de la Croix,-3.120270,47.494272,,25 Rue de la Croix,,,,56170
-2 Rue Abbe Alain Le Blevec Riantec,,,,2 Rue Abbe Alain Le Blevec,,,,56670
-2 Rue Abbe Alain Le Blevec 56670,,,,2 Rue Abbe Alain Le Blevec,,,Riantec,
-2 Rue Abbe Alain Le Blevec,-3.306785,47.713507,,2 Rue Abbe Alain Le Blevec,,,,56670
-21 Rue Charles Péguy Saint-Avé,,,,21 Rue Charles Péguy,,,,56890
-21 Rue Charles Péguy 56890,,,,21 Rue Charles Péguy,,,Saint-Avé,
-21 Rue Charles Péguy,-2.762742,47.680755,,21 Rue Charles Péguy,,,,56890
-81 Route du Cossay Saint-Gildas-de-Rhuys,,,,81 Route du Cossay,,,,56730
-81 Route du Cossay 56730,,,,81 Route du Cossay,,,Saint-Gildas-de-Rhuys,
-81 Route du Cossay,-2.803974,47.491268,,81 Route du Cossay,,,,56730
-36 Résidence Beau Soleil Saint-Nolff,,,,36 Résidence Beau Soleil,,,,56250
-36 Résidence Beau Soleil 56250,,,,36 Résidence Beau Soleil,,,Saint-Nolff,
-36 Résidence Beau Soleil,-2.680819,47.697673,,36 Résidence Beau Soleil,,,,56250
-5 Rue de la Cote Sarzeau,,,,5 Rue de la Cote,,,,56370
-5 Rue de la Cote 56370,,,,5 Rue de la Cote,,,Sarzeau,
-5 Rue de la Cote,-2.779327,47.497753,,5 Rue de la Cote,,,,56370
-25 Chemin de Bindre Séné,,,,25 Chemin de Bindre,,,,56860
-25 Chemin de Bindre 56860,,,,25 Chemin de Bindre,,,Séné,
-25 Chemin de Bindre,-2.717768,47.632136,,25 Chemin de Bindre,,,,56860
-24 Résidence Jean Monnet Sulniac,,,,24 Résidence Jean Monnet,,,,56250
-24 Résidence Jean Monnet 56250,,,,24 Résidence Jean Monnet,,,Sulniac,
-24 Résidence Jean Monnet,-2.572650,47.673721,,24 Résidence Jean Monnet,,,,56250
-16 Rue de la Libération Trédion,,,,16 Rue de la Libération,,,,56250
-16 Rue de la Libération 56250,,,,16 Rue de la Libération,,,Trédion,
-16 Rue de la Libération,-2.592773,47.791914,,16 Rue de la Libération,,,,56250
-3 Allée du Couëdic Vannes,,,,3 Allée du Couëdic,,,,56000
-3 Allée du Couëdic 56000,,,,3 Allée du Couëdic,,,Vannes,
-3 Allée du Couëdic,-2.727410,47.661763,,3 Allée du Couëdic,,,,56000
-69 Avenue de la Marne Vannes,,,,69 Avenue de la Marne,,,,56000
-69 Avenue de la Marne 56000,,,,69 Avenue de la Marne,,,Vannes,
-69 Avenue de la Marne,-2.779573,47.659461,,69 Avenue de la Marne,,,,56000
-23 Rue Edouard Herriot Bono,,,,23 Rue Edouard Herriot,,,,56400
-23 Rue Edouard Herriot 56400,,,,23 Rue Edouard Herriot,,,Bono,
-23 Rue Edouard Herriot,-2.945260,47.636698,,23 Rue Edouard Herriot,,,,56400
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+6 Sentier des Briandais Bobital,,,,6,Sentier des Briandais,,22100
+6 Sentier des Briandais 22100,,,,6,Sentier des Briandais,Bobital,
+6 Sentier des Briandais,-2.103385,48.413152,,6,Sentier des Briandais,,22100
+16 Résidence des Chênes Caulnes,,,,16,Résidence des Chênes,,22350
+16 Résidence des Chênes 22350,,,,16,Résidence des Chênes,Caulnes,
+16 Résidence des Chênes,-2.149973,48.291864,,16,Résidence des Chênes,,22350
+8 Place Duguesclin Dinan,,,,8,Place Duguesclin,,22100
+8 Place Duguesclin 22100,,,,8,Place Duguesclin,Dinan,
+8 Place Duguesclin,-2.043671,48.450922,,8,Place Duguesclin,,22100
+32 Rue de la Mare Ès Loups Erquy,,,,32,Rue de la Mare Ès Loups,,22430
+32 Rue de la Mare Ès Loups 22430,,,,32,Rue de la Mare Ès Loups,Erquy,
+32 Rue de la Mare Ès Loups,-2.449201,48.628913,,32,Rue de la Mare Ès Loups,,22430
+11 Route Kerjaffray Gouarec,,,,11,Route Kerjaffray,,22570
+11 Route Kerjaffray 22570,,,,11,Route Kerjaffray,Gouarec,
+11 Route Kerjaffray,-3.193388,48.228382,,11,Route Kerjaffray,,22570
+1 Rue du Gen de Gaulle Hémonstoir,,,,1,Rue du Gen de Gaulle,,22600
+1 Rue du Gen de Gaulle 22600,,,,1,Rue du Gen de Gaulle,Hémonstoir,
+1 Rue du Gen de Gaulle,-2.83012,48.159337,,1,Rue du Gen de Gaulle,,22600
+24 Rue des Clossiaux Maroue Lamballe,,,,24,Rue des Clossiaux Maroue,,22400
+24 Rue des Clossiaux Maroue 22400,,,,24,Rue des Clossiaux Maroue,Lamballe,
+24 Rue des Clossiaux Maroue,-2.507481,48.461821,,24,Rue des Clossiaux Maroue,,22400
+13 Rue du Sabre Lancieux,,,,13,Rue du Sabre,,22770
+13 Rue du Sabre 22770,,,,13,Rue du Sabre,Lancieux,
+13 Rue du Sabre,-2.142685,48.589369,,13,Rue du Sabre,,22770
+21 Impasse Hent Dall de Kerlabia Lanloup,,,,21,Impasse Hent Dall de Kerlabia,,22580
+21 Impasse Hent Dall de Kerlabia 22580,,,,21,Impasse Hent Dall de Kerlabia,Lanloup,
+21 Impasse Hent Dall de Kerlabia,-2.964631,48.711541,,21,Impasse Hent Dall de Kerlabia,,22580
+18 Rue René Laënnec Lannion,,,,18,Rue René Laënnec,,22300
+18 Rue René Laënnec 22300,,,,18,Rue René Laënnec,Lannion,
+18 Rue René Laënnec,-3.459777,48.739303,,18,Rue René Laënnec,,22300
+2 Avenue de l'Echapt Léhon,,,,2,Avenue de l'Echapt,,22100
+2 Avenue de l'Echapt 22100,,,,2,Avenue de l'Echapt,Léhon,
+2 Avenue de l'Echapt,-2.049523,48.439123,,2,Avenue de l'Echapt,,22100
+18 Rue Neuve Loudéac,,,,18,Rue Neuve,,22600
+18 Rue Neuve 22600,,,,18,Rue Neuve,Loudéac,
+18 Rue Neuve,-2.752705,48.177182,,18,Rue Neuve,,22600
+4 Rue des Epinais La Motte,,,,4,Rue des Epinais,,22600
+4 Rue des Epinais 22600,,,,4,Rue des Epinais,La Motte,
+4 Rue des Epinais,-2.731693,48.232805,,4,Rue des Epinais,,22600
+48 Rue François Le Louarn Paimpol,,,,48,Rue François Le Louarn,,22500
+48 Rue François Le Louarn 22500,,,,48,Rue François Le Louarn,Paimpol,
+48 Rue François Le Louarn,-2.997629,48.754377,,48,Rue François Le Louarn,,22500
+52 Rue des Frères Le Montréer Perros-Guirec,,,,52,Rue des Frères Le Montréer,,22700
+52 Rue des Frères Le Montréer 22700,,,,52,Rue des Frères Le Montréer,Perros-Guirec,
+52 Rue des Frères Le Montréer,-3.448811,48.812851,,52,Rue des Frères Le Montréer,,22700
+18 Les Aires Blanches Plancoët,,,,18,Les Aires Blanches,,22130
+18 Les Aires Blanches 22130,,,,18,Les Aires Blanches,Plancoët,
+18 Les Aires Blanches,-2.238056,48.520394,,18,Les Aires Blanches,,22130
+3 Rue Hent Coz Plélauff,,,,3,Rue Hent Coz,,22570
+3 Rue Hent Coz 22570,,,,3,Rue Hent Coz,Plélauff,
+3 Rue Hent Coz,-3.210685,48.206661,,3,Rue Hent Coz,,22570
+4 Rue des Mouettes Pléneuf-Val-André,,,,4,Rue des Mouettes,,22370
+4 Rue des Mouettes 22370,,,,4,Rue des Mouettes,Pléneuf-Val-André,
+4 Rue des Mouettes,-2.557191,48.587526,,4,Rue des Mouettes,,22370
+10 Rue Pierre Sémard Plérin,,,,10,Rue Pierre Sémard,,22190
+10 Rue Pierre Sémard 22190,,,,10,Rue Pierre Sémard,Plérin,
+10 Rue Pierre Sémard,-2.758758,48.529967,,10,Rue Pierre Sémard,,22190
+3 Impasse Saint-Roch Plestin-les-Grèves,,,,3,Impasse Saint-Roch,,22310
+3 Impasse Saint-Roch 22310,,,,3,Impasse Saint-Roch,Plestin-les-Grèves,
+3 Impasse Saint-Roch,-3.625051,48.658529,,3,Impasse Saint-Roch,,22310
+1 Rue Saint-Geran Plévenon,,,,1,Rue Saint-Geran,,22240
+1 Rue Saint-Geran 22240,,,,1,Rue Saint-Geran,Plévenon,
+1 Rue Saint-Geran,-2.303649,48.657821,,1,Rue Saint-Geran,,22240
+15 Chemin du Paou Ploubazlanec,,,,15,Chemin du Paou,,22620
+15 Chemin du Paou 22620,,,,15,Chemin du Paou,Ploubazlanec,
+15 Chemin du Paou,-3.013857,48.815575,,15,Chemin du Paou,,22620
+12 Rue des Déportés Ploufragan,,,,12,Rue des Déportés,,22440
+12 Rue des Déportés 22440,,,,12,Rue des Déportés,Ploufragan,
+12 Rue des Déportés,-2.781276,48.500142,,12,Rue des Déportés,,22440
+6491A Rue du Gen Leclerc Plouha,,,,6491A,Rue du Gen Leclerc,,22580
+6491A Rue du Gen Leclerc 22580,,,,6491A,Rue du Gen Leclerc,Plouha,
+6491A Rue du Gen Leclerc,-2.925709,48.67865,,6491A,Rue du Gen Leclerc,,22580
+12 Allée des Cerisiers Plourivo,,,,12,Allée des Cerisiers,,22860
+12 Allée des Cerisiers 22860,,,,12,Allée des Cerisiers,Plourivo,
+12 Allée des Cerisiers,-3.068601,48.744078,,12,Allée des Cerisiers,,22860
+1 Rue Chateaubriand Pordic,,,,1,Rue Chateaubriand,,22590
+1 Rue Chateaubriand 22590,,,,1,Rue Chateaubriand,Pordic,
+1 Rue Chateaubriand,-2.803699,48.574278,,1,Rue Chateaubriand,,22590
+14 Rue du Gasset Quintin,,,,14,Rue du Gasset,,22800
+14 Rue du Gasset 22800,,,,14,Rue du Gasset,Quintin,
+14 Rue du Gasset,-2.914359,48.399785,,14,Rue du Gasset,,22800
+4 Rue Anatole France Saint-Brieuc,,,,4,Rue Anatole France,,22000
+4 Rue Anatole France 22000,,,,4,Rue Anatole France,Saint-Brieuc,
+4 Rue Anatole France,-2.744764,48.505898,,4,Rue Anatole France,,22000
+7 Rue du Général Leclerc Saint-Brieuc,,,,7,Rue du Général Leclerc,,22000
+7 Rue du Général Leclerc 22000,,,,7,Rue du Général Leclerc,Saint-Brieuc,
+7 Rue du Général Leclerc,-2.76022,48.512763,,7,Rue du Général Leclerc,,22000
+9 Rue Pierre Loti Saint-Brieuc,,,,9,Rue Pierre Loti,,22000
+9 Rue Pierre Loti 22000,,,,9,Rue Pierre Loti,Saint-Brieuc,
+9 Rue Pierre Loti,-2.756462,48.51167,,9,Rue Pierre Loti,,22000
+43 Boulevard de la Côte d'Émeraude Saint-Cast-le-Guildo,,,,43,Boulevard de la Côte d'Émeraude,,22380
+43 Boulevard de la Côte d'Émeraude 22380,,,,43,Boulevard de la Côte d'Émeraude,Saint-Cast-le-Guildo,
+43 Boulevard de la Côte d'Émeraude,-2.265858,48.633341,,43,Boulevard de la Côte d'Émeraude,,22380
+33 Rue des Fresches Saint-Jacut-de-la-Mer,,,,33,Rue des Fresches,,22750
+33 Rue des Fresches 22750,,,,33,Rue des Fresches,Saint-Jacut-de-la-Mer,
+33 Rue des Fresches,-2.183134,48.6002,,33,Rue des Fresches,,22750
+10 Rue des Korrigans Saint-Quay-Portrieux,,,,10,Rue des Korrigans,,22410
+10 Rue des Korrigans 22410,,,,10,Rue des Korrigans,Saint-Quay-Portrieux,
+10 Rue des Korrigans,-2.831977,48.646387,,10,Rue des Korrigans,,22410
+5 Rue de Garen Bian Trébeurden,,,,5,Rue de Garen Bian,,22560
+5 Rue de Garen Bian 22560,,,,5,Rue de Garen Bian,Trébeurden,
+5 Rue de Garen Bian,-3.574797,48.768907,,5,Rue de Garen Bian,,22560
+1 Allée Poincaré Trégueux,,,,1,Allée Poincaré,,22950
+1 Allée Poincaré 22950,,,,1,Allée Poincaré,Trégueux,
+1 Allée Poincaré,-2.73438,48.490124,,1,Allée Poincaré,,22950
+20 Rue du Port Goret Tréveneuc,,,,20,Rue du Port Goret,,22410
+20 Rue du Port Goret 22410,,,,20,Rue du Port Goret,Tréveneuc,
+20 Rue du Port Goret,-2.862599,48.669955,,20,Rue du Port Goret,,22410
+10 Venelle Notre Dame de la Mer Bénodet,,,,10,Venelle Notre Dame de la Mer,,29950
+10 Venelle Notre Dame de la Mer 29950,,,,10,Venelle Notre Dame de la Mer,Bénodet,
+10 Venelle Notre Dame de la Mer,-4.103927,47.875185,,10,Venelle Notre Dame de la Mer,,29950
+17BIS Rue Amiral Romain Desfossés Brest,,,,17BIS,Rue Amiral Romain Desfossés,,29200
+17BIS Rue Amiral Romain Desfossés 29200,,,,17BIS,Rue Amiral Romain Desfossés,Brest,
+17BIS Rue Amiral Romain Desfossés,-4.48086,48.425263,,17BIS,Rue Amiral Romain Desfossés,,29200
+90 Rue Colette Brest,,,,90,Rue Colette,,29200
+90 Rue Colette 29200,,,,90,Rue Colette,Brest,
+90 Rue Colette,-4.545725,48.374951,,90,Rue Colette,,29200
+4 Rue Frégate la Belle-Poule Brest,,,,4,Rue Frégate la Belle-Poule,,29200
+4 Rue Frégate la Belle-Poule 29200,,,,4,Rue Frégate la Belle-Poule,Brest,
+4 Rue Frégate la Belle-Poule,-4.484221,48.386129,,4,Rue Frégate la Belle-Poule,,29200
+5 Boulevard Jean Moulin Brest,,,,5,Boulevard Jean Moulin,,29200
+5 Boulevard Jean Moulin 29200,,,,5,Boulevard Jean Moulin,Brest,
+5 Boulevard Jean Moulin,-4.49297,48.386754,,5,Boulevard Jean Moulin,,29200
+3 Rue Lumière Brest,,,,3,Rue Lumière,,29200
+3 Rue Lumière 29200,,,,3,Rue Lumière,Brest,
+3 Rue Lumière,-4.47334,48.404117,,3,Rue Lumière,,29200
+50 Rue Poullic Al Lor Brest,,,,50,Rue Poullic Al Lor,,29200
+50 Rue Poullic Al Lor 29200,,,,50,Rue Poullic Al Lor,Brest,
+50 Rue Poullic Al Lor,-4.471934,48.387116,,50,Rue Poullic Al Lor,,29200
+22 Rue Victor Cousin Brest,,,,22,Rue Victor Cousin,,29200
+22 Rue Victor Cousin 29200,,,,22,Rue Victor Cousin,Brest,
+22 Rue Victor Cousin,-4.537774,48.377049,,22,Rue Victor Cousin,,29200
+26 Route de la Grande Grève Carantec,,,,26,Route de la Grande Grève,,29660
+26 Route de la Grande Grève 29660,,,,26,Route de la Grande Grève,Carantec,
+26 Route de la Grande Grève,-3.923989,48.659955,,26,Route de la Grande Grève,,29660
+50 Quai Carnot Châteaulin,,,,50,Quai Carnot,,29150
+50 Quai Carnot 29150,,,,50,Quai Carnot,Châteaulin,
+50 Quai Carnot,-4.096023,48.195803,,50,Quai Carnot,,29150
+8 Rue Paul Sérusier Clohars-Carnoët,,,,8,Rue Paul Sérusier,,29360
+8 Rue Paul Sérusier 29360,,,,8,Rue Paul Sérusier,Clohars-Carnoët,
+8 Rue Paul Sérusier,-3.555013,47.770193,,8,Rue Paul Sérusier,,29360
+4BIS Rue Anatole Le Braz Concarneau,,,,4BIS,Rue Anatole Le Braz,,29900
+4BIS Rue Anatole Le Braz 29900,,,,4BIS,Rue Anatole Le Braz,Concarneau,
+4BIS Rue Anatole Le Braz,-3.926054,47.871812,,4BIS,Rue Anatole Le Braz,,29900
+12 Rue Monet Concarneau,,,,12,Rue Monet,,29900
+12 Rue Monet 29900,,,,12,Rue Monet,Concarneau,
+12 Rue Monet,-3.898905,47.861193,,12,Rue Monet,,29900
+56 Rue de l'Atlantique Crozon,,,,56,Rue de l'Atlantique,,29160
+56 Rue de l'Atlantique 29160,,,,56,Rue de l'Atlantique,Crozon,
+56 Rue de l'Atlantique,-4.510399,48.222496,,56,Rue de l'Atlantique,,29160
+30 Rue Ar Vilin-Goz Douarnenez,,,,30,Rue Ar Vilin-Goz,,29100
+30 Rue Ar Vilin-Goz 29100,,,,30,Rue Ar Vilin-Goz,Douarnenez,
+30 Rue Ar Vilin-Goz,-4.348851,48.096421,,30,Rue Ar Vilin-Goz,,29100
+12 Rue du Pont Douarnenez,,,,12,Rue du Pont,,29100
+12 Rue du Pont 29100,,,,12,Rue du Pont,Douarnenez,
+12 Rue du Pont,-4.32954,48.090731,,12,Rue du Pont,,29100
+7 Allée des Pins Ergué-Gabéric,,,,7,Allée des Pins,,29500
+7 Allée des Pins 29500,,,,7,Allée des Pins,Ergué-Gabéric,
+7 Allée des Pins,-4.013284,48.017743,,7,Allée des Pins,,29500
+8 Route Quimper La Forêt-Fouesnant,,,,8,Route Quimper,,29940
+8 Route Quimper 29940,,,,8,Route Quimper,La Forêt-Fouesnant,
+8 Route Quimper,-3.964487,47.919462,,8,Route Quimper,,29940
+41 Ty Pri Rosnabat Fouesnant,,,,41,Ty Pri Rosnabat,,29170
+41 Ty Pri Rosnabat 29170,,,,41,Ty Pri Rosnabat,Fouesnant,
+41 Ty Pri Rosnabat,-4.010664,47.910955,,41,Ty Pri Rosnabat,,29170
+7 Rue Saint-Gouesnou Gouesnou,,,,7,Rue Saint-Gouesnou,,29850
+7 Rue Saint-Gouesnou 29850,,,,7,Rue Saint-Gouesnou,Gouesnou,
+7 Rue Saint-Gouesnou,-4.4668,48.452416,,7,Rue Saint-Gouesnou,,29850
+16 Rue du Gymnase Guilvinec,,,,16,Rue du Gymnase,,29730
+16 Rue du Gymnase 29730,,,,16,Rue du Gymnase,Guilvinec,
+16 Rue du Gymnase,-4.282916,47.801967,,16,Rue du Gymnase,,29730
+9 Rue Louis Guilloux Guipavas,,,,9,Rue Louis Guilloux,,29490
+9 Rue Louis Guilloux 29490,,,,9,Rue Louis Guilloux,Guipavas,
+9 Rue Louis Guilloux,-4.431741,48.416497,,9,Rue Louis Guilloux,,29490
+3 Place de la Cale Île-Tudy,,,,3,Place de la Cale,,29980
+3 Place de la Cale 29980,,,,3,Place de la Cale,Île-Tudy,
+3 Place de la Cale,-4.169105,47.841136,,3,Place de la Cale,,29980
+1 Rue Anatole Le Braz Landerneau,,,,1,Rue Anatole Le Braz,,29800
+1 Rue Anatole Le Braz 29800,,,,1,Rue Anatole Le Braz,Landerneau,
+1 Rue Anatole Le Braz,-4.247649,48.454503,,1,Rue Anatole Le Braz,,29800
+32A Rue des Ecossais Landerneau,,,,32A,Rue des Ecossais,,29800
+32A Rue des Ecossais 29800,,,,32A,Rue des Ecossais,Landerneau,
+32A Rue des Ecossais,-4.235341,48.456678,,32A,Rue des Ecossais,,29800
+3 Route de Poull-Menoc Landunvez,,,,3,Route de Poull-Menoc,,29840
+3 Route de Poull-Menoc 29840,,,,3,Route de Poull-Menoc,Landunvez,
+3 Route de Poull-Menoc,-4.720739,48.554438,,3,Route de Poull-Menoc,,29840
+12 Rue Alice Coudol Lesneven,,,,12,Rue Alice Coudol,,29260
+12 Rue Alice Coudol 29260,,,,12,Rue Alice Coudol,Lesneven,
+12 Rue Alice Coudol,-4.320257,48.566925,,12,Rue Alice Coudol,,29260
+10 Rue des Aubépines Locquirec,,,,10,Rue des Aubépines,,29241
+10 Rue des Aubépines 29241,,,,10,Rue des Aubépines,Locquirec,
+10 Rue des Aubépines,-3.666623,48.679845,,10,Rue des Aubépines,,29241
+10 Route du Moulin Mer Logonna-Daoulas,,,,10,Route du Moulin Mer,,29460
+10 Route du Moulin Mer 29460,,,,10,Route du Moulin Mer,Logonna-Daoulas,
+10 Route du Moulin Mer,-4.294897,48.319117,,10,Route du Moulin Mer,,29460
+32 Rue de Pont-ar-Laër Moëlan-sur-Mer,,,,32,Rue de Pont-ar-Laër,,29350
+32 Rue de Pont-ar-Laër 29350,,,,32,Rue de Pont-ar-Laër,Moëlan-sur-Mer,
+32 Rue de Pont-ar-Laër,-3.627645,47.808588,,32,Rue de Pont-ar-Laër,,29350
+3 Rue de Ty Dour Morlaix,,,,3,Rue de Ty Dour,,29600
+3 Rue de Ty Dour 29600,,,,3,Rue de Ty Dour,Morlaix,
+3 Rue de Ty Dour,-3.82451,48.586742,,3,Rue de Ty Dour,,29600
+456 Venelle de Quélourn Penmarc'h,,,,456,Venelle de Quélourn,,29760
+456 Venelle de Quélourn 29760,,,,456,Venelle de Quélourn,Penmarc'h,
+456 Venelle de Quélourn,-4.349843,47.814379,,456,Venelle de Quélourn,,29760
+2 Rue D'Argoat Pleyber-Christ,,,,2,Rue D'Argoat,,29410
+2 Rue D'Argoat 29410,,,,2,Rue D'Argoat,Pleyber-Christ,
+2 Rue D'Argoat,-3.876835,48.498599,,2,Rue D'Argoat,,29410
+24 Rue Mein Torret Plomeur,,,,24,Rue Mein Torret,,29120
+24 Rue Mein Torret 29120,,,,24,Rue Mein Torret,Plomeur,
+24 Rue Mein Torret,-4.286608,47.807693,,24,Rue Mein Torret,,29120
+2 Chemin des Amers Ploudalmézeau,,,,2,Chemin des Amers,,29830
+2 Chemin des Amers 29830,,,,2,Chemin des Amers,Ploudalmézeau,
+2 Chemin des Amers,-4.699781,48.565118,,2,Chemin des Amers,,29830
+23 Rue Charles Le Goffic Plouescat,,,,23,Rue Charles Le Goffic,,29430
+23 Rue Charles Le Goffic 29430,,,,23,Rue Charles Le Goffic,Plouescat,
+23 Rue Charles Le Goffic,-4.178039,48.65893,,23,Rue Charles Le Goffic,,29430
+59 Rue du Cléguer Plougastel-Daoulas,,,,59,Rue du Cléguer,,29470
+59 Rue du Cléguer 29470,,,,59,Rue du Cléguer,Plougastel-Daoulas,
+59 Rue du Cléguer,-4.376045,48.375103,,59,Rue du Cléguer,,29470
+24 Rossermeur Plougastel-Daoulas,,,,24,Rossermeur,,29470
+24 Rossermeur 29470,,,,24,Rossermeur,Plougastel-Daoulas,
+24 Rossermeur,-4.345761,48.34978,,24,Rossermeur,,29470
+10 Rue des Fusiliers Marins Plouhinec,,,,10,Rue des Fusiliers Marins,,29780
+10 Rue des Fusiliers Marins 29780,,,,10,Rue des Fusiliers Marins,Plouhinec,
+10 Rue des Fusiliers Marins,-4.528938,48.013286,,10,Rue des Fusiliers Marins,,29780
+529 Rue Saint-Pol Plounéour-Trez,,,,529,Rue Saint-Pol,,29890
+529 Rue Saint-Pol 29890,,,,529,Rue Saint-Pol,,29890
+529 Rue Saint-Pol,-4.31877,48.651117,,529,Rue Saint-Pol,,29890
+7 Allée des Cèdres Plouzané,,,,7,Allée des Cèdres,,29280
+7 Allée des Cèdres 29280,,,,7,Allée des Cèdres,Plouzané,
+7 Allée des Cèdres,-4.586258,48.375167,,7,Allée des Cèdres,,29280
+17BIS RTE DE LEZAVREC Plozévet,,,,17BIS,LEZAVREC,,29710
+17BIS RTE DE LEZAVREC 29710,,,,17BIS,LEZAVREC,Plozévet,
+17BIS RTE DE LEZAVREC,-4.407623,47.973885,,17BIS,LEZAVREC,,29710
+31 Rue Jean Moulin Pont-l'Abbé,,,,31,Rue Jean Moulin,,29120
+31 Rue Jean Moulin 29120,,,,31,Rue Jean Moulin,Pont-l'Abbé,
+31 Rue Jean Moulin,-4.231055,47.864381,,31,Rue Jean Moulin,,29120
+5 Rue Saint-Laurent Quéménéven,,,,5,Rue Saint-Laurent,,29180
+5 Rue Saint-Laurent 29180,,,,5,Rue Saint-Laurent,Quéménéven,
+5 Rue Saint-Laurent,-4.120979,48.115701,,5,Rue Saint-Laurent,,29180
+16 Rue des Douves Quimper,,,,16,Rue des Douves,,29000
+16 Rue des Douves 29000,,,,16,Rue des Douves,Quimper,
+16 Rue des Douves,-4.10193,47.998592,,16,Rue des Douves,,29000
+21 Allée Joséphine Pencalet Quimper,,,,21,Allée Joséphine Pencalet,,29000
+21 Allée Joséphine Pencalet 29000,,,,21,Allée Joséphine Pencalet,Quimper,
+21 Allée Joséphine Pencalet,-4.132122,47.976205,,21,Allée Joséphine Pencalet,,29000
+21 Rue Montaigne Quimper,,,,21,Rue Montaigne,,29000
+21 Rue Montaigne 29000,,,,21,Rue Montaigne,Quimper,
+21 Rue Montaigne,-4.101233,47.984264,,21,Rue Montaigne,,29000
+23 Rue du Sallé Quimper,,,,23,Rue du Sallé,,29000
+23 Rue du Sallé 29000,,,,23,Rue du Sallé,Quimper,
+23 Rue du Sallé,-4.10376,47.996656,,23,Rue du Sallé,,29000
+7 Rue Kerguelen Quimperlé,,,,7,Rue Kerguelen,,29300
+7 Rue Kerguelen 29300,,,,7,Rue Kerguelen,Quimperlé,
+7 Rue Kerguelen,-3.553074,47.877299,,7,Rue Kerguelen,,29300
+211 Rue des Hauts de Kerhorres Le Relecq-Kerhuon,,,,211,Rue des Hauts de Kerhorres,,29480
+211 Rue des Hauts de Kerhorres 29480,,,,211,Rue des Hauts de Kerhorres,Le Relecq-Kerhuon,
+211 Rue des Hauts de Kerhorres,-4.390051,48.408666,,211,Rue des Hauts de Kerhorres,,29480
+42 Rue Peisey Nancroix Roscanvel,,,,42,Rue Peisey Nancroix,,29570
+42 Rue Peisey Nancroix 29570,,,,42,Rue Peisey Nancroix,Roscanvel,
+42 Rue Peisey Nancroix,-4.54788,48.321216,,42,Rue Peisey Nancroix,,29570
+3 Place de l'Église Saint-Évarzec,,,,3,Place de l'Église,,29170
+3 Place de l'Église 29170,,,,3,Place de l'Église,Saint-Évarzec,
+3 Place de l'Église,-4.020776,47.936276,,3,Place de l'Église,,29170
+26 Rue de Ty Arvor Saint-Pabu,,,,26,Rue de Ty Arvor,,29830
+26 Rue de Ty Arvor 29830,,,,26,Rue de Ty Arvor,Saint-Pabu,
+26 Rue de Ty Arvor,-4.627485,48.570215,,26,Rue de Ty Arvor,,29830
+41 Rue des Vosges Saint-Renan,,,,41,Rue des Vosges,,29290
+41 Rue des Vosges 29290,,,,41,Rue des Vosges,Saint-Renan,
+41 Rue des Vosges,-4.636641,48.433739,,41,Rue des Vosges,,29290
+9 RUE LEON BLUM Scaër,,,,9,BLUM,,29390
+9 RUE LEON BLUM 29390,,,,9,BLUM,Scaër,
+9 RUE LEON BLUM,-3.700026,48.022873,,9,BLUM,,29390
+26 Rue Saint Jacques Treffiagat,,,,26,Rue Saint Jacques,,29730
+26 Rue Saint Jacques 29730,,,,26,Rue Saint Jacques,Treffiagat,
+26 Rue Saint Jacques,-4.273025,47.794064,,26,Rue Saint Jacques,,29730
+11 Rue Éric Tabarly Pont-de-Buis-lès-Quimerch,,,,11,Rue Éric Tabarly,,29590
+11 Rue Éric Tabarly 29590,,,,11,Rue Éric Tabarly,Pont-de-Buis-lès-Quimerch,
+11 Rue Éric Tabarly,-4.083466,48.248724,,11,Rue Éric Tabarly,,29590
+6 Allée de l'Europe Bain-de-Bretagne,,,,6,Allée de l'Europe,,35470
+6 Allée de l'Europe 35470,,,,6,Allée de l'Europe,Bain-de-Bretagne,
+6 Allée de l'Europe,-1.68531,47.849196,,6,Allée de l'Europe,,35470
+5 Rue Châteaubriand Bédée,,,,5,Rue Châteaubriand,,35137
+5 Rue Châteaubriand 35137,,,,5,Rue Châteaubriand,Bédée,
+5 Rue Châteaubriand,-1.947428,48.181676,,5,Rue Châteaubriand,,35137
+8 Rue de Bréhat La Bouëxière,,,,8,Rue de Bréhat,,35340
+8 Rue de Bréhat 35340,,,,8,Rue de Bréhat,La Bouëxière,
+8 Rue de Bréhat,-1.439885,48.185437,,8,Rue de Bréhat,,35340
+11 Rue du Houx Breteil,,,,11,Rue du Houx,,35160
+11 Rue du Houx 35160,,,,11,Rue du Houx,Breteil,
+11 Rue du Houx,-1.90295,48.145552,,11,Rue du Houx,,35160
+28 Rue Théodore Botrel Bruz,,,,28,Rue Théodore Botrel,,35170
+28 Rue Théodore Botrel 35170,,,,28,Rue Théodore Botrel,Bruz,
+28 Rue Théodore Botrel,-1.741993,48.02182,,28,Rue Théodore Botrel,,35170
+33 Rue du Couradin Cesson-Sévigné,,,,33,Rue du Couradin,,35510
+33 Rue du Couradin 35510,,,,33,Rue du Couradin,Cesson-Sévigné,
+33 Rue du Couradin,-1.606872,48.127294,,33,Rue du Couradin,,35510
+1 Allée des Genêts Chantepie,,,,1,Allée des Genêts,,35135
+1 Allée des Genêts 35135,,,,1,Allée des Genêts,Chantepie,
+1 Allée des Genêts,-1.614846,48.082779,,1,Allée des Genêts,,35135
+3 Rue d'Armorique Chartres-de-Bretagne,,,,3,Rue d'Armorique,,35131
+3 Rue d'Armorique 35131,,,,3,Rue d'Armorique,Chartres-de-Bretagne,
+3 Rue d'Armorique,-1.706048,48.036645,,3,Rue d'Armorique,,35131
+4 Rue Leprestre de Lézonnet Châteaugiron,,,,4,Rue Leprestre de Lézonnet,,35410
+4 Rue Leprestre de Lézonnet 35410,,,,4,Rue Leprestre de Lézonnet,Châteaugiron,
+4 Rue Leprestre de Lézonnet,-1.503453,48.049784,,4,Rue Leprestre de Lézonnet,,35410
+6 Rue Berthe Morisot Cintré,,,,6,Rue Berthe Morisot,,35310
+6 Rue Berthe Morisot 35310,,,,6,Rue Berthe Morisot,Cintré,
+6 Rue Berthe Morisot,-1.875814,48.101999,,6,Rue Berthe Morisot,,35310
+10 Impasse Chauchat Dinard,,,,10,Impasse Chauchat,,35800
+10 Impasse Chauchat 35800,,,,10,Impasse Chauchat,Dinard,
+10 Impasse Chauchat,-2.060471,48.633501,,10,Impasse Chauchat,,35800
+3 Rue du Clos Lupin Dol-de-Bretagne,,,,3,Rue du Clos Lupin,,35120
+3 Rue du Clos Lupin 35120,,,,3,Rue du Clos Lupin,Dol-de-Bretagne,
+3 Rue du Clos Lupin,-1.743187,48.546469,,3,Rue du Clos Lupin,,35120
+1 Rue de la Champagne Étrelles,,,,1,Rue de la Champagne,,35370
+1 Rue de la Champagne 35370,,,,1,Rue de la Champagne,Étrelles,
+1 Rue de la Champagne,-1.197284,48.057428,,1,Rue de la Champagne,,35370
+13 Rue du Père Maunoir Fougères,,,,13,Rue du Père Maunoir,,35300
+13 Rue du Père Maunoir 35300,,,,13,Rue du Père Maunoir,Fougères,
+13 Rue du Père Maunoir,-1.190344,48.351868,,13,Rue du Père Maunoir,,35300
+3 Rue Simone Veil Gévezé,,,,3,Rue Simone Veil,,35850
+3 Rue Simone Veil 35850,,,,3,Rue Simone Veil,Gévezé,
+3 Rue Simone Veil,-1.804097,48.224109,,3,Rue Simone Veil,,35850
+32 Rue du Maréchal de Lattre de Tassigny Guichen,,,,32,Rue du Maréchal de Lattre de Tassigny,,35580
+32 Rue du Maréchal de Lattre de Tassigny 35580,,,,32,Rue du Maréchal de Lattre de Tassigny,Guichen,
+32 Rue du Maréchal de Lattre de Tassigny,-1.794726,47.974108,,32,Rue du Maréchal de Lattre de Tassigny,,35580
+1 Impasse des Bruyères Irodouër,,,,1,Impasse des Bruyères,,35850
+1 Impasse des Bruyères 35850,,,,1,Impasse des Bruyères,Irodouër,
+1 Impasse des Bruyères,-1.950843,48.244717,,1,Impasse des Bruyères,,35850
+8 le Ruel Laillé,,,,8,le Ruel,,35890
+8 le Ruel 35890,,,,8,le Ruel,Laillé,
+8 le Ruel,-1.714623,48.001487,,8,le Ruel,,35890
+12 Allée des Sternes Liffré,,,,12,Allée des Sternes,,35340
+12 Allée des Sternes 35340,,,,12,Allée des Sternes,Liffré,
+12 Allée des Sternes,-1.513746,48.208444,,12,Allée des Sternes,,35340
+12 Rue de Dinan Médréac,,,,12,Rue de Dinan,,35360
+12 Rue de Dinan 35360,,,,12,Rue de Dinan,Médréac,
+12 Rue de Dinan,-2.066663,48.268468,,12,Rue de Dinan,,35360
+5 la Pommardière Miniac-sous-Bécherel,,,,5,la Pommardière,,35190
+5 la Pommardière 35190,,,,5,la Pommardière,Miniac-sous-Bécherel,
+5 la Pommardière,-1.921621,48.300397,,5,la Pommardière,,35190
+27B Rue de la Rébunière Montgermont,,,,27B,Rue de la Rébunière,,35760
+27B Rue de la Rébunière 35760,,,,27B,Rue de la Rébunière,Montgermont,
+27B Rue de la Rébunière,-1.723916,48.162736,,27B,Rue de la Rébunière,,35760
+8 Rue Paul Verlaine Nouvoitou,,,,8,Rue Paul Verlaine,,35410
+8 Rue Paul Verlaine 35410,,,,8,Rue Paul Verlaine,Nouvoitou,
+8 Rue Paul Verlaine,-1.552305,48.03991,,8,Rue Paul Verlaine,,35410
+51 la Rochelle Orgères,,,,51,la Rochelle,,35230
+51 la Rochelle 35230,,,,51,la Rochelle,Orgères,
+51 la Rochelle,-1.653896,47.983919,,51,la Rochelle,,35230
+114 Le Vil Le Petit-Fougeray,,,,114,Le Vil,,35320
+114 Le Vil 35320,,,,114,Le Vil,Le Petit-Fougeray,
+114 Le Vil,-1.605625,47.921359,,114,Le Vil,,35320
+2E Rue de l'Aéroport Pleurtuit,,,,2E,Rue de l'Aéroport,,35730
+2E Rue de l'Aéroport 35730,,,,2E,Rue de l'Aéroport,Pleurtuit,
+2E Rue de l'Aéroport,-2.05963,48.584326,,2E,Rue de l'Aéroport,,35730
+8 Rue des Lièvries Redon,,,,8,Rue des Lièvries,,35600
+8 Rue des Lièvries 35600,,,,8,Rue des Lièvries,Redon,
+8 Rue des Lièvries,-2.08754,47.655778,,8,Rue des Lièvries,,35600
+4 Allée Bernard Josse Rennes,,,,4,Allée Bernard Josse,,35000
+4 Allée Bernard Josse 35000,,,,4,Allée Bernard Josse,Rennes,
+4 Allée Bernard Josse,-1.691285,48.09929,,4,Allée Bernard Josse,,35000
+8 Rue du Docteur Regnault Rennes,,,,8,Rue du Docteur Regnault,,35000
+8 Rue du Docteur Regnault 35000,,,,8,Rue du Docteur Regnault,Rennes,
+8 Rue du Docteur Regnault,-1.675601,48.111663,,8,Rue du Docteur Regnault,,35000
+9 Rue Hamon Rennes,,,,9,Rue Hamon,,35000
+9 Rue Hamon 35000,,,,9,Rue Hamon,Rennes,
+9 Rue Hamon,-1.703077,48.113379,,9,Rue Hamon,,35000
+8 Rue Louis Blériot Rennes,,,,8,Rue Louis Blériot,,35000
+8 Rue Louis Blériot 35000,,,,8,Rue Louis Blériot,Rennes,
+8 Rue Louis Blériot,-1.67804,48.10179,,8,Rue Louis Blériot,,35000
+5 Rue Philippe Nordmann Rennes,,,,5,Rue Philippe Nordmann,,35000
+5 Rue Philippe Nordmann 35000,,,,5,Rue Philippe Nordmann,Rennes,
+5 Rue Philippe Nordmann,-1.657406,48.107582,,5,Rue Philippe Nordmann,,35000
+28 Avenue Sir Winston Churchill Rennes,,,,28,Avenue Sir Winston Churchill,,35000
+28 Avenue Sir Winston Churchill 35000,,,,28,Avenue Sir Winston Churchill,Rennes,
+28 Avenue Sir Winston Churchill,-1.708682,48.122861,,28,Avenue Sir Winston Churchill,,35000
+7 Rue de la Haie de Terre Le Rheu,,,,7,Rue de la Haie de Terre,,35650
+7 Rue de la Haie de Terre 35650,,,,7,Rue de la Haie de Terre,Le Rheu,
+7 Rue de la Haie de Terre,-1.785236,48.095231,,7,Rue de la Haie de Terre,,35650
+17 Rue de Rennes Saint-Aubin-d'Aubigné,,,,17,Rue de Rennes,,35250
+17 Rue de Rennes 35250,,,,17,Rue de Rennes,Saint-Aubin-d'Aubigné,
+17 Rue de Rennes,-1.606008,48.26101,,17,Rue de Rennes,,35250
+16 Rue de l'Orme Saint-Broladre,,,,16,Rue de l'Orme,,35120
+16 Rue de l'Orme 35120,,,,16,Rue de l'Orme,Saint-Broladre,
+16 Rue de l'Orme,-1.661524,48.584266,,16,Rue de l'Orme,,35120
+3 Rue Alphonse Milon Saint-Grégoire,,,,3,Rue Alphonse Milon,,35760
+3 Rue Alphonse Milon 35760,,,,3,Rue Alphonse Milon,Saint-Grégoire,
+3 Rue Alphonse Milon,-1.684788,48.152535,,3,Rue Alphonse Milon,,35760
+33 Rue Pierre Brossolette Saint-Jacques-de-la-Lande,,,,33,Rue Pierre Brossolette,,35136
+33 Rue Pierre Brossolette 35136,,,,33,Rue Pierre Brossolette,Saint-Jacques-de-la-Lande,
+33 Rue Pierre Brossolette,-1.694338,48.091726,,33,Rue Pierre Brossolette,,35136
+16 Rue du Chanoine Édouard Lainé Saint-Malo,,,,16,Rue du Chanoine Édouard Lainé,,35400
+16 Rue du Chanoine Édouard Lainé 35400,,,,16,Rue du Chanoine Édouard Lainé,Saint-Malo,
+16 Rue du Chanoine Édouard Lainé,-1.99615,48.656199,,16,Rue du Chanoine Édouard Lainé,,35400
+29 Avenue du Président John Kennedy Saint-Malo,,,,29,Avenue du Président John Kennedy,,35400
+29 Avenue du Président John Kennedy 35400,,,,29,Avenue du Président John Kennedy,Saint-Malo,
+29 Avenue du Président John Kennedy,-1.987465,48.665875,,29,Avenue du Président John Kennedy,,35400
+1 Chaussée du Sillon Saint-Malo,,,,1,Chaussée du Sillon,,35400
+1 Chaussée du Sillon 35400,,,,1,Chaussée du Sillon,Saint-Malo,
+1 Chaussée du Sillon,-2.009486,48.654209,,1,Chaussée du Sillon,,35400
+18 Rue Saint-Georges Saint-Père,,,,18,Rue Saint-Georges,,35430
+18 Rue Saint-Georges 35430,,,,18,Rue Saint-Georges,Saint-Père,
+18 Rue Saint-Georges,-1.940984,48.579598,,18,Rue Saint-Georges,,35430
+5 Rue de Brocéliande Sixt-sur-Aff,,,,5,Rue de Brocéliande,,35550
+5 Rue de Brocéliande 35550,,,,5,Rue de Brocéliande,Sixt-sur-Aff,
+5 Rue de Brocéliande,-2.080183,47.773913,,5,Rue de Brocéliande,,35550
+3 Rue Xavier Grall Tinténiac,,,,3,Rue Xavier Grall,,35190
+3 Rue Xavier Grall 35190,,,,3,Rue Xavier Grall,Tinténiac,
+3 Rue Xavier Grall,-1.840169,48.33272,,3,Rue Xavier Grall,,35190
+5 les Ponts Poiriers Vern-sur-Seiche,,,,5,les Ponts Poiriers,,35770
+5 les Ponts Poiriers 35770,,,,5,les Ponts Poiriers,Vern-sur-Seiche,
+5 les Ponts Poiriers,-1.624988,48.0697,,5,les Ponts Poiriers,,35770
+139 Boulevard de Laval Vitré,,,,139,Boulevard de Laval,,35500
+139 Boulevard de Laval 35500,,,,139,Boulevard de Laval,Vitré,
+139 Boulevard de Laval,-1.187754,48.122264,,139,Boulevard de Laval,,35500
+6 Rue de la Pte de Kerners Arzon,,,,6,Rue de la Pte de Kerners,,56640
+6 Rue de la Pte de Kerners 56640,,,,6,Rue de la Pte de Kerners,Arzon,
+6 Rue de la Pte de Kerners,-2.880081,47.555487,,6,Rue de la Pte de Kerners,,56640
+20 Rue An Alre Baden,,,,20,Rue An Alre,,56870
+20 Rue An Alre 56870,,,,20,Rue An Alre,Baden,
+20 Rue An Alre,-2.922821,47.622552,,20,Rue An Alre,,56870
+20 Rue de Manegroven Belz,,,,20,Rue de Manegroven,,56550
+20 Rue de Manegroven 56550,,,,20,Rue de Manegroven,Belz,
+20 Rue de Manegroven,-3.184733,47.680799,,20,Rue de Manegroven,,56550
+14 Rue Jean de Beaumanoir Bréhan,,,,14,Rue Jean de Beaumanoir,,56580
+14 Rue Jean de Beaumanoir 56580,,,,14,Rue Jean de Beaumanoir,Bréhan,
+14 Rue Jean de Beaumanoir,-2.687628,48.059786,,14,Rue Jean de Beaumanoir,,56580
+6 Impasse des Goémons Carnac,,,,6,Impasse des Goémons,,56340
+6 Impasse des Goémons 56340,,,,6,Impasse des Goémons,Carnac,
+6 Impasse des Goémons,-3.056878,47.577451,,6,Impasse des Goémons,,56340
+13 Rue Boquelen Cléguérec,,,,13,Rue Boquelen,,56480
+13 Rue Boquelen 56480,,,,13,Rue Boquelen,Cléguérec,
+13 Rue Boquelen,-3.006142,48.091749,,13,Rue Boquelen,,56480
+6 Rue du Meunier Damgan,,,,6,Rue du Meunier,,56750
+6 Rue du Meunier 56750,,,,6,Rue du Meunier,Damgan,
+6 Rue du Meunier,-2.585269,47.520248,,6,Rue du Meunier,,56750
+9 Rue du Champ Vert Le Faouët,,,,9,Rue du Champ Vert,,56320
+9 Rue du Champ Vert 56320,,,,9,Rue du Champ Vert,Le Faouët,
+9 Rue du Champ Vert,-3.486882,48.034917,,9,Rue du Champ Vert,,56320
+16 Rue Jean Louis Kergaravat Gourin,,,,16,Rue Jean Louis Kergaravat,,56110
+16 Rue Jean Louis Kergaravat 56110,,,,16,Rue Jean Louis Kergaravat,Gourin,
+16 Rue Jean Louis Kergaravat,-3.609035,48.138322,,16,Rue Jean Louis Kergaravat,,56110
+38BIS Route de la Ruézie Guer,,,,38BIS,Route de la Ruézie,,56380
+38BIS Route de la Ruézie 56380,,,,38BIS,Route de la Ruézie,Guer,
+38BIS Route de la Ruézie,-2.12647,47.951612,,38BIS,Route de la Ruézie,,56380
+5 Rue Marie-Anne Collot Hennebont,,,,5,Rue Marie-Anne Collot,,56700
+5 Rue Marie-Anne Collot 56700,,,,5,Rue Marie-Anne Collot,Hennebont,
+5 Rue Marie-Anne Collot,-3.247926,47.816511,,5,Rue Marie-Anne Collot,,56700
+8 Rue Arthur Rimbaud Inzinzac-Lochrist,,,,8,Rue Arthur Rimbaud,,56650
+8 Rue Arthur Rimbaud 56650,,,,8,Rue Arthur Rimbaud,Inzinzac-Lochrist,
+8 Rue Arthur Rimbaud,-3.263289,47.824413,,8,Rue Arthur Rimbaud,,56650
+2 Rue Adolphe Beaufrere Lanester,,,,2,Rue Adolphe Beaufrere,,56600
+2 Rue Adolphe Beaufrere 56600,,,,2,Rue Adolphe Beaufrere,Lanester,
+2 Rue Adolphe Beaufrere,-3.3292,47.762099,,2,Rue Adolphe Beaufrere,,56600
+1 Rue de la Paix Lanester,,,,1,Rue de la Paix,,56600
+1 Rue de la Paix 56600,,,,1,Rue de la Paix,Lanester,
+1 Rue de la Paix,-3.341975,47.757099,,1,Rue de la Paix,,56600
+46 Rue des Fleurs Larmor-Plage,,,,46,Rue des Fleurs,,56260
+46 Rue des Fleurs 56260,,,,46,Rue des Fleurs,Larmor-Plage,
+46 Rue des Fleurs,-3.377173,47.713411,,46,Rue des Fleurs,,56260
+7 Rue Ernest Renan Locminé,,,,7,Rue Ernest Renan,,56500
+7 Rue Ernest Renan 56500,,,,7,Rue Ernest Renan,Locminé,
+7 Rue Ernest Renan,-2.831214,47.891179,,7,Rue Ernest Renan,,56500
+5 Impasse Berthe Morisot Lorient,,,,5,Impasse Berthe Morisot,,56100
+5 Impasse Berthe Morisot 56100,,,,5,Impasse Berthe Morisot,Lorient,
+5 Impasse Berthe Morisot,-3.382847,47.761769,,5,Impasse Berthe Morisot,,56100
+9 Rue Jules Le Grand Lorient,,,,9,Rue Jules Le Grand,,56100
+9 Rue Jules Le Grand 56100,,,,9,Rue Jules Le Grand,Lorient,
+9 Rue Jules Le Grand,-3.359382,47.750646,,9,Rue Jules Le Grand,,56100
+8 Rue Roger Le Bloa Lorient,,,,8,Rue Roger Le Bloa,,56100
+8 Rue Roger Le Bloa 56100,,,,8,Rue Roger Le Bloa,Lorient,
+8 Rue Roger Le Bloa,-3.377312,47.755901,,8,Rue Roger Le Bloa,,56100
+18 Rue d'Armor Ménéac,,,,18,Rue d'Armor,,56490
+18 Rue d'Armor 56490,,,,18,Rue d'Armor,Ménéac,
+18 Rue d'Armor,-2.458412,48.141601,,18,Rue d'Armor,,56490
+7 Rue des Lavandières Muzillac,,,,7,Rue des Lavandières,,56190
+7 Rue des Lavandières 56190,,,,7,Rue des Lavandières,Muzillac,
+7 Rue des Lavandières,-2.487385,47.553834,,7,Rue des Lavandières,,56190
+736 Impasse Landrin Pénestin,,,,736,Impasse Landrin,,56760
+736 Impasse Landrin 56760,,,,736,Impasse Landrin,Pénestin,
+736 Impasse Landrin,-2.48348,47.467474,,736,Impasse Landrin,,56760
+16 Rue du Docteur Laënnec Ploemeur,,,,16,Rue du Docteur Laënnec,,56270
+16 Rue du Docteur Laënnec 56270,,,,16,Rue du Docteur Laënnec,Ploemeur,
+16 Rue du Docteur Laënnec,-3.402496,47.741704,,16,Rue du Docteur Laënnec,,56270
+3 Rue de la Bellevue Ploërdut,,,,3,Rue de la Bellevue,,56160
+3 Rue de la Bellevue 56160,,,,3,Rue de la Bellevue,Ploërdut,
+3 Rue de la Bellevue,-3.282802,48.08832,,3,Rue de la Bellevue,,56160
+87 Rue du Val Ploërmel,,,,87,Rue du Val,,56800
+87 Rue du Val 56800,,,,87,Rue du Val,Ploërmel,
+87 Rue du Val,-2.398261,47.938237,,87,Rue du Val,,56800
+3 Rue du Clos du pré Pluherlin,,,,3,Rue du Clos du pré,,56220
+3 Rue du Clos du pré 56220,,,,3,Rue du Clos du pré,Pluherlin,
+3 Rue du Clos du pré,-2.359453,47.695888,,3,Rue du Clos du pré,,56220
+12 Place du Marché Pluvigner,,,,12,Place du Marché,,56330
+12 Place du Marché 56330,,,,12,Place du Marché,Pluvigner,
+12 Place du Marché,-3.010056,47.775239,,12,Place du Marché,,56330
+5 Rue du Paradis Pontivy,,,,5,Rue du Paradis,,56300
+5 Rue du Paradis 56300,,,,5,Rue du Paradis,Pontivy,
+5 Rue du Paradis,-2.964661,48.067146,,5,Rue du Paradis,,56300
+1 Impasse de la Forge Questembert,,,,1,Impasse de la Forge,,56230
+1 Impasse de la Forge 56230,,,,1,Impasse de la Forge,Questembert,
+1 Impasse de la Forge,-2.465397,47.641671,,1,Impasse de la Forge,,56230
+25 Rue de la Croix Quiberon,,,,25,Rue de la Croix,,56170
+25 Rue de la Croix 56170,,,,25,Rue de la Croix,Quiberon,
+25 Rue de la Croix,-3.12027,47.494272,,25,Rue de la Croix,,56170
+2 Rue Abbe Alain Le Blevec Riantec,,,,2,Rue Abbe Alain Le Blevec,,56670
+2 Rue Abbe Alain Le Blevec 56670,,,,2,Rue Abbe Alain Le Blevec,Riantec,
+2 Rue Abbe Alain Le Blevec,-3.306785,47.713507,,2,Rue Abbe Alain Le Blevec,,56670
+21 Rue Charles Péguy Saint-Avé,,,,21,Rue Charles Péguy,,56890
+21 Rue Charles Péguy 56890,,,,21,Rue Charles Péguy,Saint-Avé,
+21 Rue Charles Péguy,-2.762742,47.680755,,21,Rue Charles Péguy,,56890
+81 Route du Cossay Saint-Gildas-de-Rhuys,,,,81,Route du Cossay,,56730
+81 Route du Cossay 56730,,,,81,Route du Cossay,Saint-Gildas-de-Rhuys,
+81 Route du Cossay,-2.803974,47.491268,,81,Route du Cossay,,56730
+36 Résidence Beau Soleil Saint-Nolff,,,,36,Résidence Beau Soleil,,56250
+36 Résidence Beau Soleil 56250,,,,36,Résidence Beau Soleil,Saint-Nolff,
+36 Résidence Beau Soleil,-2.680819,47.697673,,36,Résidence Beau Soleil,,56250
+5 Rue de la Cote Sarzeau,,,,5,Rue de la Cote,,56370
+5 Rue de la Cote 56370,,,,5,Rue de la Cote,Sarzeau,
+5 Rue de la Cote,-2.779327,47.497753,,5,Rue de la Cote,,56370
+25 Chemin de Bindre Séné,,,,25,Chemin de Bindre,,56860
+25 Chemin de Bindre 56860,,,,25,Chemin de Bindre,Séné,
+25 Chemin de Bindre,-2.717768,47.632136,,25,Chemin de Bindre,,56860
+24 Résidence Jean Monnet Sulniac,,,,24,Résidence Jean Monnet,,56250
+24 Résidence Jean Monnet 56250,,,,24,Résidence Jean Monnet,Sulniac,
+24 Résidence Jean Monnet,-2.57265,47.673721,,24,Résidence Jean Monnet,,56250
+16 Rue de la Libération Trédion,,,,16,Rue de la Libération,,56250
+16 Rue de la Libération 56250,,,,16,Rue de la Libération,Trédion,
+16 Rue de la Libération,-2.592773,47.791914,,16,Rue de la Libération,,56250
+3 Allée du Couëdic Vannes,,,,3,Allée du Couëdic,,56000
+3 Allée du Couëdic 56000,,,,3,Allée du Couëdic,Vannes,
+3 Allée du Couëdic,-2.72741,47.661763,,3,Allée du Couëdic,,56000
+69 Avenue de la Marne Vannes,,,,69,Avenue de la Marne,,56000
+69 Avenue de la Marne 56000,,,,69,Avenue de la Marne,Vannes,
+69 Avenue de la Marne,-2.779573,47.659461,,69,Avenue de la Marne,,56000
+23 Rue Edouard Herriot Bono,,,,23,Rue Edouard Herriot,,56400
+23 Rue Edouard Herriot 56400,,,,23,Rue Edouard Herriot,Bono,
+23 Rue Edouard Herriot,-2.94526,47.636698,,23,Rue Edouard Herriot,,56400

--- a/geocoder_tester/world/france/centre/test_addresses.csv
+++ b/geocoder_tester/world/france/centre/test_addresses.csv
@@ -1,500 +1,500 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-29 Rue du 11 Novembre 1918 Aubigny-sur-Nère,,,,29 Rue du 11 Novembre 1918,,,,18700
-29 Rue du 11 Novembre 1918 18700,,,,29 Rue du 11 Novembre 1918,,,Aubigny-sur-Nère,
-29 Rue du 11 Novembre 1918,2.426413,47.485419,,29 Rue du 11 Novembre 1918,,,,18700
-8 Rue Pierre Juglar Blancafort,,,,8 Rue Pierre Juglar,,,,18410
-8 Rue Pierre Juglar 18410,,,,8 Rue Pierre Juglar,,,Blancafort,
-8 Rue Pierre Juglar,2.531098,47.532249,,8 Rue Pierre Juglar,,,,18410
-10B Rue Claude Monet Bourges,,,,10B Rue Claude Monet,,,,18000
-10B Rue Claude Monet 18000,,,,10B Rue Claude Monet,,,Bourges,
-10B Rue Claude Monet,2.388023,47.074773,,10B Rue Claude Monet,,,,18000
-6 Rue Helvetius Bourges,,,,6 Rue Helvetius,,,,18000
-6 Rue Helvetius 18000,,,,6 Rue Helvetius,,,Bourges,
-6 Rue Helvetius,2.432197,47.104394,,6 Rue Helvetius,,,,18000
-52 Route de Méry-ès-Bois Bourges,,,,52 Route de Méry-ès-Bois,,,,18000
-52 Route de Méry-ès-Bois 18000,,,,52 Route de Méry-ès-Bois,,,Bourges,
-52 Route de Méry-ès-Bois,2.402256,47.114852,,52 Route de Méry-ès-Bois,,,,18000
-1 Rue Tom Morel Bourges,,,,1 Rue Tom Morel,,,,18000
-1 Rue Tom Morel 18000,,,,1 Rue Tom Morel,,,Bourges,
-1 Rue Tom Morel,2.420504,47.109503,,1 Rue Tom Morel,,,,18000
-13 Rue des Petites Croix La Chapelle-Saint-Ursin,,,,13 Rue des Petites Croix,,,,18570
-13 Rue des Petites Croix 18570,,,,13 Rue des Petites Croix,,,La Chapelle-Saint-Ursin,
-13 Rue des Petites Croix,2.321167,47.057646,,13 Rue des Petites Croix,,,,18570
-6 Rue de la Petite Garenne Civray,,,,6 Rue de la Petite Garenne,,,,18290
-6 Rue de la Petite Garenne 18290,,,,6 Rue de la Petite Garenne,,,Civray,
-6 Rue de la Petite Garenne,2.175125,46.968968,,6 Rue de la Petite Garenne,,,,18290
-10 Rue du Lavoir Ennordres,,,,10 Rue du Lavoir,,,,18380
-10 Rue du Lavoir 18380,,,,10 Rue du Lavoir,,,Ennordres,
-10 Rue du Lavoir,2.381646,47.430302,,10 Rue du Lavoir,,,,18380
-36 Rue Henri Barbusse La Guerche-sur-l'Aubois,,,,36 Rue Henri Barbusse,,,,18150
-36 Rue Henri Barbusse 18150,,,,36 Rue Henri Barbusse,,,La Guerche-sur-l'Aubois,
-36 Rue Henri Barbusse,2.946167,46.950493,,36 Rue Henri Barbusse,,,,18150
-14 Rue du Plessis Lignières,,,,14 Rue du Plessis,,,,18160
-14 Rue du Plessis 18160,,,,14 Rue du Plessis,,,Lignières,
-14 Rue du Plessis,2.172512,46.748235,,14 Rue du Plessis,,,,18160
-3 Rue du Lavoir Mehun-sur-Yèvre,,,,3 Rue du Lavoir,,,,18500
-3 Rue du Lavoir 18500,,,,3 Rue du Lavoir,,,Mehun-sur-Yèvre,
-3 Rue du Lavoir,2.207491,47.115961,,3 Rue du Lavoir,,,,18500
-10 Allée des Bouleaux Nançay,,,,10 Allée des Bouleaux,,,,18330
-10 Allée des Bouleaux 18330,,,,10 Allée des Bouleaux,,,Nançay,
-10 Allée des Bouleaux,2.191169,47.354911,,10 Allée des Bouleaux,,,,18330
-26 Route de Jacques au Bois Preuilly,,,,26 Route de Jacques au Bois,,,,18120
-26 Route de Jacques au Bois 18120,,,,26 Route de Jacques au Bois,,,Preuilly,
-26 Route de Jacques au Bois,2.170297,47.093878,,26 Route de Jacques au Bois,,,,18120
-183 Avenue du 1er Régiment d'Infanterie Saint-Amand-Montrond,,,,183 Avenue du 1er Régiment d'Infanterie,,,,18200
-183 Avenue du 1er Régiment d'Infanterie 18200,,,,183 Avenue du 1er Régiment d'Infanterie,,,Saint-Amand-Montrond,
-183 Avenue du 1er Régiment d'Infanterie,2.511096,46.727887,,183 Avenue du 1er Régiment d'Infanterie,,,,18200
-26 Rue du Village d'en Haut Saint-Doulchard,,,,26 Rue du Village d'en Haut,,,,18230
-26 Rue du Village d'en Haut 18230,,,,26 Rue du Village d'en Haut,,,Saint-Doulchard,
-26 Rue du Village d'en Haut,2.349832,47.108245,,26 Rue du Village d'en Haut,,,,18230
-5 Rue Maréchal Joffre Saint-Germain-du-Puy,,,,5 Rue Maréchal Joffre,,,,18000
-5 Rue Maréchal Joffre 18000,,,,5 Rue Maréchal Joffre,,,Saint-Germain-du-Puy,
-5 Rue Maréchal Joffre,2.488517,47.103290,,5 Rue Maréchal Joffre,,,,18000
-5 Ruelle de Chavignol Sancerre,,,,5 Ruelle de Chavignol,,,,18300
-5 Ruelle de Chavignol 18300,,,,5 Ruelle de Chavignol,,,Sancerre,
-5 Ruelle de Chavignol,2.837874,47.331148,,5 Ruelle de Chavignol,,,,18300
-208 Route de la Chapelle Trouy,,,,208 Route de la Chapelle,,,,18570
-208 Route de la Chapelle 18570,,,,208 Route de la Chapelle,,,Trouy,
-208 Route de la Chapelle,2.364685,47.014987,,208 Route de la Chapelle,,,,18570
-67A Rue du Bas de Grange Vierzon,,,,67A Rue du Bas de Grange,,,,18100
-67A Rue du Bas de Grange 18100,,,,67A Rue du Bas de Grange,,,Vierzon,
-67A Rue du Bas de Grange,2.052538,47.224598,,67A Rue du Bas de Grange,,,,18100
-68 Square Henriette Dumuin Vierzon,,,,68 Square Henriette Dumuin,,,,18100
-68 Square Henriette Dumuin 18100,,,,68 Square Henriette Dumuin,,,Vierzon,
-68 Square Henriette Dumuin,2.079353,47.202297,,68 Square Henriette Dumuin,,,,18100
-12 Place Vaillant Couturier Vierzon,,,,12 Place Vaillant Couturier,,,,18100
-12 Place Vaillant Couturier 18100,,,,12 Place Vaillant Couturier,,,Vierzon,
-12 Place Vaillant Couturier,2.069506,47.223536,,12 Place Vaillant Couturier,,,,18100
-13 Rue Saint-Rémy Auneau,,,,13 Rue Saint-Rémy,,,,28700
-13 Rue Saint-Rémy 28700,,,,13 Rue Saint-Rémy,,,Auneau,
-13 Rue Saint-Rémy,1.774075,48.465430,,13 Rue Saint-Rémy,,,,28700
-2 Rue de Theuville Berchères-les-Pierres,,,,2 Rue de Theuville,,,,28630
-2 Rue de Theuville 28630,,,,2 Rue de Theuville,,,Berchères-les-Pierres,
-2 Rue de Theuville,1.538225,48.366488,,2 Rue de Theuville,,,,28630
-41 Rue de la Forge Le Boullay-Mivoye,,,,41 Rue de la Forge,,,,28210
-41 Rue de la Forge 28210,,,,41 Rue de la Forge,,,Le Boullay-Mivoye,
-41 Rue de la Forge,1.407866,48.650487,,41 Rue de la Forge,,,,28210
-1 Place des Acloutis Champhol,,,,1 Place des Acloutis,,,,28300
-1 Place des Acloutis 28300,,,,1 Place des Acloutis,,,Champhol,
-1 Place des Acloutis,1.504722,48.474293,,1 Place des Acloutis,,,,28300
-67 Boulevard Charles Péguy Chartres,,,,67 Boulevard Charles Péguy,,,,28000
-67 Boulevard Charles Péguy 28000,,,,67 Boulevard Charles Péguy,,,Chartres,
-67 Boulevard Charles Péguy,1.487727,48.452712,,67 Boulevard Charles Péguy,,,,28000
-13 Rue Nicole Chartres,,,,13 Rue Nicole,,,,28000
-13 Rue Nicole 28000,,,,13 Rue Nicole,,,Chartres,
-13 Rue Nicole,1.480597,48.447016,,13 Rue Nicole,,,,28000
-3 Chemin du Clos de Néchée Châteaudun,,,,3 Chemin du Clos de Néchée,,,,28200
-3 Chemin du Clos de Néchée 28200,,,,3 Chemin du Clos de Néchée,,,Châteaudun,
-3 Chemin du Clos de Néchée,1.344391,48.090342,,3 Chemin du Clos de Néchée,,,,28200
-7 Rue du Chêne de Lorette Châteauneuf-en-Thymerais,,,,7 Rue du Chêne de Lorette,,,,28170
-7 Rue du Chêne de Lorette 28170,,,,7 Rue du Chêne de Lorette,,,Châteauneuf-en-Thymerais,
-7 Rue du Chêne de Lorette,1.237948,48.582038,,7 Rue du Chêne de Lorette,,,,28170
-14A Avenue du 11 Novembre Cloyes-sur-le-Loir,,,,14A Avenue du 11 Novembre,,,,28220
-14A Avenue du 11 Novembre 28220,,,,14A Avenue du 11 Novembre,,,Cloyes-sur-le-Loir,
-14A Avenue du 11 Novembre,1.239230,47.994298,,14A Avenue du 11 Novembre,,,,28220
-25 Rue de l'Ancien Château Crécy-Couvé,,,,25 Rue de l'Ancien Château,,,,28500
-25 Rue de l'Ancien Château 28500,,,,25 Rue de l'Ancien Château,,,Crécy-Couvé,
-25 Rue de l'Ancien Château,1.280891,48.669260,,25 Rue de l'Ancien Château,,,,28500
-13 Boulevard Condorcet Dreux,,,,13 Boulevard Condorcet,,,,28100
-13 Boulevard Condorcet 28100,,,,13 Boulevard Condorcet,,,Dreux,
-13 Boulevard Condorcet,1.375718,48.722557,,13 Boulevard Condorcet,,,,28100
-6 Rue Théophile Ferré Dreux,,,,6 Rue Théophile Ferré,,,,28100
-6 Rue Théophile Ferré 28100,,,,6 Rue Théophile Ferré,,,Dreux,
-6 Rue Théophile Ferré,1.392780,48.740383,,6 Rue Théophile Ferré,,,,28100
-19 Rue de la Ferriere Fontaine-Simon,,,,19 Rue de la Ferriere,,,,28240
-19 Rue de la Ferriere 28240,,,,19 Rue de la Ferriere,,,Fontaine-Simon,
-19 Rue de la Ferriere,1.015190,48.517262,,19 Rue de la Ferriere,,,,28240
-17 Avenue Gustave Eiffel Gellainville,,,,17 Avenue Gustave Eiffel,,,,28630
-17 Avenue Gustave Eiffel 28630,,,,17 Avenue Gustave Eiffel,,,Gellainville,
-17 Avenue Gustave Eiffel,1.526327,48.435774,,17 Avenue Gustave Eiffel,,,,28630
-28 Rue de la Sinetterie Illiers-Combray,,,,28 Rue de la Sinetterie,,,,28120
-28 Rue de la Sinetterie 28120,,,,28 Rue de la Sinetterie,,,Illiers-Combray,
-28 Rue de la Sinetterie,1.237575,48.297163,,28 Rue de la Sinetterie,,,,28120
-18 Rue Émile Grapperon Levesville-la-Chenard,,,,18 Rue Émile Grapperon,,,,28310
-18 Rue Émile Grapperon 28310,,,,18 Rue Émile Grapperon,,,Levesville-la-Chenard,
-18 Rue Émile Grapperon,1.825194,48.302627,,18 Rue Émile Grapperon,,,,28310
-47BIS Avenue Maurice Maunoury Luisant,,,,47BIS Avenue Maurice Maunoury,,,,28600
-47BIS Avenue Maurice Maunoury 28600,,,,47BIS Avenue Maurice Maunoury,,,Luisant,
-47BIS Avenue Maurice Maunoury,1.477670,48.433557,,47BIS Avenue Maurice Maunoury,,,,28600
-3 Rue de la Mare Corbonne Mainvilliers,,,,3 Rue de la Mare Corbonne,,,,28300
-3 Rue de la Mare Corbonne 28300,,,,3 Rue de la Mare Corbonne,,,Mainvilliers,
-3 Rue de la Mare Corbonne,1.444060,48.467527,,3 Rue de la Mare Corbonne,,,,28300
-14 Rue de Vucennes Moléans,,,,14 Rue de Vucennes,,,,28200
-14 Rue de Vucennes 28200,,,,14 Rue de Vucennes,,,Moléans,
-14 Rue de Vucennes,1.394591,48.114795,,14 Rue de Vucennes,,,,28200
-9 Rue Croix de la Comtesse Nogent-le-Rotrou,,,,9 Rue Croix de la Comtesse,,,,28400
-9 Rue Croix de la Comtesse 28400,,,,9 Rue Croix de la Comtesse,,,Nogent-le-Rotrou,
-9 Rue Croix de la Comtesse,0.810984,48.322800,,9 Rue Croix de la Comtesse,,,,28400
-12 Résidence de la Vigne Blanche Oysonville,,,,12 Résidence de la Vigne Blanche,,,,28700
-12 Résidence de la Vigne Blanche 28700,,,,12 Résidence de la Vigne Blanche,,,Oysonville,
-12 Résidence de la Vigne Blanche,1.949299,48.395037,,12 Résidence de la Vigne Blanche,,,,28700
-14 Impasse des Begnoux Saint-Denis-les-Ponts,,,,14 Impasse des Begnoux,,,,28200
-14 Impasse des Begnoux 28200,,,,14 Impasse des Begnoux,,,Saint-Denis-les-Ponts,
-14 Impasse des Begnoux,1.281410,48.068079,,14 Impasse des Begnoux,,,,28200
-32 Rue Achille Méningand Saint-Prest,,,,32 Rue Achille Méningand,,,,28300
-32 Rue Achille Méningand 28300,,,,32 Rue Achille Méningand,,,Saint-Prest,
-32 Rue Achille Méningand,1.527219,48.483663,,32 Rue Achille Méningand,,,,28300
-58 Rue de la Ferte Vidame Senonches,,,,58 Rue de la Ferte Vidame,,,,28250
-58 Rue de la Ferte Vidame 28250,,,,58 Rue de la Ferte Vidame,,,Senonches,
-58 Rue de la Ferte Vidame,1.023406,48.570436,,58 Rue de la Ferte Vidame,,,,28250
-8 Rue Hector Boudon Thivars,,,,8 Rue Hector Boudon,,,,28630
-8 Rue Hector Boudon 28630,,,,8 Rue Hector Boudon,,,Thivars,
-8 Rue Hector Boudon,1.451522,48.379578,,8 Rue Hector Boudon,,,,28630
-23 Rue de la Mare Neuve Vernouillet,,,,23 Rue de la Mare Neuve,,,,28500
-23 Rue de la Mare Neuve 28500,,,,23 Rue de la Mare Neuve,,,Vernouillet,
-23 Rue de la Mare Neuve,1.327361,48.725372,,23 Rue de la Mare Neuve,,,,28500
-3 Rue de Duan Yèvres,,,,3 Rue de Duan,,,,28160
-3 Rue de Duan 28160,,,,3 Rue de Duan,,,Yèvres,
-3 Rue de Duan,1.190651,48.206269,,3 Rue de Duan,,,,28160
-54 Route de Pellevoisin Argy,,,,54 Route de Pellevoisin,,,,36500
-54 Route de Pellevoisin 36500,,,,54 Route de Pellevoisin,,,Argy,
-54 Route de Pellevoisin,1.436044,46.944336,,54 Route de Pellevoisin,,,,36500
-6 Ruelle de Preneau Les Bordes,,,,6 Ruelle de Preneau,,,,36100
-6 Ruelle de Preneau 36100,,,,6 Ruelle de Preneau,,,Les Bordes,
-6 Ruelle de Preneau,1.977993,46.978738,,6 Ruelle de Preneau,,,,36100
-14 Rue de la Gare Chaillac,,,,14 Rue de la Gare,,,,36310
-14 Rue de la Gare 36310,,,,14 Rue de la Gare,,,Chaillac,
-14 Rue de la Gare,1.298489,46.438845,,14 Rue de la Gare,,,,36310
-29 Rue Diderot Châteauroux,,,,29 Rue Diderot,,,,36000
-29 Rue Diderot 36000,,,,29 Rue Diderot,,,Châteauroux,
-29 Rue Diderot,1.692176,46.810163,,29 Rue Diderot,,,,36000
-6 Rue du Maréchal Lyautey Châteauroux,,,,6 Rue du Maréchal Lyautey,,,,36000
-6 Rue du Maréchal Lyautey 36000,,,,6 Rue du Maréchal Lyautey,,,Châteauroux,
-6 Rue du Maréchal Lyautey,1.718641,46.805242,,6 Rue du Maréchal Lyautey,,,,36000
-29 Rue des Tamaris Châteauroux,,,,29 Rue des Tamaris,,,,36000
-29 Rue des Tamaris 36000,,,,29 Rue des Tamaris,,,Châteauroux,
-29 Rue des Tamaris,1.695148,46.792218,,29 Rue des Tamaris,,,,36000
-1 Domaine de l'Epinat La Châtre-Langlin,,,,1 Domaine de l'Epinat,,,,36170
-1 Domaine de l'Epinat 36170,,,,1 Domaine de l'Epinat,,,La Châtre-Langlin,
-1 Domaine de l'Epinat,1.401510,46.424200,,1 Domaine de l'Epinat,,,,36170
-12 Allée des Myrtilles Déols,,,,12 Allée des Myrtilles,,,,36130
-12 Allée des Myrtilles 36130,,,,12 Allée des Myrtilles,,,Déols,
-12 Allée des Myrtilles,1.674838,46.855077,,12 Allée des Myrtilles,,,,36130
-6 Rue Chateaurenault Issoudun,,,,6 Rue Chateaurenault,,,,36100
-6 Rue Chateaurenault 36100,,,,6 Rue Chateaurenault,,,Issoudun,
-6 Rue Chateaurenault,1.984536,46.941200,,6 Rue Chateaurenault,,,,36100
-69 Route de Châteauroux Levroux,,,,69 Route de Châteauroux,,,,36110
-69 Route de Châteauroux 36110,,,,69 Route de Châteauroux,,,Levroux,
-69 Route de Châteauroux,1.613793,46.974386,,69 Route de Châteauroux,,,,36110
-10 Route de Chatellerault Mézières-en-Brenne,,,,10 Route de Chatellerault,,,,36290
-10 Route de Chatellerault 36290,,,,10 Route de Chatellerault,,,Mézières-en-Brenne,
-10 Route de Chatellerault,1.206500,46.821141,,10 Route de Chatellerault,,,,36290
-2 Rue Antoine Métivier Le Pêchereau,,,,2 Rue Antoine Métivier,,,,36200
-2 Rue Antoine Métivier 36200,,,,2 Rue Antoine Métivier,,,Le Pêchereau,
-2 Rue Antoine Métivier,1.530379,46.580898,,2 Rue Antoine Métivier,,,,36200
-4 Les Charrons Poulaines,,,,4 Les Charrons,,,,36210
-4 Les Charrons 36210,,,,4 Les Charrons,,,Poulaines,
-4 Les Charrons,1.662066,47.122551,,4 Les Charrons,,,,36210
-29 Rue du Docteur Jean-Jacques Renault Saint-Gaultier,,,,29 Rue du Docteur Jean-Jacques Renault,,,,36800
-29 Rue du Docteur Jean-Jacques Renault 36800,,,,29 Rue du Docteur Jean-Jacques Renault,,,Saint-Gaultier,
-29 Rue du Docteur Jean-Jacques Renault,1.415480,46.637377,,29 Rue du Docteur Jean-Jacques Renault,,,,36800
-1 Route de Nohant Sarzay,,,,1 Route de Nohant,,,,36230
-1 Route de Nohant 36230,,,,1 Route de Nohant,,,Sarzay,
-1 Route de Nohant,1.905263,46.601509,,1 Route de Nohant,,,,36230
-1 Rue du Prieuré Veuil,,,,1 Rue du Prieuré,,,,36600
-1 Rue du Prieuré 36600,,,,1 Rue du Prieuré,,,Veuil,
-1 Rue du Prieuré,1.522512,47.122010,,1 Rue du Prieuré,,,,36600
-15 Avenue de Tours Amboise,,,,15 Avenue de Tours,,,,37400
-15 Avenue de Tours 37400,,,,15 Avenue de Tours,,,Amboise,
-15 Avenue de Tours,0.972630,47.409421,,15 Avenue de Tours,,,,37400
-9 Allée des Rogareaux Azay-le-Rideau,,,,9 Allée des Rogareaux,,,,37190
-9 Allée des Rogareaux 37190,,,,9 Allée des Rogareaux,,,Azay-le-Rideau,
-9 Allée des Rogareaux,0.442993,47.267756,,9 Allée des Rogareaux,,,,37190
-6 Impasse du Carroi Forêt Beaumont-en-Véron,,,,6 Impasse du Carroi Forêt,,,,37420
-6 Impasse du Carroi Forêt 37420,,,,6 Impasse du Carroi Forêt,,,Beaumont-en-Véron,
-6 Impasse du Carroi Forêt,0.190098,47.203921,,6 Impasse du Carroi Forêt,,,,37420
-5 Rué Raymond Garrit Bourgueil,,,,5 Rué Raymond Garrit,,,,37140
-5 Rué Raymond Garrit 37140,,,,5 Rué Raymond Garrit,,,Bourgueil,
-5 Rué Raymond Garrit,0.173263,47.285568,,5 Rué Raymond Garrit,,,,37140
-7 Allée des Millepertuis Chambray-lès-Tours,,,,7 Allée des Millepertuis,,,,37170
-7 Allée des Millepertuis 37170,,,,7 Allée des Millepertuis,,,Chambray-lès-Tours,
-7 Allée des Millepertuis,0.708002,47.338651,,7 Allée des Millepertuis,,,,37170
-35 Avenue du Général de Gaulle Château-la-Vallière,,,,35 Avenue du Général de Gaulle,,,,37330
-35 Avenue du Général de Gaulle 37330,,,,35 Avenue du Général de Gaulle,,,Château-la-Vallière,
-35 Avenue du Général de Gaulle,0.325130,47.545154,,35 Avenue du Général de Gaulle,,,,37330
-231 Avenue François Mitterrand Chinon,,,,231 Avenue François Mitterrand,,,,37500
-231 Avenue François Mitterrand 37500,,,,231 Avenue François Mitterrand,,,Chinon,
-231 Avenue François Mitterrand,0.257392,47.175384,,231 Avenue François Mitterrand,,,,37500
-19BIS Rue de la Vallée de Mesvres Civray-de-Touraine,,,,19BIS Rue de la Vallée de Mesvres,,,,37150
-19BIS Rue de la Vallée de Mesvres 37150,,,,19BIS Rue de la Vallée de Mesvres,,,Civray-de-Touraine,
-19BIS Rue de la Vallée de Mesvres,1.018945,47.344801,,19BIS Rue de la Vallée de Mesvres,,,,37150
-6 Allée de Montafilent Esvres,,,,6 Allée de Montafilent,,,,37320
-6 Allée de Montafilent 37320,,,,6 Allée de Montafilent,,,Esvres,
-6 Allée de Montafilent,0.788670,47.287886,,6 Allée de Montafilent,,,,37320
-14 Rue Richard Wagner Francueil,,,,14 Rue Richard Wagner,,,,37150
-14 Rue Richard Wagner 37150,,,,14 Rue Richard Wagner,,,Francueil,
-14 Rue Richard Wagner,1.079193,47.315516,,14 Rue Richard Wagner,,,,37150
-72 Rue d'Amboise Joué-lès-Tours,,,,72 Rue d'Amboise,,,,37300
-72 Rue d'Amboise 37300,,,,72 Rue d'Amboise,,,Joué-lès-Tours,
-72 Rue d'Amboise,0.676216,47.345195,,72 Rue d'Amboise,,,,37300
-6 Rue Louis Breguet Joué-lès-Tours,,,,6 Rue Louis Breguet,,,,37300
-6 Rue Louis Breguet 37300,,,,6 Rue Louis Breguet,,,Joué-lès-Tours,
-6 Rue Louis Breguet,0.680579,47.352085,,6 Rue Louis Breguet,,,,37300
-36 Rue de Bellevue Larçay,,,,36 Rue de Bellevue,,,,37270
-36 Rue de Bellevue 37270,,,,36 Rue de Bellevue,,,Larçay,
-36 Rue de Bellevue,0.776955,47.365398,,36 Rue de Bellevue,,,,37270
-24 Rue de la Porte Poitevine Loches,,,,24 Rue de la Porte Poitevine,,,,37600
-24 Rue de la Porte Poitevine 37600,,,,24 Rue de la Porte Poitevine,,,Loches,
-24 Rue de la Porte Poitevine,0.995252,47.124085,,24 Rue de la Porte Poitevine,,,,37600
-3 Allée du Bois La Membrolle-sur-Choisille,,,,3 Allée du Bois,,,,37390
-3 Allée du Bois 37390,,,,3 Allée du Bois,,,La Membrolle-sur-Choisille,
-3 Allée du Bois,0.628461,47.434409,,3 Allée du Bois,,,,37390
-53 Rue de Boisdenier Montlouis-sur-Loire,,,,53 Rue de Boisdenier,,,,37270
-53 Rue de Boisdenier 37270,,,,53 Rue de Boisdenier,,,Montlouis-sur-Loire,
-53 Rue de Boisdenier,0.818107,47.385128,,53 Rue de Boisdenier,,,,37270
-5 Rue Georges Bernard Monts,,,,5 Rue Georges Bernard,,,,37260
-5 Rue Georges Bernard 37260,,,,5 Rue Georges Bernard,,,Monts,
-5 Rue Georges Bernard,0.622143,47.277234,,5 Rue Georges Bernard,,,,37260
-2 Rue des Prés Neuvy-le-Roi,,,,2 Rue des Prés,,,,37370
-2 Rue des Prés 37370,,,,2 Rue des Prés,,,Neuvy-le-Roi,
-2 Rue des Prés,0.596078,47.602743,,2 Rue des Prés,,,,37370
-8 Avenue de la Cloutière Perrusson,,,,8 Avenue de la Cloutière,,,,37600
-8 Avenue de la Cloutière 37600,,,,8 Avenue de la Cloutière,,,Perrusson,
-8 Avenue de la Cloutière,1.009244,47.102277,,8 Avenue de la Cloutière,,,,37600
-13 Rue Paul Bert La Riche,,,,13 Rue Paul Bert,,,,37520
-13 Rue Paul Bert 37520,,,,13 Rue Paul Bert,,,La Riche,
-13 Rue Paul Bert,0.656840,47.386018,,13 Rue Paul Bert,,,,37520
-14 Chemin des Niveaux Saint-Antoine-du-Rocher,,,,14 Chemin des Niveaux,,,,37360
-14 Chemin des Niveaux 37360,,,,14 Chemin des Niveaux,,,Saint-Antoine-du-Rocher,
-14 Chemin des Niveaux,0.636916,47.494682,,14 Chemin des Niveaux,,,,37360
-1 Rue de la Sagerie Saint-Avertin,,,,1 Rue de la Sagerie,,,,37550
-1 Rue de la Sagerie 37550,,,,1 Rue de la Sagerie,,,Saint-Avertin,
-1 Rue de la Sagerie,0.714610,47.362534,,1 Rue de la Sagerie,,,,37550
-43 Rue Louis Bézard Saint-Cyr-sur-Loire,,,,43 Rue Louis Bézard,,,,37540
-43 Rue Louis Bézard 37540,,,,43 Rue Louis Bézard,,,Saint-Cyr-sur-Loire,
-43 Rue Louis Bézard,0.657954,47.404791,,43 Rue Louis Bézard,,,,37540
-3 Rue des Grillonnieres Saint-Martin-le-Beau,,,,3 Rue des Grillonnieres,,,,37270
-3 Rue des Grillonnieres 37270,,,,3 Rue des Grillonnieres,,,Saint-Martin-le-Beau,
-3 Rue des Grillonnieres,0.897749,47.358484,,3 Rue des Grillonnieres,,,,37270
-29 Rue de la Feuillarde Saint-Pierre-des-Corps,,,,29 Rue de la Feuillarde,,,,37700
-29 Rue de la Feuillarde 37700,,,,29 Rue de la Feuillarde,,,Saint-Pierre-des-Corps,
-29 Rue de la Feuillarde,0.723678,47.380303,,29 Rue de la Feuillarde,,,,37700
-12 Rue des Violettes Savigny-en-Véron,,,,12 Rue des Violettes,,,,37420
-12 Rue des Violettes 37420,,,,12 Rue des Violettes,,,Savigny-en-Véron,
-12 Rue des Violettes,0.152694,47.207823,,12 Rue des Violettes,,,,37420
-7 Rue Alleron Tours,,,,7 Rue Alleron,,,,37200
-7 Rue Alleron 37200,,,,7 Rue Alleron,,,Tours,
-7 Rue Alleron,0.675597,47.394770,,7 Rue Alleron,,,,37200
-38 Rue Christiaan Huygens Tours,,,,38 Rue Christiaan Huygens,,,,37200
-38 Rue Christiaan Huygens 37200,,,,38 Rue Christiaan Huygens,,,Tours,
-38 Rue Christiaan Huygens,0.705052,47.437002,,38 Rue Christiaan Huygens,,,,37200
-16 Rue de Franche-Comté Tours,,,,16 Rue de Franche-Comté,,,,37200
-16 Rue de Franche-Comté 37200,,,,16 Rue de Franche-Comté,,,Tours,
-16 Rue de Franche-Comté,0.679232,47.427341,,16 Rue de Franche-Comté,,,,37200
-235 Rue Jolivet Tours,,,,235 Rue Jolivet,,,,37200
-235 Rue Jolivet 37200,,,,235 Rue Jolivet,,,Tours,
-235 Rue Jolivet,0.706729,47.383546,,235 Rue Jolivet,,,,37200
-157 Rue du Pas Notre-Dame Tours,,,,157 Rue du Pas Notre-Dame,,,,37200
-157 Rue du Pas Notre-Dame 37200,,,,157 Rue du Pas Notre-Dame,,,Tours,
-157 Rue du Pas Notre-Dame,0.697255,47.417658,,157 Rue du Pas Notre-Dame,,,,37200
-183 Rue Victor Hugo Tours,,,,183 Rue Victor Hugo,,,,37200
-183 Rue Victor Hugo 37200,,,,183 Rue Victor Hugo,,,Tours,
-183 Rue Victor Hugo,0.677813,47.387514,,183 Rue Victor Hugo,,,,37200
-3 Rue du Puits des Desrès Véretz,,,,3 Rue du Puits des Desrès,,,,37270
-3 Rue du Puits des Desrès 37270,,,,3 Rue du Puits des Desrès,,,Véretz,
-3 Rue du Puits des Desrès,0.813758,47.347767,,3 Rue du Puits des Desrès,,,,37270
-9 Rue des Varennes Villiers-au-Bouin,,,,9 Rue des Varennes,,,,37330
-9 Rue des Varennes 37330,,,,9 Rue des Varennes,,,Villiers-au-Bouin,
-9 Rue des Varennes,0.308828,47.571630,,9 Rue des Varennes,,,,37330
-25 Rue du Bourg Neuf Blois,,,,25 Rue du Bourg Neuf,,,,41000
-25 Rue du Bourg Neuf 41000,,,,25 Rue du Bourg Neuf,,,Blois,
-25 Rue du Bourg Neuf,1.331564,47.589877,,25 Rue du Bourg Neuf,,,,41000
-120 Rue Jean Monnet Blois,,,,120 Rue Jean Monnet,,,,41000
-120 Rue Jean Monnet 41000,,,,120 Rue Jean Monnet,,,Blois,
-120 Rue Jean Monnet,1.297400,47.594269,,120 Rue Jean Monnet,,,,41000
-112 Levée des Tuileries Blois,,,,112 Levée des Tuileries,,,,41000
-112 Levée des Tuileries 41000,,,,112 Levée des Tuileries,,,Blois,
-112 Levée des Tuileries,1.352904,47.595024,,112 Levée des Tuileries,,,,41000
-31 Clos des Hirondelles Chailles,,,,31 Clos des Hirondelles,,,,41120
-31 Clos des Hirondelles 41120,,,,31 Clos des Hirondelles,,,Chailles,
-31 Clos des Hirondelles,1.309223,47.531554,,31 Clos des Hirondelles,,,,41120
-4 Rue de Tremblevif Chaumont-sur-Tharonne,,,,4 Rue de Tremblevif,,,,41600
-4 Rue de Tremblevif 41600,,,,4 Rue de Tremblevif,,,Chaumont-sur-Tharonne,
-4 Rue de Tremblevif,1.903786,47.607207,,4 Rue de Tremblevif,,,,41600
-4 Rue Abel Poulin Contres,,,,4 Rue Abel Poulin,,,,41700
-4 Rue Abel Poulin 41700,,,,4 Rue Abel Poulin,,,Contres,
-4 Rue Abel Poulin,1.428402,47.419241,,4 Rue Abel Poulin,,,,41700
-24 Route de Vendôme Danzé,,,,24 Route de Vendôme,,,,41160
-24 Route de Vendôme 41160,,,,24 Route de Vendôme,,,Danzé,
-24 Route de Vendôme,1.027969,47.887904,,24 Route de Vendôme,,,,41160
-28 Rue de Chitenay Fresnes,,,,28 Rue de Chitenay,,,,41700
-28 Rue de Chitenay 41700,,,,28 Rue de Chitenay,,,Fresnes,
-28 Rue de Chitenay,1.408784,47.438084,,28 Rue de Chitenay,,,,41700
-6 Rue du Four à Chaux Lamotte-Beuvron,,,,6 Rue du Four à Chaux,,,,41600
-6 Rue du Four à Chaux 41600,,,,6 Rue du Four à Chaux,,,Lamotte-Beuvron,
-6 Rue du Four à Chaux,2.023894,47.604778,,6 Rue du Four à Chaux,,,,41600
-5 Chemin de Bouesse Maslives,,,,5 Chemin de Bouesse,,,,41250
-5 Chemin de Bouesse 41250,,,,5 Chemin de Bouesse,,,Maslives,
-5 Chemin de Bouesse,1.481338,47.629457,,5 Chemin de Bouesse,,,,41250
-130 Rue Leon Gambetta Meusnes,,,,130 Rue Leon Gambetta,,,,41130
-130 Rue Leon Gambetta 41130,,,,130 Rue Leon Gambetta,,,Meusnes,
-130 Rue Leon Gambetta,1.496977,47.247973,,130 Rue Leon Gambetta,,,,41130
-30 Rue de Champigny Montoire-sur-le-Loir,,,,30 Rue de Champigny,,,,41800
-30 Rue de Champigny 41800,,,,30 Rue de Champigny,,,Montoire-sur-le-Loir,
-30 Rue de Champigny,0.880125,47.763254,,30 Rue de Champigny,,,,41800
-10 Rue du Bois Neuf Morée,,,,10 Rue du Bois Neuf,,,,41160
-10 Rue du Bois Neuf 41160,,,,10 Rue du Bois Neuf,,,Morée,
-10 Rue du Bois Neuf,1.234117,47.899955,,10 Rue du Bois Neuf,,,,41160
-17 Rue des Hirondelles Noyers-sur-Cher,,,,17 Rue des Hirondelles,,,,41140
-17 Rue des Hirondelles 41140,,,,17 Rue des Hirondelles,,,Noyers-sur-Cher,
-17 Rue des Hirondelles,1.411315,47.275140,,17 Rue des Hirondelles,,,,41140
-3 Rue Saint-Martin Périgny,,,,3 Rue Saint-Martin,,,,41100
-3 Rue Saint-Martin 41100,,,,3 Rue Saint-Martin,,,Périgny,
-3 Rue Saint-Martin,1.151173,47.738629,,3 Rue Saint-Martin,,,,41100
-11 Rue des Champs Ragot Romorantin-Lanthenay,,,,11 Rue des Champs Ragot,,,,41200
-11 Rue des Champs Ragot 41200,,,,11 Rue des Champs Ragot,,,Romorantin-Lanthenay,
-11 Rue des Champs Ragot,1.741124,47.354267,,11 Rue des Champs Ragot,,,,41200
-25 Rue de la Pierre Romorantin-Lanthenay,,,,25 Rue de la Pierre,,,,41200
-25 Rue de la Pierre 41200,,,,25 Rue de la Pierre,,,Romorantin-Lanthenay,
-25 Rue de la Pierre,1.746458,47.358604,,25 Rue de la Pierre,,,,41200
-4 Rue des Acacias Saint-Claude-de-Diray,,,,4 Rue des Acacias,,,,41350
-4 Rue des Acacias 41350,,,,4 Rue des Acacias,,,Saint-Claude-de-Diray,
-4 Rue des Acacias,1.426361,47.612697,,4 Rue des Acacias,,,,41350
-3 Rue Clément Héron Saint-Hilaire-la-Gravelle,,,,3 Rue Clément Héron,,,,41160
-3 Rue Clément Héron 41160,,,,3 Rue Clément Héron,,,Saint-Hilaire-la-Gravelle,
-3 Rue Clément Héron,1.198098,47.925642,,3 Rue Clément Héron,,,,41160
-4 Rue Maryse Bastié Saint-Ouen,,,,4 Rue Maryse Bastié,,,,41100
-4 Rue Maryse Bastié 41100,,,,4 Rue Maryse Bastié,,,Saint-Ouen,
-4 Rue Maryse Bastié,1.080344,47.808681,,4 Rue Maryse Bastié,,,,41100
-33 Rue de la Victoire Salbris,,,,33 Rue de la Victoire,,,,41300
-33 Rue de la Victoire 41300,,,,33 Rue de la Victoire,,,Salbris,
-33 Rue de la Victoire,2.043129,47.421030,,33 Rue de la Victoire,,,,41300
-6 Rue de Romorantin Selles-sur-Cher,,,,6 Rue de Romorantin,,,,41130
-6 Rue de Romorantin 41130,,,,6 Rue de Romorantin,,,Selles-sur-Cher,
-6 Rue de Romorantin,1.558070,47.278860,,6 Rue de Romorantin,,,,41130
-48 Rue de la Fontaine Herbault Thésée,,,,48 Rue de la Fontaine Herbault,,,,41140
-48 Rue de la Fontaine Herbault 41140,,,,48 Rue de la Fontaine Herbault,,,Thésée,
-48 Rue de la Fontaine Herbault,1.331861,47.328914,,48 Rue de la Fontaine Herbault,,,,41140
-24 Avenue de l'Ile-de-France Vendôme,,,,24 Avenue de l'Ile-de-France,,,,41100
-24 Avenue de l'Ile-de-France 41100,,,,24 Avenue de l'Ile-de-France,,,Vendôme,
-24 Avenue de l'Ile-de-France,1.048803,47.807139,,24 Avenue de l'Ile-de-France,,,,41100
-14 Rue des Laurières Villebarou,,,,14 Rue des Laurières,,,,41000
-14 Rue des Laurières 41000,,,,14 Rue des Laurières,,,Villebarou,
-14 Rue des Laurières,1.310160,47.627935,,14 Rue des Laurières,,,,41000
-1 Chemin Francis Poulenc Vineuil,,,,1 Chemin Francis Poulenc,,,,41350
-1 Chemin Francis Poulenc 41350,,,,1 Chemin Francis Poulenc,,,Vineuil,
-1 Chemin Francis Poulenc,1.378604,47.583707,,1 Chemin Francis Poulenc,,,,41350
-41 Rue Vincent Scotto Amilly,,,,41 Rue Vincent Scotto,,,,45200
-41 Rue Vincent Scotto 45200,,,,41 Rue Vincent Scotto,,,Amilly,
-41 Rue Vincent Scotto,2.771866,47.974990,,41 Rue Vincent Scotto,,,,45200
-41 Rue Jean Bordier Baule,,,,41 Rue Jean Bordier,,,,45130
-41 Rue Jean Bordier 45130,,,,41 Rue Jean Bordier,,,Baule,
-41 Rue Jean Bordier,1.667553,47.812117,,41 Rue Jean Bordier,,,,45130
-54 Allée du Château Bellegarde,,,,54 Allée du Château,,,,45270
-54 Allée du Château 45270,,,,54 Allée du Château,,,Bellegarde,
-54 Allée du Château,2.439309,47.980891,,54 Allée du Château,,,,45270
-28 Rue du Bourg Boulay-les-Barres,,,,28 Rue du Bourg,,,,45140
-28 Rue du Bourg 45140,,,,28 Rue du Bourg,,,Boulay-les-Barres,
-28 Rue du Bourg,1.782356,47.978204,,28 Rue du Bourg,,,,45140
-19 Rue de la Pierre Aux Fées Cepoy,,,,19 Rue de la Pierre Aux Fées,,,,45120
-19 Rue de la Pierre Aux Fées 45120,,,,19 Rue de la Pierre Aux Fées,,,Cepoy,
-19 Rue de la Pierre Aux Fées,2.745274,48.042633,,19 Rue de la Pierre Aux Fées,,,,45120
-60 Rue La Fontaine Châlette-sur-Loing,,,,60 Rue La Fontaine,,,,45120
-60 Rue La Fontaine 45120,,,,60 Rue La Fontaine,,,Châlette-sur-Loing,
-60 Rue La Fontaine,2.733240,48.036876,,60 Rue La Fontaine,,,,45120
-31 Rue des Muids La Chapelle-Saint-Mesmin,,,,31 Rue des Muids,,,,45380
-31 Rue des Muids 45380,,,,31 Rue des Muids,,,La Chapelle-Saint-Mesmin,
-31 Rue des Muids,1.817805,47.886850,,31 Rue des Muids,,,,45380
-225 Faubourg de Courtenay Château-Renard,,,,225 Faubourg de Courtenay,,,,45220
-225 Faubourg de Courtenay 45220,,,,225 Faubourg de Courtenay,,,Château-Renard,
-225 Faubourg de Courtenay,2.929659,47.935195,,225 Faubourg de Courtenay,,,,45220
-68 Rue Maréchal Leclerc Chécy,,,,68 Rue Maréchal Leclerc,,,,45430
-68 Rue Maréchal Leclerc 45430,,,,68 Rue Maréchal Leclerc,,,Chécy,
-68 Rue Maréchal Leclerc,2.019557,47.892910,,68 Rue Maréchal Leclerc,,,,45430
-35BIS Rue de la Perrière Cléry-Saint-André,,,,35BIS Rue de la Perrière,,,,45370
-35BIS Rue de la Perrière 45370,,,,35BIS Rue de la Perrière,,,Cléry-Saint-André,
-35BIS Rue de la Perrière,1.789373,47.844877,,35BIS Rue de la Perrière,,,,45370
-18 Rue Jacques Tenon Courtenay,,,,18 Rue Jacques Tenon,,,,45320
-18 Rue Jacques Tenon 45320,,,,18 Rue Jacques Tenon,,,Courtenay,
-18 Rue Jacques Tenon,3.048843,48.036299,,18 Rue Jacques Tenon,,,,45320
-20 Rue de Bel Air Dordives,,,,20 Rue de Bel Air,,,,45680
-20 Rue de Bel Air 45680,,,,20 Rue de Bel Air,,,Dordives,
-20 Rue de Bel Air,2.774513,48.143976,,20 Rue de Bel Air,,,,45680
-5 Place de l'Église Férolles,,,,5 Place de l'Église,,,,45150
-5 Place de l'Église 45150,,,,5 Place de l'Église,,,Férolles,
-5 Place de l'Église,2.111023,47.835420,,5 Place de l'Église,,,,45150
-7 Rue De La Barrière Saint-Marc Fleury-les-Aubrais,,,,7 Rue De La Barrière Saint-Marc,,,,45400
-7 Rue De La Barrière Saint-Marc 45400,,,,7 Rue De La Barrière Saint-Marc,,,Fleury-les-Aubrais,
-7 Rue De La Barrière Saint-Marc,1.918891,47.920081,,7 Rue De La Barrière Saint-Marc,,,,45400
-28 Rue des Gillets Fontenay-sur-Loing,,,,28 Rue des Gillets,,,,45210
-28 Rue des Gillets 45210,,,,28 Rue des Gillets,,,Fontenay-sur-Loing,
-28 Rue des Gillets,2.770785,48.089684,,28 Rue des Gillets,,,,45210
-36 Rue du Pont Boucherot Gien,,,,36 Rue du Pont Boucherot,,,,45500
-36 Rue du Pont Boucherot 45500,,,,36 Rue du Pont Boucherot,,,Gien,
-36 Rue du Pont Boucherot,2.633923,47.687590,,36 Rue du Pont Boucherot,,,,45500
-2 Rue des Guettes Ingré,,,,2 Rue des Guettes,,,,45140
-2 Rue des Guettes 45140,,,,2 Rue des Guettes,,,Ingré,
-2 Rue des Guettes,1.839599,47.937674,,2 Rue des Guettes,,,,45140
-7 Chemin du Gd Noyer Lailly-en-Val,,,,7 Chemin du Gd Noyer,,,,45740
-7 Chemin du Gd Noyer 45740,,,,7 Chemin du Gd Noyer,,,Lailly-en-Val,
-7 Chemin du Gd Noyer,1.675931,47.755838,,7 Chemin du Gd Noyer,,,,45740
-5BIS Rue de la Pilonne Malesherbes,,,,5BIS Rue de la Pilonne,,,,45330
-5BIS Rue de la Pilonne 45330,,,,5BIS Rue de la Pilonne,,,Malesherbes,
-5BIS Rue de la Pilonne,2.414518,48.296287,,5BIS Rue de la Pilonne,,,,45330
-3 Avenue des Deportes Meung-sur-Loire,,,,3 Avenue des Deportes,,,,45130
-3 Avenue des Deportes 45130,,,,3 Avenue des Deportes,,,Meung-sur-Loire,
-3 Avenue des Deportes,1.692320,47.820508,,3 Avenue des Deportes,,,,45130
-10 Rue Paul Doumer Montargis,,,,10 Rue Paul Doumer,,,,45200
-10 Rue Paul Doumer 45200,,,,10 Rue Paul Doumer,,,Montargis,
-10 Rue Paul Doumer,2.743307,47.998723,,10 Rue Paul Doumer,,,,45200
-145 Grande Rue La Grande Rue La Neuville-sur-Essonne,,,,145 Grande Rue La Grande Rue,,,,45390
-145 Grande Rue La Grande Rue 45390,,,,145 Grande Rue La Grande Rue,,,La Neuville-sur-Essonne,
-145 Grande Rue La Grande Rue,2.375898,48.186715,,145 Grande Rue La Grande Rue,,,,45390
-43 Allée François Rude Olivet,,,,43 Allée François Rude,,,,45160
-43 Allée François Rude 45160,,,,43 Allée François Rude,,,Olivet,
-43 Allée François Rude,1.896843,47.879371,,43 Allée François Rude,,,,45160
-34 Rue de l'Argonne Orléans,,,,34 Rue de l'Argonne,,,,45000
-34 Rue de l'Argonne 45000,,,,34 Rue de l'Argonne,,,Orléans,
-34 Rue de l'Argonne,1.920233,47.914950,,34 Rue de l'Argonne,,,,45000
-24 Rue des Closiers Orléans,,,,24 Rue des Closiers,,,,45000
-24 Rue des Closiers 45000,,,,24 Rue des Closiers,,,Orléans,
-24 Rue des Closiers,1.888021,47.922952,,24 Rue des Closiers,,,,45000
-15 Rue Jean Perrin Orléans,,,,15 Rue Jean Perrin,,,,45000
-15 Rue Jean Perrin 45000,,,,15 Rue Jean Perrin,,,Orléans,
-15 Rue Jean Perrin,1.924820,47.834096,,15 Rue Jean Perrin,,,,45000
-99 Rue du Poirier Rond Orléans,,,,99 Rue du Poirier Rond,,,,45000
-99 Rue du Poirier Rond 45000,,,,99 Rue du Poirier Rond,,,Orléans,
-99 Rue du Poirier Rond,1.922283,47.916946,,99 Rue du Poirier Rond,,,,45000
-8 Rue des Ormes Orveau-Bellesauve,,,,8 Rue des Ormes,,,,45330
-8 Rue des Ormes 45330,,,,8 Rue des Ormes,,,Orveau-Bellesauve,
-8 Rue des Ormes,2.330965,48.281906,,8 Rue des Ormes,,,,45330
-62 Faubourg Blavetin Patay,,,,62 Faubourg Blavetin,,,,45310
-62 Faubourg Blavetin 45310,,,,62 Faubourg Blavetin,,,Patay,
-62 Faubourg Blavetin,1.699400,48.041618,,62 Faubourg Blavetin,,,,45310
-12 Sentier des Mésanges Puiseaux,,,,12 Sentier des Mésanges,,,,45390
-12 Sentier des Mésanges 45390,,,,12 Sentier des Mésanges,,,Puiseaux,
-12 Sentier des Mésanges,2.464618,48.204955,,12 Sentier des Mésanges,,,,45390
-6 Rue de Concyr Saint-Cyr-en-Val,,,,6 Rue de Concyr,,,,45590
-6 Rue de Concyr 45590,,,,6 Rue de Concyr,,,Saint-Cyr-en-Val,
-6 Rue de Concyr,1.932737,47.813521,,6 Rue de Concyr,,,,45590
-7 Rue de l'Église Saint-Firmin-sur-Loire,,,,7 Rue de l'Église,,,,45360
-7 Rue de l'Église 45360,,,,7 Rue de l'Église,,,Saint-Firmin-sur-Loire,
-7 Rue de l'Église,2.731858,47.625522,,7 Rue de l'Église,,,,45360
-153 Rue de Frédeville Saint-Jean-de-Braye,,,,153 Rue de Frédeville,,,,45800
-153 Rue de Frédeville 45800,,,,153 Rue de Frédeville,,,Saint-Jean-de-Braye,
-153 Rue de Frédeville,1.989791,47.914653,,153 Rue de Frédeville,,,,45800
-41 Rue de la Grade Saint-Jean-de-la-Ruelle,,,,41 Rue de la Grade,,,,45140
-41 Rue de la Grade 45140,,,,41 Rue de la Grade,,,Saint-Jean-de-la-Ruelle,
-41 Rue de la Grade,1.879439,47.925625,,41 Rue de la Grade,,,,45140
-344 Route de Poilly Saint-Martin-sur-Ocre,,,,344 Route de Poilly,,,,45500
-344 Route de Poilly 45500,,,,344 Route de Poilly,,,Saint-Martin-sur-Ocre,
-344 Route de Poilly,2.639578,47.663001,,344 Route de Poilly,,,,45500
-234 Route de Saint-Cyr Sandillon,,,,234 Route de Saint-Cyr,,,,45640
-234 Route de Saint-Cyr 45640,,,,234 Route de Saint-Cyr,,,Sandillon,
-234 Route de Saint-Cyr,2.025484,47.845164,,234 Route de Saint-Cyr,,,,45640
-9 Route de Château Landon Sceaux-du-Gâtinais,,,,9 Route de Château Landon,,,,45490
-9 Route de Château Landon 45490,,,,9 Route de Château Landon,,,Sceaux-du-Gâtinais,
-9 Route de Château Landon,2.597670,48.105601,,9 Route de Château Landon,,,,45490
-1 Route de la Noue Boulaie Sury-aux-Bois,,,,1 Route de la Noue Boulaie,,,,45530
-1 Route de la Noue Boulaie 45530,,,,1 Route de la Noue Boulaie,,,Sury-aux-Bois,
-1 Route de la Noue Boulaie,2.335961,47.938405,,1 Route de la Noue Boulaie,,,,45530
-58 Rue de Neuville Vennecy,,,,58 Rue de Neuville,,,,45760
-58 Rue de Neuville 45760,,,,58 Rue de Neuville,,,Vennecy,
-58 Rue de Neuville,2.055721,47.958838,,58 Rue de Neuville,,,,45760
-16 Rue Georges Chardon Villorceau,,,,16 Rue Georges Chardon,,,,45190
-16 Rue Georges Chardon 45190,,,,16 Rue Georges Chardon,,,Villorceau,
-16 Rue Georges Chardon,1.595689,47.799576,,16 Rue Georges Chardon,,,,45190
-rue de saint denis saint denis en val,,,,Rue de Saint-Denis,,,Saint-Denis-en-Val,
-rue de saint denis en val,,,,Rue de Saint-Denis,,,Saint-Denis-en-Val,
-rue du val saint denis en Val,,,,Rue du Val,,,Saint-Denis-en-Val,
-rue du val saint denis,1.9422,47.9311,,Rue du Val,,,Saint-Denis-en-Val,
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+29 Rue du 11 Novembre 1918 Aubigny-sur-Nère,,,,29,Rue du 11 Novembre 1918,,18700
+29 Rue du 11 Novembre 1918 18700,,,,29,Rue du 11 Novembre 1918,Aubigny-sur-Nère,
+29 Rue du 11 Novembre 1918,2.426413,47.485419,,29,Rue du 11 Novembre 1918,,18700
+8 Rue Pierre Juglar Blancafort,,,,8,Rue Pierre Juglar,,18410
+8 Rue Pierre Juglar 18410,,,,8,Rue Pierre Juglar,Blancafort,
+8 Rue Pierre Juglar,2.531098,47.532249,,8,Rue Pierre Juglar,,18410
+10B Rue Claude Monet Bourges,,,,10B,Rue Claude Monet,,18000
+10B Rue Claude Monet 18000,,,,10B,Rue Claude Monet,Bourges,
+10B Rue Claude Monet,2.388023,47.074773,,10B,Rue Claude Monet,,18000
+6 Rue Helvetius Bourges,,,,6,Rue Helvetius,,18000
+6 Rue Helvetius 18000,,,,6,Rue Helvetius,Bourges,
+6 Rue Helvetius,2.432197,47.104394,,6,Rue Helvetius,,18000
+52 Route de Méry-ès-Bois Bourges,,,,52,Route de Méry-ès-Bois,,18000
+52 Route de Méry-ès-Bois 18000,,,,52,Route de Méry-ès-Bois,Bourges,
+52 Route de Méry-ès-Bois,2.402256,47.114852,,52,Route de Méry-ès-Bois,,18000
+1 Rue Tom Morel Bourges,,,,1,Rue Tom Morel,,18000
+1 Rue Tom Morel 18000,,,,1,Rue Tom Morel,Bourges,
+1 Rue Tom Morel,2.420504,47.109503,,1,Rue Tom Morel,,18000
+13 Rue des Petites Croix La Chapelle-Saint-Ursin,,,,13,Rue des Petites Croix,,18570
+13 Rue des Petites Croix 18570,,,,13,Rue des Petites Croix,La Chapelle-Saint-Ursin,
+13 Rue des Petites Croix,2.321167,47.057646,,13,Rue des Petites Croix,,18570
+6 Rue de la Petite Garenne Civray,,,,6,Rue de la Petite Garenne,,18290
+6 Rue de la Petite Garenne 18290,,,,6,Rue de la Petite Garenne,Civray,
+6 Rue de la Petite Garenne,2.175125,46.968968,,6,Rue de la Petite Garenne,,18290
+10 Rue du Lavoir Ennordres,,,,10,Rue du Lavoir,,18380
+10 Rue du Lavoir 18380,,,,10,Rue du Lavoir,Ennordres,
+10 Rue du Lavoir,2.381646,47.430302,,10,Rue du Lavoir,,18380
+36 Rue Henri Barbusse La Guerche-sur-l'Aubois,,,,36,Rue Henri Barbusse,,18150
+36 Rue Henri Barbusse 18150,,,,36,Rue Henri Barbusse,La Guerche-sur-l'Aubois,
+36 Rue Henri Barbusse,2.946167,46.950493,,36,Rue Henri Barbusse,,18150
+14 Rue du Plessis Lignières,,,,14,Rue du Plessis,,18160
+14 Rue du Plessis 18160,,,,14,Rue du Plessis,Lignières,
+14 Rue du Plessis,2.172512,46.748235,,14,Rue du Plessis,,18160
+3 Rue du Lavoir Mehun-sur-Yèvre,,,,3,Rue du Lavoir,,18500
+3 Rue du Lavoir 18500,,,,3,Rue du Lavoir,Mehun-sur-Yèvre,
+3 Rue du Lavoir,2.207491,47.115961,,3,Rue du Lavoir,,18500
+10 Allée des Bouleaux Nançay,,,,10,Allée des Bouleaux,,18330
+10 Allée des Bouleaux 18330,,,,10,Allée des Bouleaux,Nançay,
+10 Allée des Bouleaux,2.191169,47.354911,,10,Allée des Bouleaux,,18330
+26 Route de Jacques au Bois Preuilly,,,,26,Route de Jacques au Bois,,18120
+26 Route de Jacques au Bois 18120,,,,26,Route de Jacques au Bois,Preuilly,
+26 Route de Jacques au Bois,2.170297,47.093878,,26,Route de Jacques au Bois,,18120
+183 Avenue du 1er Régiment d'Infanterie Saint-Amand-Montrond,,,,183,Avenue du 1er Régiment d'Infanterie,,18200
+183 Avenue du 1er Régiment d'Infanterie 18200,,,,183,Avenue du 1er Régiment d'Infanterie,Saint-Amand-Montrond,
+183 Avenue du 1er Régiment d'Infanterie,2.511096,46.727887,,183,Avenue du 1er Régiment d'Infanterie,,18200
+26 Rue du Village d'en Haut Saint-Doulchard,,,,26,Rue du Village d'en Haut,,18230
+26 Rue du Village d'en Haut 18230,,,,26,Rue du Village d'en Haut,Saint-Doulchard,
+26 Rue du Village d'en Haut,2.349832,47.108245,,26,Rue du Village d'en Haut,,18230
+5 Rue Maréchal Joffre Saint-Germain-du-Puy,,,,5,Rue Maréchal Joffre,,18000
+5 Rue Maréchal Joffre 18000,,,,5,Rue Maréchal Joffre,Saint-Germain-du-Puy,
+5 Rue Maréchal Joffre,2.488517,47.10329,,5,Rue Maréchal Joffre,,18000
+5 Ruelle de Chavignol Sancerre,,,,5,Ruelle de Chavignol,,18300
+5 Ruelle de Chavignol 18300,,,,5,Ruelle de Chavignol,Sancerre,
+5 Ruelle de Chavignol,2.837874,47.331148,,5,Ruelle de Chavignol,,18300
+208 Route de la Chapelle Trouy,,,,208,Route de la Chapelle,,18570
+208 Route de la Chapelle 18570,,,,208,Route de la Chapelle,Trouy,
+208 Route de la Chapelle,2.364685,47.014987,,208,Route de la Chapelle,,18570
+67A Rue du Bas de Grange Vierzon,,,,67A,Rue du Bas de Grange,,18100
+67A Rue du Bas de Grange 18100,,,,67A,Rue du Bas de Grange,Vierzon,
+67A Rue du Bas de Grange,2.052538,47.224598,,67A,Rue du Bas de Grange,,18100
+68 Square Henriette Dumuin Vierzon,,,,68,Square Henriette Dumuin,,18100
+68 Square Henriette Dumuin 18100,,,,68,Square Henriette Dumuin,Vierzon,
+68 Square Henriette Dumuin,2.079353,47.202297,,68,Square Henriette Dumuin,,18100
+12 Place Vaillant Couturier Vierzon,,,,12,Place Vaillant Couturier,,18100
+12 Place Vaillant Couturier 18100,,,,12,Place Vaillant Couturier,Vierzon,
+12 Place Vaillant Couturier,2.069506,47.223536,,12,Place Vaillant Couturier,,18100
+13 Rue Saint-Rémy Auneau,,,,13,Rue Saint-Rémy,,28700
+13 Rue Saint-Rémy 28700,,,,13,Rue Saint-Rémy,Auneau,
+13 Rue Saint-Rémy,1.774075,48.46543,,13,Rue Saint-Rémy,,28700
+2 Rue de Theuville Berchères-les-Pierres,,,,2,Rue de Theuville,,28630
+2 Rue de Theuville 28630,,,,2,Rue de Theuville,Berchères-les-Pierres,
+2 Rue de Theuville,1.538225,48.366488,,2,Rue de Theuville,,28630
+41 Rue de la Forge Le Boullay-Mivoye,,,,41,Rue de la Forge,,28210
+41 Rue de la Forge 28210,,,,41,Rue de la Forge,Le Boullay-Mivoye,
+41 Rue de la Forge,1.407866,48.650487,,41,Rue de la Forge,,28210
+1 Place des Acloutis Champhol,,,,1,Place des Acloutis,,28300
+1 Place des Acloutis 28300,,,,1,Place des Acloutis,Champhol,
+1 Place des Acloutis,1.504722,48.474293,,1,Place des Acloutis,,28300
+67 Boulevard Charles Péguy Chartres,,,,67,Boulevard Charles Péguy,,28000
+67 Boulevard Charles Péguy 28000,,,,67,Boulevard Charles Péguy,Chartres,
+67 Boulevard Charles Péguy,1.487727,48.452712,,67,Boulevard Charles Péguy,,28000
+13 Rue Nicole Chartres,,,,13,Rue Nicole,,28000
+13 Rue Nicole 28000,,,,13,Rue Nicole,Chartres,
+13 Rue Nicole,1.480597,48.447016,,13,Rue Nicole,,28000
+3 Chemin du Clos de Néchée Châteaudun,,,,3,Chemin du Clos de Néchée,,28200
+3 Chemin du Clos de Néchée 28200,,,,3,Chemin du Clos de Néchée,Châteaudun,
+3 Chemin du Clos de Néchée,1.344391,48.090342,,3,Chemin du Clos de Néchée,,28200
+7 Rue du Chêne de Lorette Châteauneuf-en-Thymerais,,,,7,Rue du Chêne de Lorette,,28170
+7 Rue du Chêne de Lorette 28170,,,,7,Rue du Chêne de Lorette,Châteauneuf-en-Thymerais,
+7 Rue du Chêne de Lorette,1.237948,48.582038,,7,Rue du Chêne de Lorette,,28170
+14A Avenue du 11 Novembre Cloyes-sur-le-Loir,,,,14A,Avenue du 11 Novembre,,28220
+14A Avenue du 11 Novembre 28220,,,,14A,Avenue du 11 Novembre,Cloyes-sur-le-Loir,
+14A Avenue du 11 Novembre,1.23923,47.994298,,14A,Avenue du 11 Novembre,,28220
+25 Rue de l'Ancien Château Crécy-Couvé,,,,25,Rue de l'Ancien Château,,28500
+25 Rue de l'Ancien Château 28500,,,,25,Rue de l'Ancien Château,Crécy-Couvé,
+25 Rue de l'Ancien Château,1.280891,48.66926,,25,Rue de l'Ancien Château,,28500
+13 Boulevard Condorcet Dreux,,,,13,Boulevard Condorcet,,28100
+13 Boulevard Condorcet 28100,,,,13,Boulevard Condorcet,Dreux,
+13 Boulevard Condorcet,1.375718,48.722557,,13,Boulevard Condorcet,,28100
+6 Rue Théophile Ferré Dreux,,,,6,Rue Théophile Ferré,,28100
+6 Rue Théophile Ferré 28100,,,,6,Rue Théophile Ferré,Dreux,
+6 Rue Théophile Ferré,1.39278,48.740383,,6,Rue Théophile Ferré,,28100
+19 Rue de la Ferriere Fontaine-Simon,,,,19,Rue de la Ferriere,,28240
+19 Rue de la Ferriere 28240,,,,19,Rue de la Ferriere,Fontaine-Simon,
+19 Rue de la Ferriere,1.01519,48.517262,,19,Rue de la Ferriere,,28240
+17 Avenue Gustave Eiffel Gellainville,,,,17,Avenue Gustave Eiffel,,28630
+17 Avenue Gustave Eiffel 28630,,,,17,Avenue Gustave Eiffel,Gellainville,
+17 Avenue Gustave Eiffel,1.526327,48.435774,,17,Avenue Gustave Eiffel,,28630
+28 Rue de la Sinetterie Illiers-Combray,,,,28,Rue de la Sinetterie,,28120
+28 Rue de la Sinetterie 28120,,,,28,Rue de la Sinetterie,Illiers-Combray,
+28 Rue de la Sinetterie,1.237575,48.297163,,28,Rue de la Sinetterie,,28120
+18 Rue Émile Grapperon Levesville-la-Chenard,,,,18,Rue Émile Grapperon,,28310
+18 Rue Émile Grapperon 28310,,,,18,Rue Émile Grapperon,Levesville-la-Chenard,
+18 Rue Émile Grapperon,1.825194,48.302627,,18,Rue Émile Grapperon,,28310
+47BIS Avenue Maurice Maunoury Luisant,,,,47BIS,Avenue Maurice Maunoury,,28600
+47BIS Avenue Maurice Maunoury 28600,,,,47BIS,Avenue Maurice Maunoury,Luisant,
+47BIS Avenue Maurice Maunoury,1.47767,48.433557,,47BIS,Avenue Maurice Maunoury,,28600
+3 Rue de la Mare Corbonne Mainvilliers,,,,3,Rue de la Mare Corbonne,,28300
+3 Rue de la Mare Corbonne 28300,,,,3,Rue de la Mare Corbonne,Mainvilliers,
+3 Rue de la Mare Corbonne,1.44406,48.467527,,3,Rue de la Mare Corbonne,,28300
+14 Rue de Vucennes Moléans,,,,14,Rue de Vucennes,,28200
+14 Rue de Vucennes 28200,,,,14,Rue de Vucennes,Moléans,
+14 Rue de Vucennes,1.394591,48.114795,,14,Rue de Vucennes,,28200
+9 Rue Croix de la Comtesse Nogent-le-Rotrou,,,,9,Rue Croix de la Comtesse,,28400
+9 Rue Croix de la Comtesse 28400,,,,9,Rue Croix de la Comtesse,Nogent-le-Rotrou,
+9 Rue Croix de la Comtesse,0.810984,48.3228,,9,Rue Croix de la Comtesse,,28400
+12 Résidence de la Vigne Blanche Oysonville,,,,12,Résidence de la Vigne Blanche,,28700
+12 Résidence de la Vigne Blanche 28700,,,,12,Résidence de la Vigne Blanche,Oysonville,
+12 Résidence de la Vigne Blanche,1.949299,48.395037,,12,Résidence de la Vigne Blanche,,28700
+14 Impasse des Begnoux Saint-Denis-les-Ponts,,,,14,Impasse des Begnoux,,28200
+14 Impasse des Begnoux 28200,,,,14,Impasse des Begnoux,Saint-Denis-les-Ponts,
+14 Impasse des Begnoux,1.28141,48.068079,,14,Impasse des Begnoux,,28200
+32 Rue Achille Méningand Saint-Prest,,,,32,Rue Achille Méningand,,28300
+32 Rue Achille Méningand 28300,,,,32,Rue Achille Méningand,Saint-Prest,
+32 Rue Achille Méningand,1.527219,48.483663,,32,Rue Achille Méningand,,28300
+58 Rue de la Ferte Vidame Senonches,,,,58,Rue de la Ferte Vidame,,28250
+58 Rue de la Ferte Vidame 28250,,,,58,Rue de la Ferte Vidame,Senonches,
+58 Rue de la Ferte Vidame,1.023406,48.570436,,58,Rue de la Ferte Vidame,,28250
+8 Rue Hector Boudon Thivars,,,,8,Rue Hector Boudon,,28630
+8 Rue Hector Boudon 28630,,,,8,Rue Hector Boudon,Thivars,
+8 Rue Hector Boudon,1.451522,48.379578,,8,Rue Hector Boudon,,28630
+23 Rue de la Mare Neuve Vernouillet,,,,23,Rue de la Mare Neuve,,28500
+23 Rue de la Mare Neuve 28500,,,,23,Rue de la Mare Neuve,Vernouillet,
+23 Rue de la Mare Neuve,1.327361,48.725372,,23,Rue de la Mare Neuve,,28500
+3 Rue de Duan Yèvres,,,,3,Rue de Duan,,28160
+3 Rue de Duan 28160,,,,3,Rue de Duan,Yèvres,
+3 Rue de Duan,1.190651,48.206269,,3,Rue de Duan,,28160
+54 Route de Pellevoisin Argy,,,,54,Route de Pellevoisin,,36500
+54 Route de Pellevoisin 36500,,,,54,Route de Pellevoisin,Argy,
+54 Route de Pellevoisin,1.436044,46.944336,,54,Route de Pellevoisin,,36500
+6 Ruelle de Preneau Les Bordes,,,,6,Ruelle de Preneau,,36100
+6 Ruelle de Preneau 36100,,,,6,Ruelle de Preneau,Les Bordes,
+6 Ruelle de Preneau,1.977993,46.978738,,6,Ruelle de Preneau,,36100
+14 Rue de la Gare Chaillac,,,,14,Rue de la Gare,,36310
+14 Rue de la Gare 36310,,,,14,Rue de la Gare,Chaillac,
+14 Rue de la Gare,1.298489,46.438845,,14,Rue de la Gare,,36310
+29 Rue Diderot Châteauroux,,,,29,Rue Diderot,,36000
+29 Rue Diderot 36000,,,,29,Rue Diderot,Châteauroux,
+29 Rue Diderot,1.692176,46.810163,,29,Rue Diderot,,36000
+6 Rue du Maréchal Lyautey Châteauroux,,,,6,Rue du Maréchal Lyautey,,36000
+6 Rue du Maréchal Lyautey 36000,,,,6,Rue du Maréchal Lyautey,Châteauroux,
+6 Rue du Maréchal Lyautey,1.718641,46.805242,,6,Rue du Maréchal Lyautey,,36000
+29 Rue des Tamaris Châteauroux,,,,29,Rue des Tamaris,,36000
+29 Rue des Tamaris 36000,,,,29,Rue des Tamaris,Châteauroux,
+29 Rue des Tamaris,1.695148,46.792218,,29,Rue des Tamaris,,36000
+1 Domaine de l'Epinat La Châtre-Langlin,,,,1,Domaine de l'Epinat,,36170
+1 Domaine de l'Epinat 36170,,,,1,Domaine de l'Epinat,La Châtre-Langlin,
+1 Domaine de l'Epinat,1.40151,46.4242,,1,Domaine de l'Epinat,,36170
+12 Allée des Myrtilles Déols,,,,12,Allée des Myrtilles,,36130
+12 Allée des Myrtilles 36130,,,,12,Allée des Myrtilles,Déols,
+12 Allée des Myrtilles,1.674838,46.855077,,12,Allée des Myrtilles,,36130
+6 Rue Chateaurenault Issoudun,,,,6,Rue Chateaurenault,,36100
+6 Rue Chateaurenault 36100,,,,6,Rue Chateaurenault,Issoudun,
+6 Rue Chateaurenault,1.984536,46.9412,,6,Rue Chateaurenault,,36100
+69 Route de Châteauroux Levroux,,,,69,Route de Châteauroux,,36110
+69 Route de Châteauroux 36110,,,,69,Route de Châteauroux,Levroux,
+69 Route de Châteauroux,1.613793,46.974386,,69,Route de Châteauroux,,36110
+10 Route de Chatellerault Mézières-en-Brenne,,,,10,Route de Chatellerault,,36290
+10 Route de Chatellerault 36290,,,,10,Route de Chatellerault,Mézières-en-Brenne,
+10 Route de Chatellerault,1.2065,46.821141,,10,Route de Chatellerault,,36290
+2 Rue Antoine Métivier Le Pêchereau,,,,2,Rue Antoine Métivier,,36200
+2 Rue Antoine Métivier 36200,,,,2,Rue Antoine Métivier,Le Pêchereau,
+2 Rue Antoine Métivier,1.530379,46.580898,,2,Rue Antoine Métivier,,36200
+4 Les Charrons Poulaines,,,,4,Les Charrons,,36210
+4 Les Charrons 36210,,,,4,Les Charrons,Poulaines,
+4 Les Charrons,1.662066,47.122551,,4,Les Charrons,,36210
+29 Rue du Docteur Jean-Jacques Renault Saint-Gaultier,,,,29,Rue du Docteur Jean-Jacques Renault,,36800
+29 Rue du Docteur Jean-Jacques Renault 36800,,,,29,Rue du Docteur Jean-Jacques Renault,Saint-Gaultier,
+29 Rue du Docteur Jean-Jacques Renault,1.41548,46.637377,,29,Rue du Docteur Jean-Jacques Renault,,36800
+1 Route de Nohant Sarzay,,,,1,Route de Nohant,,36230
+1 Route de Nohant 36230,,,,1,Route de Nohant,Sarzay,
+1 Route de Nohant,1.905263,46.601509,,1,Route de Nohant,,36230
+1 Rue du Prieuré Veuil,,,,1,Rue du Prieuré,,36600
+1 Rue du Prieuré 36600,,,,1,Rue du Prieuré,Veuil,
+1 Rue du Prieuré,1.522512,47.12201,,1,Rue du Prieuré,,36600
+15 Avenue de Tours Amboise,,,,15,Avenue de Tours,,37400
+15 Avenue de Tours 37400,,,,15,Avenue de Tours,Amboise,
+15 Avenue de Tours,0.97263,47.409421,,15,Avenue de Tours,,37400
+9 Allée des Rogareaux Azay-le-Rideau,,,,9,Allée des Rogareaux,,37190
+9 Allée des Rogareaux 37190,,,,9,Allée des Rogareaux,Azay-le-Rideau,
+9 Allée des Rogareaux,0.442993,47.267756,,9,Allée des Rogareaux,,37190
+6 Impasse du Carroi Forêt Beaumont-en-Véron,,,,6,Impasse du Carroi Forêt,,37420
+6 Impasse du Carroi Forêt 37420,,,,6,Impasse du Carroi Forêt,Beaumont-en-Véron,
+6 Impasse du Carroi Forêt,0.190098,47.203921,,6,Impasse du Carroi Forêt,,37420
+5 Rué Raymond Garrit Bourgueil,,,,5,Rué Raymond Garrit,,37140
+5 Rué Raymond Garrit 37140,,,,5,Rué Raymond Garrit,Bourgueil,
+5 Rué Raymond Garrit,0.173263,47.285568,,5,Rué Raymond Garrit,,37140
+7 Allée des Millepertuis Chambray-lès-Tours,,,,7,Allée des Millepertuis,,37170
+7 Allée des Millepertuis 37170,,,,7,Allée des Millepertuis,Chambray-lès-Tours,
+7 Allée des Millepertuis,0.708002,47.338651,,7,Allée des Millepertuis,,37170
+35 Avenue du Général de Gaulle Château-la-Vallière,,,,35,Avenue du Général de Gaulle,,37330
+35 Avenue du Général de Gaulle 37330,,,,35,Avenue du Général de Gaulle,Château-la-Vallière,
+35 Avenue du Général de Gaulle,0.32513,47.545154,,35,Avenue du Général de Gaulle,,37330
+231 Avenue François Mitterrand Chinon,,,,231,Avenue François Mitterrand,,37500
+231 Avenue François Mitterrand 37500,,,,231,Avenue François Mitterrand,Chinon,
+231 Avenue François Mitterrand,0.257392,47.175384,,231,Avenue François Mitterrand,,37500
+19BIS Rue de la Vallée de Mesvres Civray-de-Touraine,,,,19BIS,Rue de la Vallée de Mesvres,,37150
+19BIS Rue de la Vallée de Mesvres 37150,,,,19BIS,Rue de la Vallée de Mesvres,Civray-de-Touraine,
+19BIS Rue de la Vallée de Mesvres,1.018945,47.344801,,19BIS,Rue de la Vallée de Mesvres,,37150
+6 Allée de Montafilent Esvres,,,,6,Allée de Montafilent,,37320
+6 Allée de Montafilent 37320,,,,6,Allée de Montafilent,Esvres,
+6 Allée de Montafilent,0.78867,47.287886,,6,Allée de Montafilent,,37320
+14 Rue Richard Wagner Francueil,,,,14,Rue Richard Wagner,,37150
+14 Rue Richard Wagner 37150,,,,14,Rue Richard Wagner,Francueil,
+14 Rue Richard Wagner,1.079193,47.315516,,14,Rue Richard Wagner,,37150
+72 Rue d'Amboise Joué-lès-Tours,,,,72,Rue d'Amboise,,37300
+72 Rue d'Amboise 37300,,,,72,Rue d'Amboise,Joué-lès-Tours,
+72 Rue d'Amboise,0.676216,47.345195,,72,Rue d'Amboise,,37300
+6 Rue Louis Breguet Joué-lès-Tours,,,,6,Rue Louis Breguet,,37300
+6 Rue Louis Breguet 37300,,,,6,Rue Louis Breguet,Joué-lès-Tours,
+6 Rue Louis Breguet,0.680579,47.352085,,6,Rue Louis Breguet,,37300
+36 Rue de Bellevue Larçay,,,,36,Rue de Bellevue,,37270
+36 Rue de Bellevue 37270,,,,36,Rue de Bellevue,Larçay,
+36 Rue de Bellevue,0.776955,47.365398,,36,Rue de Bellevue,,37270
+24 Rue de la Porte Poitevine Loches,,,,24,Rue de la Porte Poitevine,,37600
+24 Rue de la Porte Poitevine 37600,,,,24,Rue de la Porte Poitevine,Loches,
+24 Rue de la Porte Poitevine,0.995252,47.124085,,24,Rue de la Porte Poitevine,,37600
+3 Allée du Bois La Membrolle-sur-Choisille,,,,3,Allée du Bois,,37390
+3 Allée du Bois 37390,,,,3,Allée du Bois,La Membrolle-sur-Choisille,
+3 Allée du Bois,0.628461,47.434409,,3,Allée du Bois,,37390
+53 Rue de Boisdenier Montlouis-sur-Loire,,,,53,Rue de Boisdenier,,37270
+53 Rue de Boisdenier 37270,,,,53,Rue de Boisdenier,Montlouis-sur-Loire,
+53 Rue de Boisdenier,0.818107,47.385128,,53,Rue de Boisdenier,,37270
+5 Rue Georges Bernard Monts,,,,5,Rue Georges Bernard,,37260
+5 Rue Georges Bernard 37260,,,,5,Rue Georges Bernard,Monts,
+5 Rue Georges Bernard,0.622143,47.277234,,5,Rue Georges Bernard,,37260
+2 Rue des Prés Neuvy-le-Roi,,,,2,Rue des Prés,,37370
+2 Rue des Prés 37370,,,,2,Rue des Prés,Neuvy-le-Roi,
+2 Rue des Prés,0.596078,47.602743,,2,Rue des Prés,,37370
+8 Avenue de la Cloutière Perrusson,,,,8,Avenue de la Cloutière,,37600
+8 Avenue de la Cloutière 37600,,,,8,Avenue de la Cloutière,Perrusson,
+8 Avenue de la Cloutière,1.009244,47.102277,,8,Avenue de la Cloutière,,37600
+13 Rue Paul Bert La Riche,,,,13,Rue Paul Bert,,37520
+13 Rue Paul Bert 37520,,,,13,Rue Paul Bert,La Riche,
+13 Rue Paul Bert,0.65684,47.386018,,13,Rue Paul Bert,,37520
+14 Chemin des Niveaux Saint-Antoine-du-Rocher,,,,14,Chemin des Niveaux,,37360
+14 Chemin des Niveaux 37360,,,,14,Chemin des Niveaux,Saint-Antoine-du-Rocher,
+14 Chemin des Niveaux,0.636916,47.494682,,14,Chemin des Niveaux,,37360
+1 Rue de la Sagerie Saint-Avertin,,,,1,Rue de la Sagerie,,37550
+1 Rue de la Sagerie 37550,,,,1,Rue de la Sagerie,Saint-Avertin,
+1 Rue de la Sagerie,0.71461,47.362534,,1,Rue de la Sagerie,,37550
+43 Rue Louis Bézard Saint-Cyr-sur-Loire,,,,43,Rue Louis Bézard,,37540
+43 Rue Louis Bézard 37540,,,,43,Rue Louis Bézard,Saint-Cyr-sur-Loire,
+43 Rue Louis Bézard,0.657954,47.404791,,43,Rue Louis Bézard,,37540
+3 Rue des Grillonnieres Saint-Martin-le-Beau,,,,3,Rue des Grillonnieres,,37270
+3 Rue des Grillonnieres 37270,,,,3,Rue des Grillonnieres,Saint-Martin-le-Beau,
+3 Rue des Grillonnieres,0.897749,47.358484,,3,Rue des Grillonnieres,,37270
+29 Rue de la Feuillarde Saint-Pierre-des-Corps,,,,29,Rue de la Feuillarde,,37700
+29 Rue de la Feuillarde 37700,,,,29,Rue de la Feuillarde,Saint-Pierre-des-Corps,
+29 Rue de la Feuillarde,0.723678,47.380303,,29,Rue de la Feuillarde,,37700
+12 Rue des Violettes Savigny-en-Véron,,,,12,Rue des Violettes,,37420
+12 Rue des Violettes 37420,,,,12,Rue des Violettes,Savigny-en-Véron,
+12 Rue des Violettes,0.152694,47.207823,,12,Rue des Violettes,,37420
+7 Rue Alleron Tours,,,,7,Rue Alleron,,37200
+7 Rue Alleron 37200,,,,7,Rue Alleron,Tours,
+7 Rue Alleron,0.675597,47.39477,,7,Rue Alleron,,37200
+38 Rue Christiaan Huygens Tours,,,,38,Rue Christiaan Huygens,,37200
+38 Rue Christiaan Huygens 37200,,,,38,Rue Christiaan Huygens,Tours,
+38 Rue Christiaan Huygens,0.705052,47.437002,,38,Rue Christiaan Huygens,,37200
+16 Rue de Franche-Comté Tours,,,,16,Rue de Franche-Comté,,37200
+16 Rue de Franche-Comté 37200,,,,16,Rue de Franche-Comté,Tours,
+16 Rue de Franche-Comté,0.679232,47.427341,,16,Rue de Franche-Comté,,37200
+235 Rue Jolivet Tours,,,,235,Rue Jolivet,,37200
+235 Rue Jolivet 37200,,,,235,Rue Jolivet,Tours,
+235 Rue Jolivet,0.706729,47.383546,,235,Rue Jolivet,,37200
+157 Rue du Pas Notre-Dame Tours,,,,157,Rue du Pas Notre-Dame,,37200
+157 Rue du Pas Notre-Dame 37200,,,,157,Rue du Pas Notre-Dame,Tours,
+157 Rue du Pas Notre-Dame,0.697255,47.417658,,157,Rue du Pas Notre-Dame,,37200
+183 Rue Victor Hugo Tours,,,,183,Rue Victor Hugo,,37200
+183 Rue Victor Hugo 37200,,,,183,Rue Victor Hugo,Tours,
+183 Rue Victor Hugo,0.677813,47.387514,,183,Rue Victor Hugo,,37200
+3 Rue du Puits des Desrès Véretz,,,,3,Rue du Puits des Desrès,,37270
+3 Rue du Puits des Desrès 37270,,,,3,Rue du Puits des Desrès,Véretz,
+3 Rue du Puits des Desrès,0.813758,47.347767,,3,Rue du Puits des Desrès,,37270
+9 Rue des Varennes Villiers-au-Bouin,,,,9,Rue des Varennes,,37330
+9 Rue des Varennes 37330,,,,9,Rue des Varennes,Villiers-au-Bouin,
+9 Rue des Varennes,0.308828,47.57163,,9,Rue des Varennes,,37330
+25 Rue du Bourg Neuf Blois,,,,25,Rue du Bourg Neuf,,41000
+25 Rue du Bourg Neuf 41000,,,,25,Rue du Bourg Neuf,Blois,
+25 Rue du Bourg Neuf,1.331564,47.589877,,25,Rue du Bourg Neuf,,41000
+120 Rue Jean Monnet Blois,,,,120,Rue Jean Monnet,,41000
+120 Rue Jean Monnet 41000,,,,120,Rue Jean Monnet,Blois,
+120 Rue Jean Monnet,1.2974,47.594269,,120,Rue Jean Monnet,,41000
+112 Levée des Tuileries Blois,,,,112,Levée des Tuileries,,41000
+112 Levée des Tuileries 41000,,,,112,Levée des Tuileries,Blois,
+112 Levée des Tuileries,1.352904,47.595024,,112,Levée des Tuileries,,41000
+31 Clos des Hirondelles Chailles,,,,31,Clos des Hirondelles,,41120
+31 Clos des Hirondelles 41120,,,,31,Clos des Hirondelles,Chailles,
+31 Clos des Hirondelles,1.309223,47.531554,,31,Clos des Hirondelles,,41120
+4 Rue de Tremblevif Chaumont-sur-Tharonne,,,,4,Rue de Tremblevif,,41600
+4 Rue de Tremblevif 41600,,,,4,Rue de Tremblevif,Chaumont-sur-Tharonne,
+4 Rue de Tremblevif,1.903786,47.607207,,4,Rue de Tremblevif,,41600
+4 Rue Abel Poulin Contres,,,,4,Rue Abel Poulin,,41700
+4 Rue Abel Poulin 41700,,,,4,Rue Abel Poulin,Contres,
+4 Rue Abel Poulin,1.428402,47.419241,,4,Rue Abel Poulin,,41700
+24 Route de Vendôme Danzé,,,,24,Route de Vendôme,,41160
+24 Route de Vendôme 41160,,,,24,Route de Vendôme,Danzé,
+24 Route de Vendôme,1.027969,47.887904,,24,Route de Vendôme,,41160
+28 Rue de Chitenay Fresnes,,,,28,Rue de Chitenay,,41700
+28 Rue de Chitenay 41700,,,,28,Rue de Chitenay,Fresnes,
+28 Rue de Chitenay,1.408784,47.438084,,28,Rue de Chitenay,,41700
+6 Rue du Four à Chaux Lamotte-Beuvron,,,,6,Rue du Four à Chaux,,41600
+6 Rue du Four à Chaux 41600,,,,6,Rue du Four à Chaux,Lamotte-Beuvron,
+6 Rue du Four à Chaux,2.023894,47.604778,,6,Rue du Four à Chaux,,41600
+5 Chemin de Bouesse Maslives,,,,5,Chemin de Bouesse,,41250
+5 Chemin de Bouesse 41250,,,,5,Chemin de Bouesse,Maslives,
+5 Chemin de Bouesse,1.481338,47.629457,,5,Chemin de Bouesse,,41250
+130 Rue Leon Gambetta Meusnes,,,,130,Rue Leon Gambetta,,41130
+130 Rue Leon Gambetta 41130,,,,130,Rue Leon Gambetta,Meusnes,
+130 Rue Leon Gambetta,1.496977,47.247973,,130,Rue Leon Gambetta,,41130
+30 Rue de Champigny Montoire-sur-le-Loir,,,,30,Rue de Champigny,,41800
+30 Rue de Champigny 41800,,,,30,Rue de Champigny,Montoire-sur-le-Loir,
+30 Rue de Champigny,0.880125,47.763254,,30,Rue de Champigny,,41800
+10 Rue du Bois Neuf Morée,,,,10,Rue du Bois Neuf,,41160
+10 Rue du Bois Neuf 41160,,,,10,Rue du Bois Neuf,Morée,
+10 Rue du Bois Neuf,1.234117,47.899955,,10,Rue du Bois Neuf,,41160
+17 Rue des Hirondelles Noyers-sur-Cher,,,,17,Rue des Hirondelles,,41140
+17 Rue des Hirondelles 41140,,,,17,Rue des Hirondelles,Noyers-sur-Cher,
+17 Rue des Hirondelles,1.411315,47.27514,,17,Rue des Hirondelles,,41140
+3 Rue Saint-Martin Périgny,,,,3,Rue Saint-Martin,,41100
+3 Rue Saint-Martin 41100,,,,3,Rue Saint-Martin,Périgny,
+3 Rue Saint-Martin,1.151173,47.738629,,3,Rue Saint-Martin,,41100
+11 Rue des Champs Ragot Romorantin-Lanthenay,,,,11,Rue des Champs Ragot,,41200
+11 Rue des Champs Ragot 41200,,,,11,Rue des Champs Ragot,Romorantin-Lanthenay,
+11 Rue des Champs Ragot,1.741124,47.354267,,11,Rue des Champs Ragot,,41200
+25 Rue de la Pierre Romorantin-Lanthenay,,,,25,Rue de la Pierre,,41200
+25 Rue de la Pierre 41200,,,,25,Rue de la Pierre,Romorantin-Lanthenay,
+25 Rue de la Pierre,1.746458,47.358604,,25,Rue de la Pierre,,41200
+4 Rue des Acacias Saint-Claude-de-Diray,,,,4,Rue des Acacias,,41350
+4 Rue des Acacias 41350,,,,4,Rue des Acacias,Saint-Claude-de-Diray,
+4 Rue des Acacias,1.426361,47.612697,,4,Rue des Acacias,,41350
+3 Rue Clément Héron Saint-Hilaire-la-Gravelle,,,,3,Rue Clément Héron,,41160
+3 Rue Clément Héron 41160,,,,3,Rue Clément Héron,Saint-Hilaire-la-Gravelle,
+3 Rue Clément Héron,1.198098,47.925642,,3,Rue Clément Héron,,41160
+4 Rue Maryse Bastié Saint-Ouen,,,,4,Rue Maryse Bastié,,41100
+4 Rue Maryse Bastié 41100,,,,4,Rue Maryse Bastié,Saint-Ouen,
+4 Rue Maryse Bastié,1.080344,47.808681,,4,Rue Maryse Bastié,,41100
+33 Rue de la Victoire Salbris,,,,33,Rue de la Victoire,,41300
+33 Rue de la Victoire 41300,,,,33,Rue de la Victoire,Salbris,
+33 Rue de la Victoire,2.043129,47.42103,,33,Rue de la Victoire,,41300
+6 Rue de Romorantin Selles-sur-Cher,,,,6,Rue de Romorantin,,41130
+6 Rue de Romorantin 41130,,,,6,Rue de Romorantin,Selles-sur-Cher,
+6 Rue de Romorantin,1.55807,47.27886,,6,Rue de Romorantin,,41130
+48 Rue de la Fontaine Herbault Thésée,,,,48,Rue de la Fontaine Herbault,,41140
+48 Rue de la Fontaine Herbault 41140,,,,48,Rue de la Fontaine Herbault,Thésée,
+48 Rue de la Fontaine Herbault,1.331861,47.328914,,48,Rue de la Fontaine Herbault,,41140
+24 Avenue de l'Ile-de-France Vendôme,,,,24,Avenue de l'Ile-de-France,,41100
+24 Avenue de l'Ile-de-France 41100,,,,24,Avenue de l'Ile-de-France,Vendôme,
+24 Avenue de l'Ile-de-France,1.048803,47.807139,,24,Avenue de l'Ile-de-France,,41100
+14 Rue des Laurières Villebarou,,,,14,Rue des Laurières,,41000
+14 Rue des Laurières 41000,,,,14,Rue des Laurières,Villebarou,
+14 Rue des Laurières,1.31016,47.627935,,14,Rue des Laurières,,41000
+1 Chemin Francis Poulenc Vineuil,,,,1,Chemin Francis Poulenc,,41350
+1 Chemin Francis Poulenc 41350,,,,1,Chemin Francis Poulenc,Vineuil,
+1 Chemin Francis Poulenc,1.378604,47.583707,,1,Chemin Francis Poulenc,,41350
+41 Rue Vincent Scotto Amilly,,,,41,Rue Vincent Scotto,,45200
+41 Rue Vincent Scotto 45200,,,,41,Rue Vincent Scotto,Amilly,
+41 Rue Vincent Scotto,2.771866,47.97499,,41,Rue Vincent Scotto,,45200
+41 Rue Jean Bordier Baule,,,,41,Rue Jean Bordier,,45130
+41 Rue Jean Bordier 45130,,,,41,Rue Jean Bordier,Baule,
+41 Rue Jean Bordier,1.667553,47.812117,,41,Rue Jean Bordier,,45130
+54 Allée du Château Bellegarde,,,,54,Allée du Château,,45270
+54 Allée du Château 45270,,,,54,Allée du Château,Bellegarde,
+54 Allée du Château,2.439309,47.980891,,54,Allée du Château,,45270
+28 Rue du Bourg Boulay-les-Barres,,,,28,Rue du Bourg,,45140
+28 Rue du Bourg 45140,,,,28,Rue du Bourg,Boulay-les-Barres,
+28 Rue du Bourg,1.782356,47.978204,,28,Rue du Bourg,,45140
+19 Rue de la Pierre Aux Fées Cepoy,,,,19,Rue de la Pierre Aux Fées,,45120
+19 Rue de la Pierre Aux Fées 45120,,,,19,Rue de la Pierre Aux Fées,Cepoy,
+19 Rue de la Pierre Aux Fées,2.745274,48.042633,,19,Rue de la Pierre Aux Fées,,45120
+60 Rue La Fontaine Châlette-sur-Loing,,,,60,Rue La Fontaine,,45120
+60 Rue La Fontaine 45120,,,,60,Rue La Fontaine,Châlette-sur-Loing,
+60 Rue La Fontaine,2.73324,48.036876,,60,Rue La Fontaine,,45120
+31 Rue des Muids La Chapelle-Saint-Mesmin,,,,31,Rue des Muids,,45380
+31 Rue des Muids 45380,,,,31,Rue des Muids,La Chapelle-Saint-Mesmin,
+31 Rue des Muids,1.817805,47.88685,,31,Rue des Muids,,45380
+225 Faubourg de Courtenay Château-Renard,,,,225,Faubourg de Courtenay,,45220
+225 Faubourg de Courtenay 45220,,,,225,Faubourg de Courtenay,Château-Renard,
+225 Faubourg de Courtenay,2.929659,47.935195,,225,Faubourg de Courtenay,,45220
+68 Rue Maréchal Leclerc Chécy,,,,68,Rue Maréchal Leclerc,,45430
+68 Rue Maréchal Leclerc 45430,,,,68,Rue Maréchal Leclerc,Chécy,
+68 Rue Maréchal Leclerc,2.019557,47.89291,,68,Rue Maréchal Leclerc,,45430
+35BIS Rue de la Perrière Cléry-Saint-André,,,,35BIS,Rue de la Perrière,,45370
+35BIS Rue de la Perrière 45370,,,,35BIS,Rue de la Perrière,Cléry-Saint-André,
+35BIS Rue de la Perrière,1.789373,47.844877,,35BIS,Rue de la Perrière,,45370
+18 Rue Jacques Tenon Courtenay,,,,18,Rue Jacques Tenon,,45320
+18 Rue Jacques Tenon 45320,,,,18,Rue Jacques Tenon,Courtenay,
+18 Rue Jacques Tenon,3.048843,48.036299,,18,Rue Jacques Tenon,,45320
+20 Rue de Bel Air Dordives,,,,20,Rue de Bel Air,,45680
+20 Rue de Bel Air 45680,,,,20,Rue de Bel Air,Dordives,
+20 Rue de Bel Air,2.774513,48.143976,,20,Rue de Bel Air,,45680
+5 Place de l'Église Férolles,,,,5,Place de l'Église,,45150
+5 Place de l'Église 45150,,,,5,Place de l'Église,Férolles,
+5 Place de l'Église,2.111023,47.83542,,5,Place de l'Église,,45150
+7 Rue De La Barrière Saint-Marc Fleury-les-Aubrais,,,,7,Rue De La Barrière Saint-Marc,,45400
+7 Rue De La Barrière Saint-Marc 45400,,,,7,Rue De La Barrière Saint-Marc,Fleury-les-Aubrais,
+7 Rue De La Barrière Saint-Marc,1.918891,47.920081,,7,Rue De La Barrière Saint-Marc,,45400
+28 Rue des Gillets Fontenay-sur-Loing,,,,28,Rue des Gillets,,45210
+28 Rue des Gillets 45210,,,,28,Rue des Gillets,Fontenay-sur-Loing,
+28 Rue des Gillets,2.770785,48.089684,,28,Rue des Gillets,,45210
+36 Rue du Pont Boucherot Gien,,,,36,Rue du Pont Boucherot,,45500
+36 Rue du Pont Boucherot 45500,,,,36,Rue du Pont Boucherot,Gien,
+36 Rue du Pont Boucherot,2.633923,47.68759,,36,Rue du Pont Boucherot,,45500
+2 Rue des Guettes Ingré,,,,2,Rue des Guettes,,45140
+2 Rue des Guettes 45140,,,,2,Rue des Guettes,Ingré,
+2 Rue des Guettes,1.839599,47.937674,,2,Rue des Guettes,,45140
+7 Chemin du Gd Noyer Lailly-en-Val,,,,7,Chemin du Gd Noyer,,45740
+7 Chemin du Gd Noyer 45740,,,,7,Chemin du Gd Noyer,Lailly-en-Val,
+7 Chemin du Gd Noyer,1.675931,47.755838,,7,Chemin du Gd Noyer,,45740
+5BIS Rue de la Pilonne Malesherbes,,,,5BIS,Rue de la Pilonne,,45330
+5BIS Rue de la Pilonne 45330,,,,5BIS,Rue de la Pilonne,Malesherbes,
+5BIS Rue de la Pilonne,2.414518,48.296287,,5BIS,Rue de la Pilonne,,45330
+3 Avenue des Deportes Meung-sur-Loire,,,,3,Avenue des Deportes,,45130
+3 Avenue des Deportes 45130,,,,3,Avenue des Deportes,Meung-sur-Loire,
+3 Avenue des Deportes,1.69232,47.820508,,3,Avenue des Deportes,,45130
+10 Rue Paul Doumer Montargis,,,,10,Rue Paul Doumer,,45200
+10 Rue Paul Doumer 45200,,,,10,Rue Paul Doumer,Montargis,
+10 Rue Paul Doumer,2.743307,47.998723,,10,Rue Paul Doumer,,45200
+145 Grande Rue La Grande Rue La Neuville-sur-Essonne,,,,145,Grande Rue La Grande Rue,,45390
+145 Grande Rue La Grande Rue 45390,,,,145,Grande Rue La Grande Rue,La Neuville-sur-Essonne,
+145 Grande Rue La Grande Rue,2.375898,48.186715,,145,Grande Rue La Grande Rue,,45390
+43 Allée François Rude Olivet,,,,43,Allée François Rude,,45160
+43 Allée François Rude 45160,,,,43,Allée François Rude,Olivet,
+43 Allée François Rude,1.896843,47.879371,,43,Allée François Rude,,45160
+34 Rue de l'Argonne Orléans,,,,34,Rue de l'Argonne,,45000
+34 Rue de l'Argonne 45000,,,,34,Rue de l'Argonne,Orléans,
+34 Rue de l'Argonne,1.920233,47.91495,,34,Rue de l'Argonne,,45000
+24 Rue des Closiers Orléans,,,,24,Rue des Closiers,,45000
+24 Rue des Closiers 45000,,,,24,Rue des Closiers,Orléans,
+24 Rue des Closiers,1.888021,47.922952,,24,Rue des Closiers,,45000
+15 Rue Jean Perrin Orléans,,,,15,Rue Jean Perrin,,45000
+15 Rue Jean Perrin 45000,,,,15,Rue Jean Perrin,Orléans,
+15 Rue Jean Perrin,1.92482,47.834096,,15,Rue Jean Perrin,,45000
+99 Rue du Poirier Rond Orléans,,,,99,Rue du Poirier Rond,,45000
+99 Rue du Poirier Rond 45000,,,,99,Rue du Poirier Rond,Orléans,
+99 Rue du Poirier Rond,1.922283,47.916946,,99,Rue du Poirier Rond,,45000
+8 Rue des Ormes Orveau-Bellesauve,,,,8,Rue des Ormes,,45330
+8 Rue des Ormes 45330,,,,8,Rue des Ormes,Orveau-Bellesauve,
+8 Rue des Ormes,2.330965,48.281906,,8,Rue des Ormes,,45330
+62 Faubourg Blavetin Patay,,,,62,Faubourg Blavetin,,45310
+62 Faubourg Blavetin 45310,,,,62,Faubourg Blavetin,Patay,
+62 Faubourg Blavetin,1.6994,48.041618,,62,Faubourg Blavetin,,45310
+12 Sentier des Mésanges Puiseaux,,,,12,Sentier des Mésanges,,45390
+12 Sentier des Mésanges 45390,,,,12,Sentier des Mésanges,Puiseaux,
+12 Sentier des Mésanges,2.464618,48.204955,,12,Sentier des Mésanges,,45390
+6 Rue de Concyr Saint-Cyr-en-Val,,,,6,Rue de Concyr,,45590
+6 Rue de Concyr 45590,,,,6,Rue de Concyr,Saint-Cyr-en-Val,
+6 Rue de Concyr,1.932737,47.813521,,6,Rue de Concyr,,45590
+7 Rue de l'Église Saint-Firmin-sur-Loire,,,,7,Rue de l'Église,,45360
+7 Rue de l'Église 45360,,,,7,Rue de l'Église,Saint-Firmin-sur-Loire,
+7 Rue de l'Église,2.731858,47.625522,,7,Rue de l'Église,,45360
+153 Rue de Frédeville Saint-Jean-de-Braye,,,,153,Rue de Frédeville,,45800
+153 Rue de Frédeville 45800,,,,153,Rue de Frédeville,Saint-Jean-de-Braye,
+153 Rue de Frédeville,1.989791,47.914653,,153,Rue de Frédeville,,45800
+41 Rue de la Grade Saint-Jean-de-la-Ruelle,,,,41,Rue de la Grade,,45140
+41 Rue de la Grade 45140,,,,41,Rue de la Grade,Saint-Jean-de-la-Ruelle,
+41 Rue de la Grade,1.879439,47.925625,,41,Rue de la Grade,,45140
+344 Route de Poilly Saint-Martin-sur-Ocre,,,,344,Route de Poilly,,45500
+344 Route de Poilly 45500,,,,344,Route de Poilly,Saint-Martin-sur-Ocre,
+344 Route de Poilly,2.639578,47.663001,,344,Route de Poilly,,45500
+234 Route de Saint-Cyr Sandillon,,,,234,Route de Saint-Cyr,,45640
+234 Route de Saint-Cyr 45640,,,,234,Route de Saint-Cyr,Sandillon,
+234 Route de Saint-Cyr,2.025484,47.845164,,234,Route de Saint-Cyr,,45640
+9 Route de Château Landon Sceaux-du-Gâtinais,,,,9,Route de Château Landon,,45490
+9 Route de Château Landon 45490,,,,9,Route de Château Landon,Sceaux-du-Gâtinais,
+9 Route de Château Landon,2.59767,48.105601,,9,Route de Château Landon,,45490
+1 Route de la Noue Boulaie Sury-aux-Bois,,,,1,Route de la Noue Boulaie,,45530
+1 Route de la Noue Boulaie 45530,,,,1,Route de la Noue Boulaie,Sury-aux-Bois,
+1 Route de la Noue Boulaie,2.335961,47.938405,,1,Route de la Noue Boulaie,,45530
+58 Rue de Neuville Vennecy,,,,58,Rue de Neuville,,45760
+58 Rue de Neuville 45760,,,,58,Rue de Neuville,Vennecy,
+58 Rue de Neuville,2.055721,47.958838,,58,Rue de Neuville,,45760
+16 Rue Georges Chardon Villorceau,,,,16,Rue Georges Chardon,,45190
+16 Rue Georges Chardon 45190,,,,16,Rue Georges Chardon,Villorceau,
+16 Rue Georges Chardon,1.595689,47.799576,,16,Rue Georges Chardon,,45190
+rue de saint denis saint denis en val,,,,,Rue de Saint-Denis,Saint-Denis-en-Val,
+rue de saint denis en val,,,,,Rue de Saint-Denis,Saint-Denis-en-Val,
+rue du val saint denis en Val,,,,,Rue du Val,Saint-Denis-en-Val,
+rue du val saint denis,1.9422,47.9311,,,Rue du Val,Saint-Denis-en-Val,

--- a/geocoder_tester/world/france/champagneardenne/test_addresses.csv
+++ b/geocoder_tester/world/france/champagneardenne/test_addresses.csv
@@ -1,142 +1,142 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-36 Rue Alexandre Ribot Charleville-Mézières,,,,36 Rue Alexandre Ribot,,,,08000
-36 Rue Alexandre Ribot 08000,,,,36 Rue Alexandre Ribot,,,Charleville-Mézières,
-36 Rue Alexandre Ribot,4.692834,49.762267,,36 Rue Alexandre Ribot,,,,08000
-19 Rue de la Haie Forest Charleville-Mézières,,,,19 Rue de la Haie Forest,,,,08000
-19 Rue de la Haie Forest 08000,,,,19 Rue de la Haie Forest,,,Charleville-Mézières,
-19 Rue de la Haie Forest,4.707697,49.762260,,19 Rue de la Haie Forest,,,,08000
-1 Rue Robert Coispine Charleville-Mézières,,,,1 Rue Robert Coispine,,,,08000
-1 Rue Robert Coispine 08000,,,,1 Rue Robert Coispine,,,Charleville-Mézières,
-1 Rue Robert Coispine,4.728837,49.776240,,1 Rue Robert Coispine,,,,08000
-59 Ruelle des Bos Biaux Fumay,,,,59 Ruelle des Bos Biaux,,,,08170
-59 Ruelle des Bos Biaux 08170,,,,59 Ruelle des Bos Biaux,,,Fumay,
-59 Ruelle des Bos Biaux,4.709419,49.993740,,59 Ruelle des Bos Biaux,,,,08170
-21 Rue de la Gravelle Les Hautes-Rivières,,,,21 Rue de la Gravelle,,,,08800
-21 Rue de la Gravelle 08800,,,,21 Rue de la Gravelle,,,Les Hautes-Rivières,
-21 Rue de la Gravelle,4.848680,49.874857,,21 Rue de la Gravelle,,,,08800
-8 Rue Mirabeau Nouzonville,,,,8 Rue Mirabeau,,,,08700
-8 Rue Mirabeau 08700,,,,8 Rue Mirabeau,,,Nouzonville,
-8 Rue Mirabeau,4.749088,49.812759,,8 Rue Mirabeau,,,,08700
-7 Rue de Rome Rethel,,,,7 Rue de Rome,,,,08300
-7 Rue de Rome 08300,,,,7 Rue de Rome,,,Rethel,
-7 Rue de Rome,4.359087,49.508235,,7 Rue de Rome,,,,08300
-3 Rue Thiers Sedan,,,,3 Rue Thiers,,,,08200
-3 Rue Thiers 08200,,,,3 Rue Thiers,,,Sedan,
-3 Rue Thiers,4.941802,49.701606,,3 Rue Thiers,,,,08200
-2 Rue Maurice Thorez Vivier-au-Court,,,,2 Rue Maurice Thorez,,,,08440
-2 Rue Maurice Thorez 08440,,,,2 Rue Maurice Thorez,,,Vivier-au-Court,
-2 Rue Maurice Thorez,4.833177,49.731886,,2 Rue Maurice Thorez,,,,08440
-14 Rue du Lavoir Les Bordes-Aumont,,,,14 Rue du Lavoir,,,,10800
-14 Rue du Lavoir 10800,,,,14 Rue du Lavoir,,,Les Bordes-Aumont,
-14 Rue du Lavoir,4.131931,48.188106,,14 Rue du Lavoir,,,,10800
-2 Rue du Prof Jacques Monod La Chapelle-Saint-Luc,,,,2 Rue du Prof Jacques Monod,,,,10600
-2 Rue du Prof Jacques Monod 10600,,,,2 Rue du Prof Jacques Monod,,,La Chapelle-Saint-Luc,
-2 Rue du Prof Jacques Monod,4.062153,48.320304,,2 Rue du Prof Jacques Monod,,,,10600
-6 Rue des Anc Combattants En Afn Gélannes,,,,6 Rue des Anc Combattants En Afn,,,,10100
-6 Rue des Anc Combattants En Afn 10100,,,,6 Rue des Anc Combattants En Afn,,,Gélannes,
-6 Rue des Anc Combattants En Afn,3.671526,48.488513,,6 Rue des Anc Combattants En Afn,,,,10100
-52 Rue Lamartine Les Noës-près-Troyes,,,,52 Rue Lamartine,,,,10420
-52 Rue Lamartine 10420,,,,52 Rue Lamartine,,,Les Noës-près-Troyes,
-52 Rue Lamartine,4.039084,48.301085,,52 Rue Lamartine,,,,10420
-8 Rue du Pont Les Riceys,,,,8 Rue du Pont,,,,10340
-8 Rue du Pont 10340,,,,8 Rue du Pont,,,Les Riceys,
-8 Rue du Pont,4.369641,47.994290,,8 Rue du Pont,,,,10340
-1 Rue Henri Millet Romilly-sur-Seine,,,,1 Rue Henri Millet,,,,10100
-1 Rue Henri Millet 10100,,,,1 Rue Henri Millet,,,Romilly-sur-Seine,
-1 Rue Henri Millet,3.725025,48.520924,,1 Rue Henri Millet,,,,10100
-72 Route d'Auxerre Saint-André-les-Vergers,,,,72 Route d'Auxerre,,,,10120
-72 Route d'Auxerre 10120,,,,72 Route d'Auxerre,,,Saint-André-les-Vergers,
-72 Route d'Auxerre,4.063074,48.276773,,72 Route d'Auxerre,,,,10120
-92 Boulevard de Dijon Saint-Julien-les-Villas,,,,92 Boulevard de Dijon,,,,10800
-92 Boulevard de Dijon 10800,,,,92 Boulevard de Dijon,,,Saint-Julien-les-Villas,
-92 Boulevard de Dijon,4.086304,48.271765,,92 Boulevard de Dijon,,,,10800
-7TER Rue des Mésanges Saint-Parres-aux-Tertres,,,,7TER Rue des Mésanges,,,,10410
-7TER Rue des Mésanges 10410,,,,7TER Rue des Mésanges,,,Saint-Parres-aux-Tertres,
-7TER Rue des Mésanges,4.117906,48.295986,,7TER Rue des Mésanges,,,,10410
-707 Rue des Hainelles Souligny,,,,707 Rue des Hainelles,,,,10320
-707 Rue des Hainelles 10320,,,,707 Rue des Hainelles,,,Souligny,
-707 Rue des Hainelles,4.003768,48.209416,,707 Rue des Hainelles,,,,10320
-98 Rue Étienne Pedron Troyes,,,,98 Rue Étienne Pedron,,,,10000
-98 Rue Étienne Pedron 10000,,,,98 Rue Étienne Pedron,,,Troyes,
-98 Rue Étienne Pedron,4.074901,48.314462,,98 Rue Étienne Pedron,,,,10000
-8 Rue Paul Lafargue Troyes,,,,8 Rue Paul Lafargue,,,,10000
-8 Rue Paul Lafargue 10000,,,,8 Rue Paul Lafargue,,,Troyes,
-8 Rue Paul Lafargue,4.089487,48.291149,,8 Rue Paul Lafargue,,,,10000
-4 Rue du Haut Villery,,,,4 Rue du Haut,,,,10320
-4 Rue du Haut 10320,,,,4 Rue du Haut,,,Villery,
-4 Rue du Haut,4.017812,48.171256,,4 Rue du Haut,,,,10320
-1 Route de Reims Bétheny,,,,1 Route de Reims,,,,51450
-1 Route de Reims 51450,,,,1 Route de Reims,,,Bétheny,
-1 Route de Reims,4.056697,49.283142,,1 Route de Reims,,,,51450
-53 Rue Chevalier Châlons-en-Champagne,,,,53 Rue Chevalier,,,,51000
-53 Rue Chevalier 51000,,,,53 Rue Chevalier,,,Châlons-en-Champagne,
-53 Rue Chevalier,4.374463,48.962045,,53 Rue Chevalier,,,,51000
-32 Rue Maxime David Châlons-en-Champagne,,,,32 Rue Maxime David,,,,51000
-32 Rue Maxime David 51000,,,,32 Rue Maxime David,,,Châlons-en-Champagne,
-32 Rue Maxime David,4.350607,48.959426,,32 Rue Maxime David,,,,51000
-26 Voie Communale Résidence Les Tamaris Compertrix,,,,26 Voie Communale Résidence Les Tamaris,,,,51510
-26 Voie Communale Résidence Les Tamaris 51510,,,,26 Voie Communale Résidence Les Tamaris,,,Compertrix,
-26 Voie Communale Résidence Les Tamaris,4.348143,48.938559,,26 Voie Communale Résidence Les Tamaris,,,,51510
-175 Rue de la Libération Cramant,,,,175 Rue de la Libération,,,,51530
-175 Rue de la Libération 51530,,,,175 Rue de la Libération,,,Cramant,
-175 Rue de la Libération,3.991424,48.984642,,175 Rue de la Libération,,,,51530
-24 Rue Maurice Cerveaux Épernay,,,,24 Rue Maurice Cerveaux,,,,51200
-24 Rue Maurice Cerveaux 51200,,,,24 Rue Maurice Cerveaux,,,Épernay,
-24 Rue Maurice Cerveaux,3.960426,49.039449,,24 Rue Maurice Cerveaux,,,,51200
-12 Rue Cave Labbé Fismes,,,,12 Rue Cave Labbé,,,,51170
-12 Rue Cave Labbé 51170,,,,12 Rue Cave Labbé,,,Fismes,
-12 Rue Cave Labbé,3.678957,49.310475,,12 Rue Cave Labbé,,,,51170
-20 Rue des Mûriers Loivre,,,,20 Rue des Mûriers,,,,51220
-20 Rue des Mûriers 51220,,,,20 Rue des Mûriers,,,Loivre,
-20 Rue des Mûriers,3.984738,49.343236,,20 Rue des Mûriers,,,,51220
-6 Ruelle des Cotons Recy,,,,6 Ruelle des Cotons,,,,51520
-6 Ruelle des Cotons 51520,,,,6 Ruelle des Cotons,,,Recy,
-6 Ruelle des Cotons,4.310643,48.988206,,6 Ruelle des Cotons,,,,51520
-36 Boulevard Carteret Reims,,,,36 Boulevard Carteret,,,,51100
-36 Boulevard Carteret 51100,,,,36 Boulevard Carteret,,,Reims,
-36 Boulevard Carteret,4.048212,49.258186,,36 Boulevard Carteret,,,,51100
-1BIS Rue Edmé Moreau Reims,,,,1BIS Rue Edmé Moreau,,,,51100
-1BIS Rue Edmé Moreau 51100,,,,1BIS Rue Edmé Moreau,,,Reims,
-1BIS Rue Edmé Moreau,4.027579,49.279338,,1BIS Rue Edmé Moreau,,,,51100
-13 Rue Jacques Cellier Reims,,,,13 Rue Jacques Cellier,,,,51100
-13 Rue Jacques Cellier 51100,,,,13 Rue Jacques Cellier,,,Reims,
-13 Rue Jacques Cellier,4.029197,49.280848,,13 Rue Jacques Cellier,,,,51100
-2 Allée Marcel Cheval Reims,,,,2 Allée Marcel Cheval,,,,51100
-2 Allée Marcel Cheval 51100,,,,2 Allée Marcel Cheval,,,Reims,
-2 Allée Marcel Cheval,4.010638,49.238315,,2 Allée Marcel Cheval,,,,51100
-3 Allée Raoul Ponchon Reims,,,,3 Allée Raoul Ponchon,,,,51100
-3 Allée Raoul Ponchon 51100,,,,3 Allée Raoul Ponchon,,,Reims,
-3 Allée Raoul Ponchon,4.028643,49.224722,,3 Allée Raoul Ponchon,,,,51100
-5 Rue des Cheminots Les Rivières-Henruel,,,,5 Rue des Cheminots,,,,51300
-5 Rue des Cheminots 51300,,,,5 Rue des Cheminots,,,Les Rivières-Henruel,
-5 Rue des Cheminots,4.563654,48.654470,,5 Rue des Cheminots,,,,51300
-3 Rue des Rondes Sainte-Menehould,,,,3 Rue des Rondes,,,,51800
-3 Rue des Rondes 51800,,,,3 Rue des Rondes,,,Sainte-Menehould,
-3 Rue des Rondes,4.900179,49.092698,,3 Rue des Rondes,,,,51800
-25 Rue Jean Jaurès Tinqueux,,,,25 Rue Jean Jaurès,,,,51430
-25 Rue Jean Jaurès 51430,,,,25 Rue Jean Jaurès,,,Tinqueux,
-25 Rue Jean Jaurès,3.994585,49.251321,,25 Rue Jean Jaurès,,,,51430
-15 Rue de la Pépinière Vitry-le-François,,,,15 Rue de la Pépinière,,,,51300
-15 Rue de la Pépinière 51300,,,,15 Rue de la Pépinière,,,Vitry-le-François,
-15 Rue de la Pépinière,4.585770,48.716909,,15 Rue de la Pépinière,,,,51300
-39 Rue de la Vivarde Chancenay,,,,39 Rue de la Vivarde,,,,52100
-39 Rue de la Vivarde 52100,,,,39 Rue de la Vivarde,,,Chancenay,
-39 Rue de la Vivarde,4.993608,48.675268,,39 Rue de la Vivarde,,,,52100
-35 Rue Lévy-Alphandéry Chaumont,,,,35 Rue Lévy-Alphandéry,,,,52000
-35 Rue Lévy-Alphandéry 52000,,,,35 Rue Lévy-Alphandéry,,,Chaumont,
-35 Rue Lévy-Alphandéry,5.135919,48.106428,,35 Rue Lévy-Alphandéry,,,,52000
-23 Route du Der Éclaron-Braucourt-Sainte-Livière,,,,23 Route du Der,,,,52290
-23 Route du Der 52290,,,,23 Route du Der,,,Éclaron-Braucourt-Sainte-Livière,
-23 Route du Der,4.863770,48.586881,,23 Route du Der,,,,52290
-20 Rue du Grand Bie Langres,,,,20 Rue du Grand Bie,,,,52200
-20 Rue du Grand Bie 52200,,,,20 Rue du Grand Bie,,,Langres,
-20 Rue du Grand Bie,5.332716,47.862026,,20 Rue du Grand Bie,,,,52200
-15 Rue André Theuriet Prolongée Saint-Dizier,,,,15 Rue André Theuriet Prolongée,,,,52100
-15 Rue André Theuriet Prolongée 52100,,,,15 Rue André Theuriet Prolongée,,,Saint-Dizier,
-15 Rue André Theuriet Prolongée,4.955728,48.641445,,15 Rue André Theuriet Prolongée,,,,52100
-3 Rue Paul Cézanne Saint-Dizier,,,,3 Rue Paul Cézanne,,,,52100
-3 Rue Paul Cézanne 52100,,,,3 Rue Paul Cézanne,,,Saint-Dizier,
-3 Rue Paul Cézanne,4.969206,48.643365,,3 Rue Paul Cézanne,,,,52100
-30 Rue des Jardins Wassy,,,,30 Rue des Jardins,,,,52130
-30 Rue des Jardins 52130,,,,30 Rue des Jardins,,,Wassy,
-30 Rue des Jardins,4.944818,48.501168,,30 Rue des Jardins,,,,52130
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+36 Rue Alexandre Ribot Charleville-Mézières,,,,36,Rue Alexandre Ribot,,8000
+36 Rue Alexandre Ribot 08000,,,,36,Rue Alexandre Ribot,Charleville-Mézières,
+36 Rue Alexandre Ribot,4.692834,49.762267,,36,Rue Alexandre Ribot,,8000
+19 Rue de la Haie Forest Charleville-Mézières,,,,19,Rue de la Haie Forest,,8000
+19 Rue de la Haie Forest 08000,,,,19,Rue de la Haie Forest,Charleville-Mézières,
+19 Rue de la Haie Forest,4.707697,49.76226,,19,Rue de la Haie Forest,,8000
+1 Rue Robert Coispine Charleville-Mézières,,,,1,Rue Robert Coispine,,8000
+1 Rue Robert Coispine 08000,,,,1,Rue Robert Coispine,Charleville-Mézières,
+1 Rue Robert Coispine,4.728837,49.77624,,1,Rue Robert Coispine,,8000
+59 Ruelle des Bos Biaux Fumay,,,,59,Ruelle des Bos Biaux,,8170
+59 Ruelle des Bos Biaux 08170,,,,59,Ruelle des Bos Biaux,Fumay,
+59 Ruelle des Bos Biaux,4.709419,49.99374,,59,Ruelle des Bos Biaux,,8170
+21 Rue de la Gravelle Les Hautes-Rivières,,,,21,Rue de la Gravelle,,8800
+21 Rue de la Gravelle 08800,,,,21,Rue de la Gravelle,Les Hautes-Rivières,
+21 Rue de la Gravelle,4.84868,49.874857,,21,Rue de la Gravelle,,8800
+8 Rue Mirabeau Nouzonville,,,,8,Rue Mirabeau,,8700
+8 Rue Mirabeau 08700,,,,8,Rue Mirabeau,Nouzonville,
+8 Rue Mirabeau,4.749088,49.812759,,8,Rue Mirabeau,,8700
+7 Rue de Rome Rethel,,,,7,Rue de Rome,,8300
+7 Rue de Rome 08300,,,,7,Rue de Rome,Rethel,
+7 Rue de Rome,4.359087,49.508235,,7,Rue de Rome,,8300
+3 Rue Thiers Sedan,,,,3,Rue Thiers,,8200
+3 Rue Thiers 08200,,,,3,Rue Thiers,Sedan,
+3 Rue Thiers,4.941802,49.701606,,3,Rue Thiers,,8200
+2 Rue Maurice Thorez Vivier-au-Court,,,,2,Rue Maurice Thorez,,8440
+2 Rue Maurice Thorez 08440,,,,2,Rue Maurice Thorez,Vivier-au-Court,
+2 Rue Maurice Thorez,4.833177,49.731886,,2,Rue Maurice Thorez,,8440
+14 Rue du Lavoir Les Bordes-Aumont,,,,14,Rue du Lavoir,,10800
+14 Rue du Lavoir 10800,,,,14,Rue du Lavoir,Les Bordes-Aumont,
+14 Rue du Lavoir,4.131931,48.188106,,14,Rue du Lavoir,,10800
+2 Rue du Prof Jacques Monod La Chapelle-Saint-Luc,,,,2,Rue du Prof Jacques Monod,,10600
+2 Rue du Prof Jacques Monod 10600,,,,2,Rue du Prof Jacques Monod,La Chapelle-Saint-Luc,
+2 Rue du Prof Jacques Monod,4.062153,48.320304,,2,Rue du Prof Jacques Monod,,10600
+6 Rue des Anc Combattants En Afn Gélannes,,,,6,Rue des Anc Combattants En Afn,,10100
+6 Rue des Anc Combattants En Afn 10100,,,,6,Rue des Anc Combattants En Afn,Gélannes,
+6 Rue des Anc Combattants En Afn,3.671526,48.488513,,6,Rue des Anc Combattants En Afn,,10100
+52 Rue Lamartine Les Noës-près-Troyes,,,,52,Rue Lamartine,,10420
+52 Rue Lamartine 10420,,,,52,Rue Lamartine,Les Noës-près-Troyes,
+52 Rue Lamartine,4.039084,48.301085,,52,Rue Lamartine,,10420
+8 Rue du Pont Les Riceys,,,,8,Rue du Pont,,10340
+8 Rue du Pont 10340,,,,8,Rue du Pont,Les Riceys,
+8 Rue du Pont,4.369641,47.99429,,8,Rue du Pont,,10340
+1 Rue Henri Millet Romilly-sur-Seine,,,,1,Rue Henri Millet,,10100
+1 Rue Henri Millet 10100,,,,1,Rue Henri Millet,Romilly-sur-Seine,
+1 Rue Henri Millet,3.725025,48.520924,,1,Rue Henri Millet,,10100
+72 Route d'Auxerre Saint-André-les-Vergers,,,,72,Route d'Auxerre,,10120
+72 Route d'Auxerre 10120,,,,72,Route d'Auxerre,Saint-André-les-Vergers,
+72 Route d'Auxerre,4.063074,48.276773,,72,Route d'Auxerre,,10120
+92 Boulevard de Dijon Saint-Julien-les-Villas,,,,92,Boulevard de Dijon,,10800
+92 Boulevard de Dijon 10800,,,,92,Boulevard de Dijon,Saint-Julien-les-Villas,
+92 Boulevard de Dijon,4.086304,48.271765,,92,Boulevard de Dijon,,10800
+7TER Rue des Mésanges Saint-Parres-aux-Tertres,,,,7TER,Rue des Mésanges,,10410
+7TER Rue des Mésanges 10410,,,,7TER,Rue des Mésanges,Saint-Parres-aux-Tertres,
+7TER Rue des Mésanges,4.117906,48.295986,,7TER,Rue des Mésanges,,10410
+707 Rue des Hainelles Souligny,,,,707,Rue des Hainelles,,10320
+707 Rue des Hainelles 10320,,,,707,Rue des Hainelles,Souligny,
+707 Rue des Hainelles,4.003768,48.209416,,707,Rue des Hainelles,,10320
+98 Rue Étienne Pedron Troyes,,,,98,Rue Étienne Pedron,,10000
+98 Rue Étienne Pedron 10000,,,,98,Rue Étienne Pedron,Troyes,
+98 Rue Étienne Pedron,4.074901,48.314462,,98,Rue Étienne Pedron,,10000
+8 Rue Paul Lafargue Troyes,,,,8,Rue Paul Lafargue,,10000
+8 Rue Paul Lafargue 10000,,,,8,Rue Paul Lafargue,Troyes,
+8 Rue Paul Lafargue,4.089487,48.291149,,8,Rue Paul Lafargue,,10000
+4 Rue du Haut Villery,,,,4,Rue du Haut,,10320
+4 Rue du Haut 10320,,,,4,Rue du Haut,Villery,
+4 Rue du Haut,4.017812,48.171256,,4,Rue du Haut,,10320
+1 Route de Reims Bétheny,,,,1,Route de Reims,,51450
+1 Route de Reims 51450,,,,1,Route de Reims,Bétheny,
+1 Route de Reims,4.056697,49.283142,,1,Route de Reims,,51450
+53 Rue Chevalier Châlons-en-Champagne,,,,53,Rue Chevalier,,51000
+53 Rue Chevalier 51000,,,,53,Rue Chevalier,Châlons-en-Champagne,
+53 Rue Chevalier,4.374463,48.962045,,53,Rue Chevalier,,51000
+32 Rue Maxime David Châlons-en-Champagne,,,,32,Rue Maxime David,,51000
+32 Rue Maxime David 51000,,,,32,Rue Maxime David,Châlons-en-Champagne,
+32 Rue Maxime David,4.350607,48.959426,,32,Rue Maxime David,,51000
+26 Voie Communale Résidence Les Tamaris Compertrix,,,,26,Voie Communale Résidence Les Tamaris,,51510
+26 Voie Communale Résidence Les Tamaris 51510,,,,26,Voie Communale Résidence Les Tamaris,Compertrix,
+26 Voie Communale Résidence Les Tamaris,4.348143,48.938559,,26,Voie Communale Résidence Les Tamaris,,51510
+175 Rue de la Libération Cramant,,,,175,Rue de la Libération,,51530
+175 Rue de la Libération 51530,,,,175,Rue de la Libération,Cramant,
+175 Rue de la Libération,3.991424,48.984642,,175,Rue de la Libération,,51530
+24 Rue Maurice Cerveaux Épernay,,,,24,Rue Maurice Cerveaux,,51200
+24 Rue Maurice Cerveaux 51200,,,,24,Rue Maurice Cerveaux,Épernay,
+24 Rue Maurice Cerveaux,3.960426,49.039449,,24,Rue Maurice Cerveaux,,51200
+12 Rue Cave Labbé Fismes,,,,12,Rue Cave Labbé,,51170
+12 Rue Cave Labbé 51170,,,,12,Rue Cave Labbé,Fismes,
+12 Rue Cave Labbé,3.678957,49.310475,,12,Rue Cave Labbé,,51170
+20 Rue des Mûriers Loivre,,,,20,Rue des Mûriers,,51220
+20 Rue des Mûriers 51220,,,,20,Rue des Mûriers,Loivre,
+20 Rue des Mûriers,3.984738,49.343236,,20,Rue des Mûriers,,51220
+6 Ruelle des Cotons Recy,,,,6,Ruelle des Cotons,,51520
+6 Ruelle des Cotons 51520,,,,6,Ruelle des Cotons,Recy,
+6 Ruelle des Cotons,4.310643,48.988206,,6,Ruelle des Cotons,,51520
+36 Boulevard Carteret Reims,,,,36,Boulevard Carteret,,51100
+36 Boulevard Carteret 51100,,,,36,Boulevard Carteret,Reims,
+36 Boulevard Carteret,4.048212,49.258186,,36,Boulevard Carteret,,51100
+1BIS Rue Edmé Moreau Reims,,,,1BIS,Rue Edmé Moreau,,51100
+1BIS Rue Edmé Moreau 51100,,,,1BIS,Rue Edmé Moreau,Reims,
+1BIS Rue Edmé Moreau,4.027579,49.279338,,1BIS,Rue Edmé Moreau,,51100
+13 Rue Jacques Cellier Reims,,,,13,Rue Jacques Cellier,,51100
+13 Rue Jacques Cellier 51100,,,,13,Rue Jacques Cellier,Reims,
+13 Rue Jacques Cellier,4.029197,49.280848,,13,Rue Jacques Cellier,,51100
+2 Allée Marcel Cheval Reims,,,,2,Allée Marcel Cheval,,51100
+2 Allée Marcel Cheval 51100,,,,2,Allée Marcel Cheval,Reims,
+2 Allée Marcel Cheval,4.010638,49.238315,,2,Allée Marcel Cheval,,51100
+3 Allée Raoul Ponchon Reims,,,,3,Allée Raoul Ponchon,,51100
+3 Allée Raoul Ponchon 51100,,,,3,Allée Raoul Ponchon,Reims,
+3 Allée Raoul Ponchon,4.028643,49.224722,,3,Allée Raoul Ponchon,,51100
+5 Rue des Cheminots Les Rivières-Henruel,,,,5,Rue des Cheminots,,51300
+5 Rue des Cheminots 51300,,,,5,Rue des Cheminots,Les Rivières-Henruel,
+5 Rue des Cheminots,4.563654,48.65447,,5,Rue des Cheminots,,51300
+3 Rue des Rondes Sainte-Menehould,,,,3,Rue des Rondes,,51800
+3 Rue des Rondes 51800,,,,3,Rue des Rondes,Sainte-Menehould,
+3 Rue des Rondes,4.900179,49.092698,,3,Rue des Rondes,,51800
+25 Rue Jean Jaurès Tinqueux,,,,25,Rue Jean Jaurès,,51430
+25 Rue Jean Jaurès 51430,,,,25,Rue Jean Jaurès,Tinqueux,
+25 Rue Jean Jaurès,3.994585,49.251321,,25,Rue Jean Jaurès,,51430
+15 Rue de la Pépinière Vitry-le-François,,,,15,Rue de la Pépinière,,51300
+15 Rue de la Pépinière 51300,,,,15,Rue de la Pépinière,Vitry-le-François,
+15 Rue de la Pépinière,4.58577,48.716909,,15,Rue de la Pépinière,,51300
+39 Rue de la Vivarde Chancenay,,,,39,Rue de la Vivarde,,52100
+39 Rue de la Vivarde 52100,,,,39,Rue de la Vivarde,Chancenay,
+39 Rue de la Vivarde,4.993608,48.675268,,39,Rue de la Vivarde,,52100
+35 Rue Lévy-Alphandéry Chaumont,,,,35,Rue Lévy-Alphandéry,,52000
+35 Rue Lévy-Alphandéry 52000,,,,35,Rue Lévy-Alphandéry,Chaumont,
+35 Rue Lévy-Alphandéry,5.135919,48.106428,,35,Rue Lévy-Alphandéry,,52000
+23 Route du Der Éclaron-Braucourt-Sainte-Livière,,,,23,Route du Der,,52290
+23 Route du Der 52290,,,,23,Route du Der,Éclaron-Braucourt-Sainte-Livière,
+23 Route du Der,4.86377,48.586881,,23,Route du Der,,52290
+20 Rue du Grand Bie Langres,,,,20,Rue du Grand Bie,,52200
+20 Rue du Grand Bie 52200,,,,20,Rue du Grand Bie,Langres,
+20 Rue du Grand Bie,5.332716,47.862026,,20,Rue du Grand Bie,,52200
+15 Rue André Theuriet Prolongée Saint-Dizier,,,,15,Rue André Theuriet Prolongée,,52100
+15 Rue André Theuriet Prolongée 52100,,,,15,Rue André Theuriet Prolongée,Saint-Dizier,
+15 Rue André Theuriet Prolongée,4.955728,48.641445,,15,Rue André Theuriet Prolongée,,52100
+3 Rue Paul Cézanne Saint-Dizier,,,,3,Rue Paul Cézanne,,52100
+3 Rue Paul Cézanne 52100,,,,3,Rue Paul Cézanne,Saint-Dizier,
+3 Rue Paul Cézanne,4.969206,48.643365,,3,Rue Paul Cézanne,,52100
+30 Rue des Jardins Wassy,,,,30,Rue des Jardins,,52130
+30 Rue des Jardins 52130,,,,30,Rue des Jardins,Wassy,
+30 Rue des Jardins,4.944818,48.501168,,30,Rue des Jardins,,52130

--- a/geocoder_tester/world/france/corse/test_addresses.csv
+++ b/geocoder_tester/world/france/corse/test_addresses.csv
@@ -1,4 +1,4 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-840 Rue des Platanes Ghisonaccia,,,,840 Rue des Platanes,,,,20240
-840 Rue des Platanes 20240,,,,840 Rue des Platanes,,,Ghisonaccia,
-840 Rue des Platanes,9.377350,42.059717,,840 Rue des Platanes,,,,20240
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+840 Rue des Platanes Ghisonaccia,,,,840,Rue des Platanes,,20240
+840 Rue des Platanes 20240,,,,840,Rue des Platanes,Ghisonaccia,
+840 Rue des Platanes,9.37735,42.059717,,840,Rue des Platanes,,20240

--- a/geocoder_tester/world/france/franchecomte/test_addresses.csv
+++ b/geocoder_tester/world/france/franchecomte/test_addresses.csv
@@ -1,187 +1,187 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-13 Rue des Cités du Parc Audincourt,,,,13 Rue des Cités du Parc,,,,25400
-13 Rue des Cités du Parc 25400,,,,13 Rue des Cités du Parc,,,Audincourt,
-13 Rue des Cités du Parc,6.838678,47.477260,,13 Rue des Cités du Parc,,,,25400
-6 Impasse de la Combe Bart,,,,6 Impasse de la Combe,,,,25420
-6 Impasse de la Combe 25420,,,,6 Impasse de la Combe,,,Bart,
-6 Impasse de la Combe,6.760767,47.494454,,6 Impasse de la Combe,,,,25420
-9TER Avenue Arthur Gaulard Besançon,,,,9TER Avenue Arthur Gaulard,,,,25000
-9TER Avenue Arthur Gaulard 25000,,,,9TER Avenue Arthur Gaulard,,,Besançon,
-9TER Avenue Arthur Gaulard,6.033302,47.235734,,9TER Avenue Arthur Gaulard,,,,25000
-6 Rue des Fluttes Agasses Besançon,,,,6 Rue des Fluttes Agasses,,,,25000
-6 Rue des Fluttes Agasses 25000,,,,6 Rue des Fluttes Agasses,,,Besançon,
-6 Rue des Fluttes Agasses,6.029131,47.257356,,6 Rue des Fluttes Agasses,,,,25000
-21 Chemin de Palente Besançon,,,,21 Chemin de Palente,,,,25000
-21 Chemin de Palente 25000,,,,21 Chemin de Palente,,,Besançon,
-21 Chemin de Palente,6.049113,47.267004,,21 Chemin de Palente,,,,25000
-11 Rue Henri Bretagne Bethoncourt,,,,11 Rue Henri Bretagne,,,,25200
-11 Rue Henri Bretagne 25200,,,,11 Rue Henri Bretagne,,,Bethoncourt,
-11 Rue Henri Bretagne,6.793921,47.526935,,11 Rue Henri Bretagne,,,,25200
-12 Rue des Bauchets Brognard,,,,12 Rue des Bauchets,,,,25600
-12 Rue des Bauchets 25600,,,,12 Rue des Bauchets,,,Brognard,
-12 Rue des Bauchets,6.861625,47.527155,,12 Rue des Bauchets,,,,25600
-3 Voie Communale Grande Rue Chaux-lès-Passavant,,,,3 Voie Communale Grande Rue,,,,25530
-3 Voie Communale Grande Rue 25530,,,,3 Voie Communale Grande Rue,,,Chaux-lès-Passavant,
-3 Voie Communale Grande Rue,6.355875,47.232831,,3 Voie Communale Grande Rue,,,,25530
-11 Rue des Écoles Dampierre-sur-le-Doubs,,,,11 Rue des Écoles,,,,25420
-11 Rue des Écoles 25420,,,,11 Rue des Écoles,,,Dampierre-sur-le-Doubs,
-11 Rue des Écoles,6.736575,47.474900,,11 Rue des Écoles,,,,25420
-4 Rue des Acacias Émagny,,,,4 Rue des Acacias,,,,25170
-4 Rue des Acacias 25170,,,,4 Rue des Acacias,,,Émagny,
-4 Rue des Acacias,5.869936,47.310739,,4 Rue des Acacias,,,,25170
-3 Rue de Verdun Fesches-le-Châtel,,,,3 Rue de Verdun,,,,25490
-3 Rue de Verdun 25490,,,,3 Rue de Verdun,,,Fesches-le-Châtel,
-3 Rue de Verdun,6.912476,47.522955,,3 Rue de Verdun,,,,25490
-2 Rue de la Vierge Gennes,,,,2 Rue de la Vierge,,,,25660
-2 Rue de la Vierge 25660,,,,2 Rue de la Vierge,,,Gennes,
-2 Rue de la Vierge,6.122875,47.241570,,2 Rue de la Vierge,,,,25660
-5 Rue des Jardins Hérimoncourt,,,,5 Rue des Jardins,,,,25310
-5 Rue des Jardins 25310,,,,5 Rue des Jardins,,,Hérimoncourt,
-5 Rue des Jardins,6.882118,47.445937,,5 Rue des Jardins,,,,25310
-7BIS Rue du Temple Villers-le-Lac,,,,7BIS Rue du Temple,,,,25130
-7BIS Rue du Temple 25130,,,,7BIS Rue du Temple,,,Villers-le-Lac,
-7BIS Rue du Temple,6.683169,47.059668,,7BIS Rue du Temple,,,,25130
-3 Rue du Chalet Malans,,,,3 Rue du Chalet,,,,25330
-3 Rue du Chalet 25330,,,,3 Rue du Chalet,,,Malans,
-3 Rue du Chalet,6.031905,47.047892,,3 Rue du Chalet,,,,25330
-28 Rue de la Rançonnière Métabief,,,,28 Rue de la Rançonnière,,,,25370
-28 Rue de la Rançonnière 25370,,,,28 Rue de la Rançonnière,,,Métabief,
-28 Rue de la Rançonnière,6.346866,46.768748,,28 Rue de la Rançonnière,,,,25370
-3 Impasse des Prés Montbéliard,,,,3 Impasse des Prés,,,,25200
-3 Impasse des Prés 25200,,,,3 Impasse des Prés,,,Montbéliard,
-3 Impasse des Prés,6.787316,47.521539,,3 Impasse des Prés,,,,25200
-10 Rue de la Chaussée Morteau,,,,10 Rue de la Chaussée,,,,25500
-10 Rue de la Chaussée 25500,,,,10 Rue de la Chaussée,,,Morteau,
-10 Rue de la Chaussée,6.602351,47.056447,,10 Rue de la Chaussée,,,,25500
-2 Rue du Chanoine Renaud Ornans,,,,2 Rue du Chanoine Renaud,,,,25290
-2 Rue du Chanoine Renaud 25290,,,,2 Rue du Chanoine Renaud,,,Ornans,
-2 Rue du Chanoine Renaud,6.139398,47.098687,,2 Rue du Chanoine Renaud,,,,25290
-25 Rue Arago Pontarlier,,,,25 Rue Arago,,,,25300
-25 Rue Arago 25300,,,,25 Rue Arago,,,Pontarlier,
-25 Rue Arago,6.340043,46.913420,,25 Rue Arago,,,,25300
-41C Rue du 12 Septembre Pont-de-Roide,,,,41C Rue du 12 Septembre,,,,25150
-41C Rue du 12 Septembre 25150,,,,41C Rue du 12 Septembre,,,Pont-de-Roide,
-41C Rue du 12 Septembre,6.767064,47.379425,,41C Rue du 12 Septembre,,,,25150
-28 Rue de Champonot Roulans,,,,28 Rue de Champonot,,,,25640
-28 Rue de Champonot 25640,,,,28 Rue de Champonot,,,Roulans,
-28 Rue de Champonot,6.234419,47.318534,,28 Rue de Champonot,,,,25640
-11 Rue Les Perrières Sancey-le-Grand,,,,11 Rue Les Perrières,,,,25430
-11 Rue Les Perrières 25430,,,,11 Rue Les Perrières,,,,25430
-11 Rue Les Perrières,6.586225,47.302039,,11 Rue Les Perrières,,,,25430
-7 Rue de Bournois Soye,,,,7 Rue de Bournois,,,,25250
-7 Rue de Bournois 25250,,,,7 Rue de Bournois,,,Soye,
-7 Rue de Bournois,6.498261,47.446654,,7 Rue de Bournois,,,,25250
-4BIS Rue des Buis Valentigney,,,,4BIS Rue des Buis,,,,25700
-4BIS Rue des Buis 25700,,,,4BIS Rue des Buis,,,Valentigney,
-4BIS Rue des Buis,6.827798,47.466687,,4BIS Rue des Buis,,,,25700
-2 Rue du Chateau d'Eau Viéthorey,,,,2 Rue du Chateau d'Eau,,,,25340
-2 Rue du Chateau d'Eau 25340,,,,2 Rue du Chateau d'Eau,,,Viéthorey,
-2 Rue du Chateau d'Eau,6.430471,47.424688,,2 Rue du Chateau d'Eau,,,,25340
-3 Rue du Bois Aumur,,,,3 Rue du Bois,,,,39410
-3 Rue du Bois 39410,,,,3 Rue du Bois,,,Aumur,
-3 Rue du Bois,5.352416,47.055722,,3 Rue du Bois,,,,39410
-12 LA COTE DES BELETTES Bracon,,,,12 LA COTE DES BELETTES,,,,39110
-12 LA COTE DES BELETTES 39110,,,,12 LA COTE DES BELETTES,,,Bracon,
-12 LA COTE DES BELETTES,5.886580,46.914550,,12 LA COTE DES BELETTES,,,,39110
-9A Impasse du Tunnel Champvans,,,,9A Impasse du Tunnel,,,,39100
-9A Impasse du Tunnel 39100,,,,9A Impasse du Tunnel,,,Champvans,
-9A Impasse du Tunnel,5.450449,47.106639,,9A Impasse du Tunnel,,,,39100
-2 Rue des Saules Cize,,,,2 Rue des Saules,,,,39300
-2 Rue des Saules 39300,,,,2 Rue des Saules,,,Cize,
-2 Rue des Saules,5.908900,46.731107,,2 Rue des Saules,,,,39300
-43 Rue d'Alsace Damparis,,,,43 Rue d'Alsace,,,,39500
-43 Rue d'Alsace 39500,,,,43 Rue d'Alsace,,,Damparis,
-43 Rue d'Alsace,5.411958,47.068153,,43 Rue d'Alsace,,,,39500
-4 Rue des Gardes Dole,,,,4 Rue des Gardes,,,,39100
-4 Rue des Gardes 39100,,,,4 Rue des Gardes,,,Dole,
-4 Rue des Gardes,5.481158,47.090678,,4 Rue des Gardes,,,,39100
-4 Impasse de la Combe Écrille,,,,4 Impasse de la Combe,,,,39270
-4 Impasse de la Combe 39270,,,,4 Impasse de la Combe,,,Écrille,
-4 Impasse de la Combe,5.629383,46.506205,,4 Impasse de la Combe,,,,39270
-2 Rue des Perrodins Gigny,,,,2 Rue des Perrodins,,,,39320
-2 Rue des Perrodins 39320,,,,2 Rue des Perrodins,,,Gigny,
-2 Rue des Perrodins,5.478474,46.450127,,2 Rue des Perrodins,,,,39320
-14 Avenue Camille Prost Lons-le-Saunier,,,,14 Avenue Camille Prost,,,,39000
-14 Avenue Camille Prost 39000,,,,14 Avenue Camille Prost,,,Lons-le-Saunier,
-14 Avenue Camille Prost,5.567459,46.671617,,14 Avenue Camille Prost,,,,39000
-9 Impasse de l'Alambic Maynal,,,,9 Impasse de l'Alambic,,,,39190
-9 Impasse de l'Alambic 39190,,,,9 Impasse de l'Alambic,,,Maynal,
-9 Impasse de l'Alambic,5.419226,46.556207,,9 Impasse de l'Alambic,,,,39190
-13 Rue Henri Ponard Montmorot,,,,13 Rue Henri Ponard,,,,39570
-13 Rue Henri Ponard 39570,,,,13 Rue Henri Ponard,,,Montmorot,
-13 Rue Henri Ponard,5.524156,46.678019,,13 Rue Henri Ponard,,,,39570
-544 Route de Champagnole Ney,,,,544 Route de Champagnole,,,,39300
-544 Route de Champagnole 39300,,,,544 Route de Champagnole,,,Ney,
-544 Route de Champagnole,5.894406,46.737226,,544 Route de Champagnole,,,,39300
-120 Chemin du Milieu Le Pin,,,,120 Chemin du Milieu,,,,39210
-120 Chemin du Milieu 39210,,,,120 Chemin du Milieu,,,Le Pin,
-120 Chemin du Milieu,5.568293,46.706344,,120 Chemin du Milieu,,,,39210
-10 Rue de Gray Ranchot,,,,10 Rue de Gray,,,,39700
-10 Rue de Gray 39700,,,,10 Rue de Gray,,,Ranchot,
-10 Rue de Gray,5.721617,47.152031,,10 Rue de Gray,,,,39700
-18 Rue du Collège Saint-Claude,,,,18 Rue du Collège,,,,39200
-18 Rue du Collège 39200,,,,18 Rue du Collège,,,Saint-Claude,
-18 Rue du Collège,5.865220,46.389434,,18 Rue du Collège,,,,39200
-60 Rue de la République Salins-les-Bains,,,,60 Rue de la République,,,,39110
-60 Rue de la République 39110,,,,60 Rue de la République,,,Salins-les-Bains,
-60 Rue de la République,5.877548,46.934385,,60 Rue de la République,,,,39110
-2 Lotissement de la Source Thoirette,,,,2 Lotissement de la Source,,,,39240
-2 Lotissement de la Source 39240,,,,2 Lotissement de la Source,,,Thoirette,
-2 Lotissement de la Source,5.518774,46.265174,,2 Lotissement de la Source,,,,39240
-14 Route de Nevy Voiteur,,,,14 Route de Nevy,,,,39210
-14 Route de Nevy 39210,,,,14 Route de Nevy,,,Voiteur,
-14 Route de Nevy,5.612596,46.753849,,14 Route de Nevy,,,,39210
-12 Route de Bussières Boulot,,,,12 Route de Bussières,,,,70190
-12 Route de Bussières 70190,,,,12 Route de Bussières,,,Boulot,
-12 Route de Bussières,5.962335,47.341876,,12 Route de Bussières,,,,70190
-9 Rue de la Crottière Choye,,,,9 Rue de la Crottière,,,,70700
-9 Rue de la Crottière 70700,,,,9 Rue de la Crottière,,,Choye,
-9 Rue de la Crottière,5.764126,47.388209,,9 Rue de la Crottière,,,,70700
-5 Place de la Gare Faucogney-et-la-Mer,,,,5 Place de la Gare,,,,70310
-5 Place de la Gare 70310,,,,5 Place de la Gare,,,Faucogney-et-la-Mer,
-5 Place de la Gare,6.562944,47.846449,,5 Place de la Gare,,,,70310
-9 Rue de la Croisette Frotey-lès-Lure,,,,9 Rue de la Croisette,,,,70200
-9 Rue de la Croisette 70200,,,,9 Rue de la Croisette,,,Frotey-lès-Lure,
-9 Rue de la Croisette,6.557208,47.652409,,9 Rue de la Croisette,,,,70200
-3 Chemin des Combes Héricourt,,,,3 Chemin des Combes,,,,70400
-3 Chemin des Combes 70400,,,,3 Chemin des Combes,,,Héricourt,
-3 Chemin des Combes,6.779222,47.545099,,3 Chemin des Combes,,,,70400
-10 Rue Lasalle Lure,,,,10 Rue Lasalle,,,,70200
-10 Rue Lasalle 70200,,,,10 Rue Lasalle,,,Lure,
-10 Rue Lasalle,6.504907,47.675916,,10 Rue Lasalle,,,,70200
-13 Rue de la Fontaine Montboillon,,,,13 Rue de la Fontaine,,,,70700
-13 Rue de la Fontaine 70700,,,,13 Rue de la Fontaine,,,Montboillon,
-13 Rue de la Fontaine,5.922623,47.372848,,13 Rue de la Fontaine,,,,70700
-30 Rue du Rapois Plancher-Bas,,,,30 Rue du Rapois,,,,70290
-30 Rue du Rapois 70290,,,,30 Rue du Rapois,,,Plancher-Bas,
-30 Rue du Rapois,6.723711,47.737453,,30 Rue du Rapois,,,,70290
-2 Rue du Tacot Rioz,,,,2 Rue du Tacot,,,,70190
-2 Rue du Tacot 70190,,,,2 Rue du Tacot,,,Rioz,
-2 Rue du Tacot,6.067185,47.425715,,2 Rue du Tacot,,,,70190
-2 Rue de la Fontaine Saulnot,,,,2 Rue de la Fontaine,,,,70400
-2 Rue de la Fontaine 70400,,,,2 Rue de la Fontaine,,,Saulnot,
-2 Rue de la Fontaine,6.629135,47.562783,,2 Rue de la Fontaine,,,,70400
-13BIS Rue des Planchottes Velet,,,,13BIS Rue des Planchottes,,,,70100
-13BIS Rue des Planchottes 70100,,,,13BIS Rue des Planchottes,,,Velet,
-13BIS Rue des Planchottes,5.562849,47.427122,,13BIS Rue des Planchottes,,,,70100
-7 Rue du Pre Aux Vernes Villersexel,,,,7 Rue du Pre Aux Vernes,,,,70110
-7 Rue du Pre Aux Vernes 70110,,,,7 Rue du Pre Aux Vernes,,,Villersexel,
-7 Rue du Pre Aux Vernes,6.423483,47.546044,,7 Rue du Pre Aux Vernes,,,,70110
-6A Avenue du Champ de Mars Belfort,,,,6A Avenue du Champ de Mars,,,,90000
-6A Avenue du Champ de Mars 90000,,,,6A Avenue du Champ de Mars,,,Belfort,
-6A Avenue du Champ de Mars,6.857771,47.650695,,6A Avenue du Champ de Mars,,,,90000
-11 Rue de Valenciennes Belfort,,,,11 Rue de Valenciennes,,,,90000
-11 Rue de Valenciennes 90000,,,,11 Rue de Valenciennes,,,Belfort,
-11 Rue de Valenciennes,6.851994,47.642109,,11 Rue de Valenciennes,,,,90000
-16 Rue de la Coursière Danjoutin,,,,16 Rue de la Coursière,,,,90400
-16 Rue de la Coursière 90400,,,,16 Rue de la Coursière,,,Danjoutin,
-16 Rue de la Coursière,6.857924,47.616649,,16 Rue de la Coursière,,,,90400
-24 Rue du Thiamont Évette-Salbert,,,,24 Rue du Thiamont,,,,90350
-24 Rue du Thiamont 90350,,,,24 Rue du Thiamont,,,Évette-Salbert,
-24 Rue du Thiamont,6.790198,47.667140,,24 Rue du Thiamont,,,,90350
-4 Rue Sur la Côte Lebetain,,,,4 Rue Sur la Côte,,,,90100
-4 Rue Sur la Côte 90100,,,,4 Rue Sur la Côte,,,Lebetain,
-4 Rue Sur la Côte,6.973595,47.487491,,4 Rue Sur la Côte,,,,90100
-3 Rue du Château Roppe,,,,3 Rue du Château,,,,90380
-3 Rue du Château 90380,,,,3 Rue du Château,,,Roppe,
-3 Rue du Château,6.920818,47.666964,,3 Rue du Château,,,,90380
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+13 Rue des Cités du Parc Audincourt,,,,13,Rue des Cités du Parc,,25400
+13 Rue des Cités du Parc 25400,,,,13,Rue des Cités du Parc,Audincourt,
+13 Rue des Cités du Parc,6.838678,47.47726,,13,Rue des Cités du Parc,,25400
+6 Impasse de la Combe Bart,,,,6,Impasse de la Combe,,25420
+6 Impasse de la Combe 25420,,,,6,Impasse de la Combe,Bart,
+6 Impasse de la Combe,6.760767,47.494454,,6,Impasse de la Combe,,25420
+9TER Avenue Arthur Gaulard Besançon,,,,9TER,Avenue Arthur Gaulard,,25000
+9TER Avenue Arthur Gaulard 25000,,,,9TER,Avenue Arthur Gaulard,Besançon,
+9TER Avenue Arthur Gaulard,6.033302,47.235734,,9TER,Avenue Arthur Gaulard,,25000
+6 Rue des Fluttes Agasses Besançon,,,,6,Rue des Fluttes Agasses,,25000
+6 Rue des Fluttes Agasses 25000,,,,6,Rue des Fluttes Agasses,Besançon,
+6 Rue des Fluttes Agasses,6.029131,47.257356,,6,Rue des Fluttes Agasses,,25000
+21 Chemin de Palente Besançon,,,,21,Chemin de Palente,,25000
+21 Chemin de Palente 25000,,,,21,Chemin de Palente,Besançon,
+21 Chemin de Palente,6.049113,47.267004,,21,Chemin de Palente,,25000
+11 Rue Henri Bretagne Bethoncourt,,,,11,Rue Henri Bretagne,,25200
+11 Rue Henri Bretagne 25200,,,,11,Rue Henri Bretagne,Bethoncourt,
+11 Rue Henri Bretagne,6.793921,47.526935,,11,Rue Henri Bretagne,,25200
+12 Rue des Bauchets Brognard,,,,12,Rue des Bauchets,,25600
+12 Rue des Bauchets 25600,,,,12,Rue des Bauchets,Brognard,
+12 Rue des Bauchets,6.861625,47.527155,,12,Rue des Bauchets,,25600
+3 Voie Communale Grande Rue Chaux-lès-Passavant,,,,3,Voie Communale Grande Rue,,25530
+3 Voie Communale Grande Rue 25530,,,,3,Voie Communale Grande Rue,Chaux-lès-Passavant,
+3 Voie Communale Grande Rue,6.355875,47.232831,,3,Voie Communale Grande Rue,,25530
+11 Rue des Écoles Dampierre-sur-le-Doubs,,,,11,Rue des Écoles,,25420
+11 Rue des Écoles 25420,,,,11,Rue des Écoles,Dampierre-sur-le-Doubs,
+11 Rue des Écoles,6.736575,47.4749,,11,Rue des Écoles,,25420
+4 Rue des Acacias Émagny,,,,4,Rue des Acacias,,25170
+4 Rue des Acacias 25170,,,,4,Rue des Acacias,Émagny,
+4 Rue des Acacias,5.869936,47.310739,,4,Rue des Acacias,,25170
+3 Rue de Verdun Fesches-le-Châtel,,,,3,Rue de Verdun,,25490
+3 Rue de Verdun 25490,,,,3,Rue de Verdun,Fesches-le-Châtel,
+3 Rue de Verdun,6.912476,47.522955,,3,Rue de Verdun,,25490
+2 Rue de la Vierge Gennes,,,,2,Rue de la Vierge,,25660
+2 Rue de la Vierge 25660,,,,2,Rue de la Vierge,Gennes,
+2 Rue de la Vierge,6.122875,47.24157,,2,Rue de la Vierge,,25660
+5 Rue des Jardins Hérimoncourt,,,,5,Rue des Jardins,,25310
+5 Rue des Jardins 25310,,,,5,Rue des Jardins,Hérimoncourt,
+5 Rue des Jardins,6.882118,47.445937,,5,Rue des Jardins,,25310
+7BIS Rue du Temple Villers-le-Lac,,,,7BIS,Rue du Temple,,25130
+7BIS Rue du Temple 25130,,,,7BIS,Rue du Temple,Villers-le-Lac,
+7BIS Rue du Temple,6.683169,47.059668,,7BIS,Rue du Temple,,25130
+3 Rue du Chalet Malans,,,,3,Rue du Chalet,,25330
+3 Rue du Chalet 25330,,,,3,Rue du Chalet,Malans,
+3 Rue du Chalet,6.031905,47.047892,,3,Rue du Chalet,,25330
+28 Rue de la Rançonnière Métabief,,,,28,Rue de la Rançonnière,,25370
+28 Rue de la Rançonnière 25370,,,,28,Rue de la Rançonnière,Métabief,
+28 Rue de la Rançonnière,6.346866,46.768748,,28,Rue de la Rançonnière,,25370
+3 Impasse des Prés Montbéliard,,,,3,Impasse des Prés,,25200
+3 Impasse des Prés 25200,,,,3,Impasse des Prés,Montbéliard,
+3 Impasse des Prés,6.787316,47.521539,,3,Impasse des Prés,,25200
+10 Rue de la Chaussée Morteau,,,,10,Rue de la Chaussée,,25500
+10 Rue de la Chaussée 25500,,,,10,Rue de la Chaussée,Morteau,
+10 Rue de la Chaussée,6.602351,47.056447,,10,Rue de la Chaussée,,25500
+2 Rue du Chanoine Renaud Ornans,,,,2,Rue du Chanoine Renaud,,25290
+2 Rue du Chanoine Renaud 25290,,,,2,Rue du Chanoine Renaud,Ornans,
+2 Rue du Chanoine Renaud,6.139398,47.098687,,2,Rue du Chanoine Renaud,,25290
+25 Rue Arago Pontarlier,,,,25,Rue Arago,,25300
+25 Rue Arago 25300,,,,25,Rue Arago,Pontarlier,
+25 Rue Arago,6.340043,46.91342,,25,Rue Arago,,25300
+41C Rue du 12 Septembre Pont-de-Roide,,,,41C,Rue du 12 Septembre,,25150
+41C Rue du 12 Septembre 25150,,,,41C,Rue du 12 Septembre,Pont-de-Roide,
+41C Rue du 12 Septembre,6.767064,47.379425,,41C,Rue du 12 Septembre,,25150
+28 Rue de Champonot Roulans,,,,28,Rue de Champonot,,25640
+28 Rue de Champonot 25640,,,,28,Rue de Champonot,Roulans,
+28 Rue de Champonot,6.234419,47.318534,,28,Rue de Champonot,,25640
+11 Rue Les Perrières Sancey-le-Grand,,,,11,Rue Les Perrières,,25430
+11 Rue Les Perrières 25430,,,,11,Rue Les Perrières,,25430
+11 Rue Les Perrières,6.586225,47.302039,,11,Rue Les Perrières,,25430
+7 Rue de Bournois Soye,,,,7,Rue de Bournois,,25250
+7 Rue de Bournois 25250,,,,7,Rue de Bournois,Soye,
+7 Rue de Bournois,6.498261,47.446654,,7,Rue de Bournois,,25250
+4BIS Rue des Buis Valentigney,,,,4BIS,Rue des Buis,,25700
+4BIS Rue des Buis 25700,,,,4BIS,Rue des Buis,Valentigney,
+4BIS Rue des Buis,6.827798,47.466687,,4BIS,Rue des Buis,,25700
+2 Rue du Chateau d'Eau Viéthorey,,,,2,Rue du Chateau d'Eau,,25340
+2 Rue du Chateau d'Eau 25340,,,,2,Rue du Chateau d'Eau,Viéthorey,
+2 Rue du Chateau d'Eau,6.430471,47.424688,,2,Rue du Chateau d'Eau,,25340
+3 Rue du Bois Aumur,,,,3,Rue du Bois,,39410
+3 Rue du Bois 39410,,,,3,Rue du Bois,Aumur,
+3 Rue du Bois,5.352416,47.055722,,3,Rue du Bois,,39410
+12 LA COTE DES BELETTES Bracon,,,,12,BELETTES,,39110
+12 LA COTE DES BELETTES 39110,,,,12,BELETTES,Bracon,
+12 LA COTE DES BELETTES,5.88658,46.91455,,12,BELETTES,,39110
+9A Impasse du Tunnel Champvans,,,,9A,Impasse du Tunnel,,39100
+9A Impasse du Tunnel 39100,,,,9A,Impasse du Tunnel,Champvans,
+9A Impasse du Tunnel,5.450449,47.106639,,9A,Impasse du Tunnel,,39100
+2 Rue des Saules Cize,,,,2,Rue des Saules,,39300
+2 Rue des Saules 39300,,,,2,Rue des Saules,Cize,
+2 Rue des Saules,5.9089,46.731107,,2,Rue des Saules,,39300
+43 Rue d'Alsace Damparis,,,,43,Rue d'Alsace,,39500
+43 Rue d'Alsace 39500,,,,43,Rue d'Alsace,Damparis,
+43 Rue d'Alsace,5.411958,47.068153,,43,Rue d'Alsace,,39500
+4 Rue des Gardes Dole,,,,4,Rue des Gardes,,39100
+4 Rue des Gardes 39100,,,,4,Rue des Gardes,Dole,
+4 Rue des Gardes,5.481158,47.090678,,4,Rue des Gardes,,39100
+4 Impasse de la Combe Écrille,,,,4,Impasse de la Combe,,39270
+4 Impasse de la Combe 39270,,,,4,Impasse de la Combe,Écrille,
+4 Impasse de la Combe,5.629383,46.506205,,4,Impasse de la Combe,,39270
+2 Rue des Perrodins Gigny,,,,2,Rue des Perrodins,,39320
+2 Rue des Perrodins 39320,,,,2,Rue des Perrodins,Gigny,
+2 Rue des Perrodins,5.478474,46.450127,,2,Rue des Perrodins,,39320
+14 Avenue Camille Prost Lons-le-Saunier,,,,14,Avenue Camille Prost,,39000
+14 Avenue Camille Prost 39000,,,,14,Avenue Camille Prost,Lons-le-Saunier,
+14 Avenue Camille Prost,5.567459,46.671617,,14,Avenue Camille Prost,,39000
+9 Impasse de l'Alambic Maynal,,,,9,Impasse de l'Alambic,,39190
+9 Impasse de l'Alambic 39190,,,,9,Impasse de l'Alambic,Maynal,
+9 Impasse de l'Alambic,5.419226,46.556207,,9,Impasse de l'Alambic,,39190
+13 Rue Henri Ponard Montmorot,,,,13,Rue Henri Ponard,,39570
+13 Rue Henri Ponard 39570,,,,13,Rue Henri Ponard,Montmorot,
+13 Rue Henri Ponard,5.524156,46.678019,,13,Rue Henri Ponard,,39570
+544 Route de Champagnole Ney,,,,544,Route de Champagnole,,39300
+544 Route de Champagnole 39300,,,,544,Route de Champagnole,Ney,
+544 Route de Champagnole,5.894406,46.737226,,544,Route de Champagnole,,39300
+120 Chemin du Milieu Le Pin,,,,120,Chemin du Milieu,,39210
+120 Chemin du Milieu 39210,,,,120,Chemin du Milieu,Le Pin,
+120 Chemin du Milieu,5.568293,46.706344,,120,Chemin du Milieu,,39210
+10 Rue de Gray Ranchot,,,,10,Rue de Gray,,39700
+10 Rue de Gray 39700,,,,10,Rue de Gray,Ranchot,
+10 Rue de Gray,5.721617,47.152031,,10,Rue de Gray,,39700
+18 Rue du Collège Saint-Claude,,,,18,Rue du Collège,,39200
+18 Rue du Collège 39200,,,,18,Rue du Collège,Saint-Claude,
+18 Rue du Collège,5.86522,46.389434,,18,Rue du Collège,,39200
+60 Rue de la République Salins-les-Bains,,,,60,Rue de la République,,39110
+60 Rue de la République 39110,,,,60,Rue de la République,Salins-les-Bains,
+60 Rue de la République,5.877548,46.934385,,60,Rue de la République,,39110
+2 Lotissement de la Source Thoirette,,,,2,Lotissement de la Source,,39240
+2 Lotissement de la Source 39240,,,,2,Lotissement de la Source,Thoirette,
+2 Lotissement de la Source,5.518774,46.265174,,2,Lotissement de la Source,,39240
+14 Route de Nevy Voiteur,,,,14,Route de Nevy,,39210
+14 Route de Nevy 39210,,,,14,Route de Nevy,Voiteur,
+14 Route de Nevy,5.612596,46.753849,,14,Route de Nevy,,39210
+12 Route de Bussières Boulot,,,,12,Route de Bussières,,70190
+12 Route de Bussières 70190,,,,12,Route de Bussières,Boulot,
+12 Route de Bussières,5.962335,47.341876,,12,Route de Bussières,,70190
+9 Rue de la Crottière Choye,,,,9,Rue de la Crottière,,70700
+9 Rue de la Crottière 70700,,,,9,Rue de la Crottière,Choye,
+9 Rue de la Crottière,5.764126,47.388209,,9,Rue de la Crottière,,70700
+5 Place de la Gare Faucogney-et-la-Mer,,,,5,Place de la Gare,,70310
+5 Place de la Gare 70310,,,,5,Place de la Gare,Faucogney-et-la-Mer,
+5 Place de la Gare,6.562944,47.846449,,5,Place de la Gare,,70310
+9 Rue de la Croisette Frotey-lès-Lure,,,,9,Rue de la Croisette,,70200
+9 Rue de la Croisette 70200,,,,9,Rue de la Croisette,Frotey-lès-Lure,
+9 Rue de la Croisette,6.557208,47.652409,,9,Rue de la Croisette,,70200
+3 Chemin des Combes Héricourt,,,,3,Chemin des Combes,,70400
+3 Chemin des Combes 70400,,,,3,Chemin des Combes,Héricourt,
+3 Chemin des Combes,6.779222,47.545099,,3,Chemin des Combes,,70400
+10 Rue Lasalle Lure,,,,10,Rue Lasalle,,70200
+10 Rue Lasalle 70200,,,,10,Rue Lasalle,Lure,
+10 Rue Lasalle,6.504907,47.675916,,10,Rue Lasalle,,70200
+13 Rue de la Fontaine Montboillon,,,,13,Rue de la Fontaine,,70700
+13 Rue de la Fontaine 70700,,,,13,Rue de la Fontaine,Montboillon,
+13 Rue de la Fontaine,5.922623,47.372848,,13,Rue de la Fontaine,,70700
+30 Rue du Rapois Plancher-Bas,,,,30,Rue du Rapois,,70290
+30 Rue du Rapois 70290,,,,30,Rue du Rapois,Plancher-Bas,
+30 Rue du Rapois,6.723711,47.737453,,30,Rue du Rapois,,70290
+2 Rue du Tacot Rioz,,,,2,Rue du Tacot,,70190
+2 Rue du Tacot 70190,,,,2,Rue du Tacot,Rioz,
+2 Rue du Tacot,6.067185,47.425715,,2,Rue du Tacot,,70190
+2 Rue de la Fontaine Saulnot,,,,2,Rue de la Fontaine,,70400
+2 Rue de la Fontaine 70400,,,,2,Rue de la Fontaine,Saulnot,
+2 Rue de la Fontaine,6.629135,47.562783,,2,Rue de la Fontaine,,70400
+13BIS Rue des Planchottes Velet,,,,13BIS,Rue des Planchottes,,70100
+13BIS Rue des Planchottes 70100,,,,13BIS,Rue des Planchottes,Velet,
+13BIS Rue des Planchottes,5.562849,47.427122,,13BIS,Rue des Planchottes,,70100
+7 Rue du Pre Aux Vernes Villersexel,,,,7,Rue du Pre Aux Vernes,,70110
+7 Rue du Pre Aux Vernes 70110,,,,7,Rue du Pre Aux Vernes,Villersexel,
+7 Rue du Pre Aux Vernes,6.423483,47.546044,,7,Rue du Pre Aux Vernes,,70110
+6A Avenue du Champ de Mars Belfort,,,,6A,Avenue du Champ de Mars,,90000
+6A Avenue du Champ de Mars 90000,,,,6A,Avenue du Champ de Mars,Belfort,
+6A Avenue du Champ de Mars,6.857771,47.650695,,6A,Avenue du Champ de Mars,,90000
+11 Rue de Valenciennes Belfort,,,,11,Rue de Valenciennes,,90000
+11 Rue de Valenciennes 90000,,,,11,Rue de Valenciennes,Belfort,
+11 Rue de Valenciennes,6.851994,47.642109,,11,Rue de Valenciennes,,90000
+16 Rue de la Coursière Danjoutin,,,,16,Rue de la Coursière,,90400
+16 Rue de la Coursière 90400,,,,16,Rue de la Coursière,Danjoutin,
+16 Rue de la Coursière,6.857924,47.616649,,16,Rue de la Coursière,,90400
+24 Rue du Thiamont Évette-Salbert,,,,24,Rue du Thiamont,,90350
+24 Rue du Thiamont 90350,,,,24,Rue du Thiamont,Évette-Salbert,
+24 Rue du Thiamont,6.790198,47.66714,,24,Rue du Thiamont,,90350
+4 Rue Sur la Côte Lebetain,,,,4,Rue Sur la Côte,,90100
+4 Rue Sur la Côte 90100,,,,4,Rue Sur la Côte,Lebetain,
+4 Rue Sur la Côte,6.973595,47.487491,,4,Rue Sur la Côte,,90100
+3 Rue du Château Roppe,,,,3,Rue du Château,,90380
+3 Rue du Château 90380,,,,3,Rue du Château,Roppe,
+3 Rue du Château,6.920818,47.666964,,3,Rue du Château,,90380

--- a/geocoder_tester/world/france/hautenormandie/test_addresses.csv
+++ b/geocoder_tester/world/france/hautenormandie/test_addresses.csv
@@ -1,226 +1,226 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-13 Rue des Rouliers Les Authieux,,,,13 Rue des Rouliers,,,,27220
-13 Rue des Rouliers 27220,,,,13 Rue des Rouliers,,,Les Authieux,
-13 Rue des Rouliers,1.234970,48.900906,,13 Rue des Rouliers,,,,27220
-7 Rue du Noyer Bernay,,,,7 Rue du Noyer,,,,27300
-7 Rue du Noyer 27300,,,,7 Rue du Noyer,,,Bernay,
-7 Rue du Noyer,0.590570,49.094897,,7 Rue du Noyer,,,,27300
-604 Rue du Champ Aux Moines Le Bosc-Roger-en-Roumois,,,,604 Rue du Champ Aux Moines,,,,27670
-604 Rue du Champ Aux Moines 27670,,,,604 Rue du Champ Aux Moines,,,Le Bosc-Roger-en-Roumois,
-604 Rue du Champ Aux Moines,0.912920,49.293280,,604 Rue du Champ Aux Moines,,,,27670
-14 Rue des Jardins Bourneville,,,,14 Rue des Jardins,,,,27500
-14 Rue des Jardins 27500,,,,14 Rue des Jardins,,,Bourneville,
-14 Rue des Jardins,0.623808,49.391871,,14 Rue des Jardins,,,,27500
-25 Rue du Pressoir Bueil,,,,25 Rue du Pressoir,,,,27730
-25 Rue du Pressoir 27730,,,,25 Rue du Pressoir,,,Bueil,
-25 Rue du Pressoir,1.441543,48.936503,,25 Rue du Pressoir,,,,27730
-8 Rue Louis Aragon Conches-en-Ouche,,,,8 Rue Louis Aragon,,,,27190
-8 Rue Louis Aragon 27190,,,,8 Rue Louis Aragon,,,Conches-en-Ouche,
-8 Rue Louis Aragon,0.933788,48.954948,,8 Rue Louis Aragon,,,,27190
-312 Rue Saint-Jacques Écaquelon,,,,312 Rue Saint-Jacques,,,,27290
-312 Rue Saint-Jacques 27290,,,,312 Rue Saint-Jacques,,,Écaquelon,
-312 Rue Saint-Jacques,0.728013,49.290787,,312 Rue Saint-Jacques,,,,27290
-35 Boulevard Gambetta Évreux,,,,35 Boulevard Gambetta,,,,27000
-35 Boulevard Gambetta 27000,,,,35 Boulevard Gambetta,,,Évreux,
-35 Boulevard Gambetta,1.148740,49.019156,,35 Boulevard Gambetta,,,,27000
-2 Rue de la Verderie Évreux,,,,2 Rue de la Verderie,,,,27000
-2 Rue de la Verderie 27000,,,,2 Rue de la Verderie,,,Évreux,
-2 Rue de la Verderie,1.156091,49.036569,,2 Rue de la Verderie,,,,27000
-21A Rue Abbe Pouchard Gaillon,,,,21A Rue Abbe Pouchard,,,,27600
-21A Rue Abbe Pouchard 27600,,,,21A Rue Abbe Pouchard,,,Gaillon,
-21A Rue Abbe Pouchard,1.326741,49.160142,,21A Rue Abbe Pouchard,,,,27600
-53 Rue de la Libération Gisors,,,,53 Rue de la Libération,,,,27140
-53 Rue de la Libération 27140,,,,53 Rue de la Libération,,,Gisors,
-53 Rue de la Libération,1.780065,49.274664,,53 Rue de la Libération,,,,27140
-3 Chemin des Renardières Hardencourt-Cocherel,,,,3 Chemin des Renardières,,,,27120
-3 Chemin des Renardières 27120,,,,3 Chemin des Renardières,,,Hardencourt-Cocherel,
-3 Chemin des Renardières,1.315255,49.040892,,3 Chemin des Renardières,,,,27120
-9 Impasse des Pervenches Incarville,,,,9 Impasse des Pervenches,,,,27400
-9 Impasse des Pervenches 27400,,,,9 Impasse des Pervenches,,,Incarville,
-9 Impasse des Pervenches,1.174025,49.235357,,9 Impasse des Pervenches,,,,27400
-38 Rue Pierre Mendès France Louviers,,,,38 Rue Pierre Mendès France,,,,27400
-38 Rue Pierre Mendès France 27400,,,,38 Rue Pierre Mendès France,,,Louviers,
-38 Rue Pierre Mendès France,1.169084,49.214763,,38 Rue Pierre Mendès France,,,,27400
-545 Rue Pasteur Montaure,,,,545 Rue Pasteur,,,,27400
-545 Rue Pasteur 27400,,,,545 Rue Pasteur,,,Montaure,
-545 Rue Pasteur,1.082702,49.246724,,545 Rue Pasteur,,,,27400
-3 Rue des Préaux Pinterville,,,,3 Rue des Préaux,,,,27400
-3 Rue des Préaux 27400,,,,3 Rue des Préaux,,,Pinterville,
-3 Rue des Préaux,1.177433,49.191197,,3 Rue des Préaux,,,,27400
-8404 Rue de Masures Poses,,,,8404 Rue de Masures,,,,27740
-8404 Rue de Masures 27740,,,,8404 Rue de Masures,,,Poses,
-8404 Rue de Masures,1.225037,49.308282,,8404 Rue de Masures,,,,27740
-19 Rue de la Grange Vimont Saint-Aubin-sur-Gaillon,,,,19 Rue de la Grange Vimont,,,,27600
-19 Rue de la Grange Vimont 27600,,,,19 Rue de la Grange Vimont,,,Saint-Aubin-sur-Gaillon,
-19 Rue de la Grange Vimont,1.335503,49.141125,,19 Rue de la Grange Vimont,,,,27600
-326 Route de la Croix Blanche Saint-Maclou,,,,326 Route de la Croix Blanche,,,,27210
-326 Route de la Croix Blanche 27210,,,,326 Route de la Croix Blanche,,,Saint-Maclou,
-326 Route de la Croix Blanche,0.428597,49.357349,,326 Route de la Croix Blanche,,,,27210
-10 Rue des Longchamps Saint-Pierre-des-Fleurs,,,,10 Rue des Longchamps,,,,27370
-10 Rue des Longchamps 27370,,,,10 Rue des Longchamps,,,Saint-Pierre-des-Fleurs,
-10 Rue des Longchamps,0.965997,49.252260,,10 Rue des Longchamps,,,,27370
-6 Route de Pont de l'Arche Surtauville,,,,6 Route de Pont de l'Arche,,,,27400
-6 Route de Pont de l'Arche 27400,,,,6 Route de Pont de l'Arche,,,Surtauville,
-6 Route de Pont de l'Arche,1.050641,49.207324,,6 Route de Pont de l'Arche,,,,27400
-11 Rue de la Mairie La Vacherie,,,,11 Rue de la Mairie,,,,27400
-11 Rue de la Mairie 27400,,,,11 Rue de la Mairie,,,La Vacherie,
-11 Rue de la Mairie,1.148132,49.119791,,11 Rue de la Mairie,,,,27400
-2 Rue des Coteaux Vernon,,,,2 Rue des Coteaux,,,,27200
-2 Rue des Coteaux 27200,,,,2 Rue des Coteaux,,,Vernon,
-2 Rue des Coteaux,1.458266,49.083851,,2 Rue des Coteaux,,,,27200
-3 Impasse de la Mare des Champs Sylvains-les-Moulins,,,,3 Impasse de la Mare des Champs,,,,27240
-3 Impasse de la Mare des Champs 27240,,,,3 Impasse de la Mare des Champs,,,Sylvains-les-Moulins,
-3 Impasse de la Mare des Champs,1.098074,48.906151,,3 Impasse de la Mare des Champs,,,,27240
-5 Sentier des Noyers Autretot,,,,5 Sentier des Noyers,,,,76190
-5 Sentier des Noyers 76190,,,,5 Sentier des Noyers,,,Autretot,
-5 Sentier des Noyers,0.730148,49.651844,,5 Sentier des Noyers,,,,76190
-83 Route de Saint-Jean de la Neuville Beuzeville-la-Grenier,,,,83 Route de Saint-Jean de la Neuville,,,,76210
-83 Route de Saint-Jean de la Neuville 76210,,,,83 Route de Saint-Jean de la Neuville,,,Beuzeville-la-Grenier,
-83 Route de Saint-Jean de la Neuville,0.420601,49.594948,,83 Route de Saint-Jean de la Neuville,,,,76210
-1995 Chemin de la Bretèque Bois-Guillaume,,,,1995 Chemin de la Bretèque,,,,76420
-1995 Chemin de la Bretèque 76420,,,,1995 Chemin de la Bretèque,,,Bois-Guillaume,
-1995 Chemin de la Bretèque,1.103663,49.488150,,1995 Chemin de la Bretèque,,,,76420
-12 Rue Henri Ferric Bolbec,,,,12 Rue Henri Ferric,,,,76210
-12 Rue Henri Ferric 76210,,,,12 Rue Henri Ferric,,,Bolbec,
-12 Rue Henri Ferric,0.475851,49.569928,,12 Rue Henri Ferric,,,,76210
-56 Rue Jeanne d'Arc Bracquemont,,,,56 Rue Jeanne d'Arc,,,,76370
-56 Rue Jeanne d'Arc 76370,,,,56 Rue Jeanne d'Arc,,,Bracquemont,
-56 Rue Jeanne d'Arc,1.152023,49.939255,,56 Rue Jeanne d'Arc,,,,76370
-22 Rue Blanqui Caudebec-lès-Elbeuf,,,,22 Rue Blanqui,,,,76320
-22 Rue Blanqui 76320,,,,22 Rue Blanqui,,,Caudebec-lès-Elbeuf,
-22 Rue Blanqui,1.015540,49.285464,,22 Rue Blanqui,,,,76320
-346 Rue des Pinsons Clères,,,,346 Rue des Pinsons,,,,76690
-346 Rue des Pinsons 76690,,,,346 Rue des Pinsons,,,Clères,
-346 Rue des Pinsons,1.111553,49.601816,,346 Rue des Pinsons,,,,76690
-334 Route de Dieppe Déville-lès-Rouen,,,,334 Route de Dieppe,,,,76250
-334 Route de Dieppe 76250,,,,334 Route de Dieppe,,,Déville-lès-Rouen,
-334 Route de Dieppe,1.050768,49.468706,,334 Route de Dieppe,,,,76250
-89 Rue Général Leclerc Dieppe,,,,89 Rue Général Leclerc,,,,76200
-89 Rue Général Leclerc 76200,,,,89 Rue Général Leclerc,,,Dieppe,
-89 Rue Général Leclerc,1.117153,49.937543,,89 Rue Général Leclerc,,,,76200
-743 Route de Rouen Duclair,,,,743 Route de Rouen,,,,76480
-743 Route de Rouen 76480,,,,743 Route de Rouen,,,Duclair,
-743 Route de Rouen,0.885740,49.484719,,743 Route de Rouen,,,,76480
-5 Rue de la Lézarde Épouville,,,,5 Rue de la Lézarde,,,,76133
-5 Rue de la Lézarde 76133,,,,5 Rue de la Lézarde,,,Épouville,
-5 Rue de la Lézarde,0.225959,49.561027,,5 Rue de la Lézarde,,,,76133
-16 Rue Cauchoise Fécamp,,,,16 Rue Cauchoise,,,,76400
-16 Rue Cauchoise 76400,,,,16 Rue Cauchoise,,,Fécamp,
-16 Rue Cauchoise,0.382559,49.751537,,16 Rue Cauchoise,,,,76400
-26 Square Saint-Ouen Fécamp,,,,26 Square Saint-Ouen,,,,76400
-26 Square Saint-Ouen 76400,,,,26 Square Saint-Ouen,,,Fécamp,
-26 Square Saint-Ouen,0.405837,49.750482,,26 Square Saint-Ouen,,,,76400
-21 Rue du Hameau Martin Goderville,,,,21 Rue du Hameau Martin,,,,76110
-21 Rue du Hameau Martin 76110,,,,21 Rue du Hameau Martin,,,Goderville,
-21 Rue du Hameau Martin,0.361758,49.645224,,21 Rue du Hameau Martin,,,,76110
-315 Rue de l'Église Gouy,,,,315 Rue de l'Église,,,,76520
-315 Rue de l'Église 76520,,,,315 Rue de l'Église,,,Gouy,
-315 Rue de l'Église,1.145677,49.352913,,315 Rue de l'Église,,,,76520
-15A Avenue du Général Leclerc Le Grand-Quevilly,,,,15A Avenue du Général Leclerc,,,,76120
-15A Avenue du Général Leclerc 76120,,,,15A Avenue du Général Leclerc,,,Le Grand-Quevilly,
-15A Avenue du Général Leclerc,1.050397,49.419664,,15A Avenue du Général Leclerc,,,,76120
-13 Quai de la Douane Harfleur,,,,13 Quai de la Douane,,,,76700
-13 Quai de la Douane 76700,,,,13 Quai de la Douane,,,Harfleur,
-13 Quai de la Douane,0.197408,49.505426,,13 Quai de la Douane,,,,76700
-53 Rue Auguste Rispal Le Havre,,,,53 Rue Auguste Rispal,,,,76620
-53 Rue Auguste Rispal 76620,,,,53 Rue Auguste Rispal,,,Le Havre,
-53 Rue Auguste Rispal,0.141466,49.493119,,53 Rue Auguste Rispal,,,,76620
-14 Rue de Cronstadt Le Havre,,,,14 Rue de Cronstadt,,,,76620
-14 Rue de Cronstadt 76620,,,,14 Rue de Cronstadt,,,Le Havre,
-14 Rue de Cronstadt,0.118016,49.502934,,14 Rue de Cronstadt,,,,76620
-73 Rue Frédéric Bellanger Le Havre,,,,73 Rue Frédéric Bellanger,,,,76620
-73 Rue Frédéric Bellanger 76620,,,,73 Rue Frédéric Bellanger,,,Le Havre,
-73 Rue Frédéric Bellanger,0.098739,49.495559,,73 Rue Frédéric Bellanger,,,,76620
-100 Rue Jean Maridor Le Havre,,,,100 Rue Jean Maridor,,,,76620
-100 Rue Jean Maridor 76620,,,,100 Rue Jean Maridor,,,Le Havre,
-100 Rue Jean Maridor,0.161824,49.501670,,100 Rue Jean Maridor,,,,76620
-57 Place Maurice Blard Le Havre,,,,57 Place Maurice Blard,,,,76620
-57 Place Maurice Blard 76620,,,,57 Place Maurice Blard,,,Le Havre,
-57 Place Maurice Blard,0.161205,49.522488,,57 Place Maurice Blard,,,,76620
-176 Cours de la République Le Havre,,,,176 Cours de la République,,,,76620
-176 Cours de la République 76620,,,,176 Cours de la République,,,Le Havre,
-176 Cours de la République,0.130347,49.499782,,176 Cours de la République,,,,76620
-22 Rue Zamenhof Le Havre,,,,22 Rue Zamenhof,,,,76620
-22 Rue Zamenhof 76620,,,,22 Rue Zamenhof,,,Le Havre,
-22 Rue Zamenhof,0.110717,49.506427,,22 Rue Zamenhof,,,,76620
-1 Rue Kinkerville Lillebonne,,,,1 Rue Kinkerville,,,,76170
-1 Rue Kinkerville 76170,,,,1 Rue Kinkerville,,,Lillebonne,
-1 Rue Kinkerville,0.538023,49.517609,,1 Rue Kinkerville,,,,76170
-531 Rue Émile Zola Malaunay,,,,531 Rue Émile Zola,,,,76770
-531 Rue Émile Zola 76770,,,,531 Rue Émile Zola,,,Malaunay,
-531 Rue Émile Zola,1.027502,49.532250,,531 Rue Émile Zola,,,,76770
-116 Rue des Tisserands Mélamare,,,,116 Rue des Tisserands,,,,76170
-116 Rue des Tisserands 76170,,,,116 Rue des Tisserands,,,Mélamare,
-116 Rue des Tisserands,0.453998,49.537440,,116 Rue des Tisserands,,,,76170
-17 Rue Félix Faure Montivilliers,,,,17 Rue Félix Faure,,,,76290
-17 Rue Félix Faure 76290,,,,17 Rue Félix Faure,,,Montivilliers,
-17 Rue Félix Faure,0.194612,49.545841,,17 Rue Félix Faure,,,,76290
-12 Rue Jacques Boutrolles d'Estaimbuc Mont-Saint-Aignan,,,,12 Rue Jacques Boutrolles d'Estaimbuc,,,,76130
-12 Rue Jacques Boutrolles d'Estaimbuc 76130,,,,12 Rue Jacques Boutrolles d'Estaimbuc,,,Mont-Saint-Aignan,
-12 Rue Jacques Boutrolles d'Estaimbuc,1.077756,49.460585,,12 Rue Jacques Boutrolles d'Estaimbuc,,,,76130
-548 Rue du Froc aux Moines La Neuville-Chant-d'Oisel,,,,548 Rue du Froc aux Moines,,,,76520
-548 Rue du Froc aux Moines 76520,,,,548 Rue du Froc aux Moines,,,La Neuville-Chant-d'Oisel,
-548 Rue du Froc aux Moines,1.246127,49.372657,,548 Rue du Froc aux Moines,,,,76520
-22 Rue Antoine Laurent de Lavoisier Franqueville-Saint-Pierre,,,,22 Rue Antoine Laurent de Lavoisier,,,,76520
-22 Rue Antoine Laurent de Lavoisier 76520,,,,22 Rue Antoine Laurent de Lavoisier,,,Franqueville-Saint-Pierre,
-22 Rue Antoine Laurent de Lavoisier,1.162197,49.401051,,22 Rue Antoine Laurent de Lavoisier,,,,76520
-11 Rue Armand Salacrou Octeville-sur-Mer,,,,11 Rue Armand Salacrou,,,,76930
-11 Rue Armand Salacrou 76930,,,,11 Rue Armand Salacrou,,,Octeville-sur-Mer,
-11 Rue Armand Salacrou,0.128136,49.557246,,11 Rue Armand Salacrou,,,,76930
-344 Chemin du Hamelet Oudalle,,,,344 Chemin du Hamelet,,,,76430
-344 Chemin du Hamelet 76430,,,,344 Chemin du Hamelet,,,Oudalle,
-344 Chemin du Hamelet,0.316363,49.508413,,344 Chemin du Hamelet,,,,76430
-218 Avenue des Alliés Le Petit-Quevilly,,,,218 Avenue des Alliés,,,,76140
-218 Avenue des Alliés 76140,,,,218 Avenue des Alliés,,,Le Petit-Quevilly,
-218 Avenue des Alliés,1.054599,49.423888,,218 Avenue des Alliés,,,,76140
-1 Rue du Val du Tot Petiville,,,,1 Rue du Val du Tot,,,,76330
-1 Rue du Val du Tot 76330,,,,1 Rue du Val du Tot,,,Petiville,
-1 Rue du Val du Tot,0.590030,49.459649,,1 Rue du Val du Tot,,,,76330
-187 Rue Annie de Pène Rouen,,,,187 Rue Annie de Pène,,,,76000
-187 Rue Annie de Pène 76000,,,,187 Rue Annie de Pène,,,Rouen,
-187 Rue Annie de Pène,1.117021,49.433809,,187 Rue Annie de Pène,,,,76000
-18 Rue du Docteur Paul Hélot Rouen,,,,18 Rue du Docteur Paul Hélot,,,,76000
-18 Rue du Docteur Paul Hélot 76000,,,,18 Rue du Docteur Paul Hélot,,,Rouen,
-18 Rue du Docteur Paul Hélot,1.130281,49.444134,,18 Rue du Docteur Paul Hélot,,,,76000
-11 Cité Léveillé Rouen,,,,11 Cité Léveillé,,,,76000
-11 Cité Léveillé 76000,,,,11 Cité Léveillé,,,Rouen,
-11 Cité Léveillé,1.120472,49.435710,,11 Cité Léveillé,,,,76000
-13 Rue Repainville Rouen,,,,13 Rue Repainville,,,,76000
-13 Rue Repainville 76000,,,,13 Rue Repainville,,,Rouen,
-13 Rue Repainville,1.134594,49.435497,,13 Rue Repainville,,,,76000
-1 Impasse Douche Sainte-Adresse,,,,1 Impasse Douche,,,,76310
-1 Impasse Douche 76310,,,,1 Impasse Douche,,,Sainte-Adresse,
-1 Impasse Douche,0.082490,49.508955,,1 Impasse Douche,,,,76310
-22 Rue Prevost Saint-Aubin-lès-Elbeuf,,,,22 Rue Prevost,,,,76410
-22 Rue Prevost 76410,,,,22 Rue Prevost,,,Saint-Aubin-lès-Elbeuf,
-22 Rue Prevost,1.016989,49.298788,,22 Rue Prevost,,,,76410
-43 Rue Hubert Latham Saint-Étienne-du-Rouvray,,,,43 Rue Hubert Latham,,,,76800
-43 Rue Hubert Latham 76800,,,,43 Rue Hubert Latham,,,Saint-Étienne-du-Rouvray,
-43 Rue Hubert Latham,1.079453,49.396008,,43 Rue Hubert Latham,,,,76800
-3056 Rue des Canadiens Saint-Jacques-sur-Darnétal,,,,3056 Rue des Canadiens,,,,76160
-3056 Rue des Canadiens 76160,,,,3056 Rue des Canadiens,,,Saint-Jacques-sur-Darnétal,
-3056 Rue des Canadiens,1.207715,49.460822,,3056 Rue des Canadiens,,,,76160
-2 Chemin du Sapin Saint-Martin-du-Manoir,,,,2 Chemin du Sapin,,,,76290
-2 Chemin du Sapin 76290,,,,2 Chemin du Sapin,,,Saint-Martin-du-Manoir,
-2 Chemin du Sapin,0.233531,49.530025,,2 Chemin du Sapin,,,,76290
-224 Chemin de Villers Saint-Pierre-de-Varengeville,,,,224 Chemin de Villers,,,,76480
-224 Chemin de Villers 76480,,,,224 Chemin de Villers,,,Saint-Pierre-de-Varengeville,
-224 Chemin de Villers,0.916695,49.506322,,224 Chemin de Villers,,,,76480
-8 Rue Marcel Dupré Saint-Valery-en-Caux,,,,8 Rue Marcel Dupré,,,,76460
-8 Rue Marcel Dupré 76460,,,,8 Rue Marcel Dupré,,,Saint-Valery-en-Caux,
-8 Rue Marcel Dupré,0.717066,49.859225,,8 Rue Marcel Dupré,,,,76460
-40 Rue des Épis Sotteville-lès-Rouen,,,,40 Rue des Épis,,,,76300
-40 Rue des Épis 76300,,,,40 Rue des Épis,,,Sotteville-lès-Rouen,
-40 Rue des Épis,1.085740,49.417869,,40 Rue des Épis,,,,76300
-6 Rue du Rond-Point du 14 Juillet Sotteville-lès-Rouen,,,,6 Rue du Rond-Point du 14 Juillet,,,,76300
-6 Rue du Rond-Point du 14 Juillet 76300,,,,6 Rue du Rond-Point du 14 Juillet,,,Sotteville-lès-Rouen,
-6 Rue du Rond-Point du 14 Juillet,1.091610,49.406994,,6 Rue du Rond-Point du 14 Juillet,,,,76300
-113 Rue Gay Lussac Le Trait,,,,113 Rue Gay Lussac,,,,76580
-113 Rue Gay Lussac 76580,,,,113 Rue Gay Lussac,,,Le Trait,
-113 Rue Gay Lussac,0.815537,49.476693,,113 Rue Gay Lussac,,,,76580
-126 Impasse de la Forêt Vatteville-la-Rue,,,,126 Impasse de la Forêt,,,,76940
-126 Impasse de la Forêt 76940,,,,126 Impasse de la Forêt,,,Vatteville-la-Rue,
-126 Impasse de la Forêt,0.652682,49.445441,,126 Impasse de la Forêt,,,,76940
-4B Rue de la Croix-rouge Yvetot,,,,4B Rue de la Croix-rouge,,,,76190
-4B Rue de la Croix-rouge 76190,,,,4B Rue de la Croix-rouge,,,Yvetot,
-4B Rue de la Croix-rouge,0.760384,49.620362,,4B Rue de la Croix-rouge,,,,76190
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+13 Rue des Rouliers Les Authieux,,,,13,Rue des Rouliers,,27220
+13 Rue des Rouliers 27220,,,,13,Rue des Rouliers,Les Authieux,
+13 Rue des Rouliers,1.23497,48.900906,,13,Rue des Rouliers,,27220
+7 Rue du Noyer Bernay,,,,7,Rue du Noyer,,27300
+7 Rue du Noyer 27300,,,,7,Rue du Noyer,Bernay,
+7 Rue du Noyer,0.59057,49.094897,,7,Rue du Noyer,,27300
+604 Rue du Champ Aux Moines Le Bosc-Roger-en-Roumois,,,,604,Rue du Champ Aux Moines,,27670
+604 Rue du Champ Aux Moines 27670,,,,604,Rue du Champ Aux Moines,Le Bosc-Roger-en-Roumois,
+604 Rue du Champ Aux Moines,0.91292,49.29328,,604,Rue du Champ Aux Moines,,27670
+14 Rue des Jardins Bourneville,,,,14,Rue des Jardins,,27500
+14 Rue des Jardins 27500,,,,14,Rue des Jardins,Bourneville,
+14 Rue des Jardins,0.623808,49.391871,,14,Rue des Jardins,,27500
+25 Rue du Pressoir Bueil,,,,25,Rue du Pressoir,,27730
+25 Rue du Pressoir 27730,,,,25,Rue du Pressoir,Bueil,
+25 Rue du Pressoir,1.441543,48.936503,,25,Rue du Pressoir,,27730
+8 Rue Louis Aragon Conches-en-Ouche,,,,8,Rue Louis Aragon,,27190
+8 Rue Louis Aragon 27190,,,,8,Rue Louis Aragon,Conches-en-Ouche,
+8 Rue Louis Aragon,0.933788,48.954948,,8,Rue Louis Aragon,,27190
+312 Rue Saint-Jacques Écaquelon,,,,312,Rue Saint-Jacques,,27290
+312 Rue Saint-Jacques 27290,,,,312,Rue Saint-Jacques,Écaquelon,
+312 Rue Saint-Jacques,0.728013,49.290787,,312,Rue Saint-Jacques,,27290
+35 Boulevard Gambetta Évreux,,,,35,Boulevard Gambetta,,27000
+35 Boulevard Gambetta 27000,,,,35,Boulevard Gambetta,Évreux,
+35 Boulevard Gambetta,1.14874,49.019156,,35,Boulevard Gambetta,,27000
+2 Rue de la Verderie Évreux,,,,2,Rue de la Verderie,,27000
+2 Rue de la Verderie 27000,,,,2,Rue de la Verderie,Évreux,
+2 Rue de la Verderie,1.156091,49.036569,,2,Rue de la Verderie,,27000
+21A Rue Abbe Pouchard Gaillon,,,,21A,Rue Abbe Pouchard,,27600
+21A Rue Abbe Pouchard 27600,,,,21A,Rue Abbe Pouchard,Gaillon,
+21A Rue Abbe Pouchard,1.326741,49.160142,,21A,Rue Abbe Pouchard,,27600
+53 Rue de la Libération Gisors,,,,53,Rue de la Libération,,27140
+53 Rue de la Libération 27140,,,,53,Rue de la Libération,Gisors,
+53 Rue de la Libération,1.780065,49.274664,,53,Rue de la Libération,,27140
+3 Chemin des Renardières Hardencourt-Cocherel,,,,3,Chemin des Renardières,,27120
+3 Chemin des Renardières 27120,,,,3,Chemin des Renardières,Hardencourt-Cocherel,
+3 Chemin des Renardières,1.315255,49.040892,,3,Chemin des Renardières,,27120
+9 Impasse des Pervenches Incarville,,,,9,Impasse des Pervenches,,27400
+9 Impasse des Pervenches 27400,,,,9,Impasse des Pervenches,Incarville,
+9 Impasse des Pervenches,1.174025,49.235357,,9,Impasse des Pervenches,,27400
+38 Rue Pierre Mendès France Louviers,,,,38,Rue Pierre Mendès France,,27400
+38 Rue Pierre Mendès France 27400,,,,38,Rue Pierre Mendès France,Louviers,
+38 Rue Pierre Mendès France,1.169084,49.214763,,38,Rue Pierre Mendès France,,27400
+545 Rue Pasteur Montaure,,,,545,Rue Pasteur,,27400
+545 Rue Pasteur 27400,,,,545,Rue Pasteur,Montaure,
+545 Rue Pasteur,1.082702,49.246724,,545,Rue Pasteur,,27400
+3 Rue des Préaux Pinterville,,,,3,Rue des Préaux,,27400
+3 Rue des Préaux 27400,,,,3,Rue des Préaux,Pinterville,
+3 Rue des Préaux,1.177433,49.191197,,3,Rue des Préaux,,27400
+8404 Rue de Masures Poses,,,,8404,Rue de Masures,,27740
+8404 Rue de Masures 27740,,,,8404,Rue de Masures,Poses,
+8404 Rue de Masures,1.225037,49.308282,,8404,Rue de Masures,,27740
+19 Rue de la Grange Vimont Saint-Aubin-sur-Gaillon,,,,19,Rue de la Grange Vimont,,27600
+19 Rue de la Grange Vimont 27600,,,,19,Rue de la Grange Vimont,Saint-Aubin-sur-Gaillon,
+19 Rue de la Grange Vimont,1.335503,49.141125,,19,Rue de la Grange Vimont,,27600
+326 Route de la Croix Blanche Saint-Maclou,,,,326,Route de la Croix Blanche,,27210
+326 Route de la Croix Blanche 27210,,,,326,Route de la Croix Blanche,Saint-Maclou,
+326 Route de la Croix Blanche,0.428597,49.357349,,326,Route de la Croix Blanche,,27210
+10 Rue des Longchamps Saint-Pierre-des-Fleurs,,,,10,Rue des Longchamps,,27370
+10 Rue des Longchamps 27370,,,,10,Rue des Longchamps,Saint-Pierre-des-Fleurs,
+10 Rue des Longchamps,0.965997,49.25226,,10,Rue des Longchamps,,27370
+6 Route de Pont de l'Arche Surtauville,,,,6,Route de Pont de l'Arche,,27400
+6 Route de Pont de l'Arche 27400,,,,6,Route de Pont de l'Arche,Surtauville,
+6 Route de Pont de l'Arche,1.050641,49.207324,,6,Route de Pont de l'Arche,,27400
+11 Rue de la Mairie La Vacherie,,,,11,Rue de la Mairie,,27400
+11 Rue de la Mairie 27400,,,,11,Rue de la Mairie,La Vacherie,
+11 Rue de la Mairie,1.148132,49.119791,,11,Rue de la Mairie,,27400
+2 Rue des Coteaux Vernon,,,,2,Rue des Coteaux,,27200
+2 Rue des Coteaux 27200,,,,2,Rue des Coteaux,Vernon,
+2 Rue des Coteaux,1.458266,49.083851,,2,Rue des Coteaux,,27200
+3 Impasse de la Mare des Champs Sylvains-les-Moulins,,,,3,Impasse de la Mare des Champs,,27240
+3 Impasse de la Mare des Champs 27240,,,,3,Impasse de la Mare des Champs,Sylvains-les-Moulins,
+3 Impasse de la Mare des Champs,1.098074,48.906151,,3,Impasse de la Mare des Champs,,27240
+5 Sentier des Noyers Autretot,,,,5,Sentier des Noyers,,76190
+5 Sentier des Noyers 76190,,,,5,Sentier des Noyers,Autretot,
+5 Sentier des Noyers,0.730148,49.651844,,5,Sentier des Noyers,,76190
+83 Route de Saint-Jean de la Neuville Beuzeville-la-Grenier,,,,83,Route de Saint-Jean de la Neuville,,76210
+83 Route de Saint-Jean de la Neuville 76210,,,,83,Route de Saint-Jean de la Neuville,Beuzeville-la-Grenier,
+83 Route de Saint-Jean de la Neuville,0.420601,49.594948,,83,Route de Saint-Jean de la Neuville,,76210
+1995 Chemin de la Bretèque Bois-Guillaume,,,,1995,Chemin de la Bretèque,,76420
+1995 Chemin de la Bretèque 76420,,,,1995,Chemin de la Bretèque,Bois-Guillaume,
+1995 Chemin de la Bretèque,1.103663,49.48815,,1995,Chemin de la Bretèque,,76420
+12 Rue Henri Ferric Bolbec,,,,12,Rue Henri Ferric,,76210
+12 Rue Henri Ferric 76210,,,,12,Rue Henri Ferric,Bolbec,
+12 Rue Henri Ferric,0.475851,49.569928,,12,Rue Henri Ferric,,76210
+56 Rue Jeanne d'Arc Bracquemont,,,,56,Rue Jeanne d'Arc,,76370
+56 Rue Jeanne d'Arc 76370,,,,56,Rue Jeanne d'Arc,Bracquemont,
+56 Rue Jeanne d'Arc,1.152023,49.939255,,56,Rue Jeanne d'Arc,,76370
+22 Rue Blanqui Caudebec-lès-Elbeuf,,,,22,Rue Blanqui,,76320
+22 Rue Blanqui 76320,,,,22,Rue Blanqui,Caudebec-lès-Elbeuf,
+22 Rue Blanqui,1.01554,49.285464,,22,Rue Blanqui,,76320
+346 Rue des Pinsons Clères,,,,346,Rue des Pinsons,,76690
+346 Rue des Pinsons 76690,,,,346,Rue des Pinsons,Clères,
+346 Rue des Pinsons,1.111553,49.601816,,346,Rue des Pinsons,,76690
+334 Route de Dieppe Déville-lès-Rouen,,,,334,Route de Dieppe,,76250
+334 Route de Dieppe 76250,,,,334,Route de Dieppe,Déville-lès-Rouen,
+334 Route de Dieppe,1.050768,49.468706,,334,Route de Dieppe,,76250
+89 Rue Général Leclerc Dieppe,,,,89,Rue Général Leclerc,,76200
+89 Rue Général Leclerc 76200,,,,89,Rue Général Leclerc,Dieppe,
+89 Rue Général Leclerc,1.117153,49.937543,,89,Rue Général Leclerc,,76200
+743 Route de Rouen Duclair,,,,743,Route de Rouen,,76480
+743 Route de Rouen 76480,,,,743,Route de Rouen,Duclair,
+743 Route de Rouen,0.88574,49.484719,,743,Route de Rouen,,76480
+5 Rue de la Lézarde Épouville,,,,5,Rue de la Lézarde,,76133
+5 Rue de la Lézarde 76133,,,,5,Rue de la Lézarde,Épouville,
+5 Rue de la Lézarde,0.225959,49.561027,,5,Rue de la Lézarde,,76133
+16 Rue Cauchoise Fécamp,,,,16,Rue Cauchoise,,76400
+16 Rue Cauchoise 76400,,,,16,Rue Cauchoise,Fécamp,
+16 Rue Cauchoise,0.382559,49.751537,,16,Rue Cauchoise,,76400
+26 Square Saint-Ouen Fécamp,,,,26,Square Saint-Ouen,,76400
+26 Square Saint-Ouen 76400,,,,26,Square Saint-Ouen,Fécamp,
+26 Square Saint-Ouen,0.405837,49.750482,,26,Square Saint-Ouen,,76400
+21 Rue du Hameau Martin Goderville,,,,21,Rue du Hameau Martin,,76110
+21 Rue du Hameau Martin 76110,,,,21,Rue du Hameau Martin,Goderville,
+21 Rue du Hameau Martin,0.361758,49.645224,,21,Rue du Hameau Martin,,76110
+315 Rue de l'Église Gouy,,,,315,Rue de l'Église,,76520
+315 Rue de l'Église 76520,,,,315,Rue de l'Église,Gouy,
+315 Rue de l'Église,1.145677,49.352913,,315,Rue de l'Église,,76520
+15A Avenue du Général Leclerc Le Grand-Quevilly,,,,15A,Avenue du Général Leclerc,,76120
+15A Avenue du Général Leclerc 76120,,,,15A,Avenue du Général Leclerc,Le Grand-Quevilly,
+15A Avenue du Général Leclerc,1.050397,49.419664,,15A,Avenue du Général Leclerc,,76120
+13 Quai de la Douane Harfleur,,,,13,Quai de la Douane,,76700
+13 Quai de la Douane 76700,,,,13,Quai de la Douane,Harfleur,
+13 Quai de la Douane,0.197408,49.505426,,13,Quai de la Douane,,76700
+53 Rue Auguste Rispal Le Havre,,,,53,Rue Auguste Rispal,,76620
+53 Rue Auguste Rispal 76620,,,,53,Rue Auguste Rispal,Le Havre,
+53 Rue Auguste Rispal,0.141466,49.493119,,53,Rue Auguste Rispal,,76620
+14 Rue de Cronstadt Le Havre,,,,14,Rue de Cronstadt,,76620
+14 Rue de Cronstadt 76620,,,,14,Rue de Cronstadt,Le Havre,
+14 Rue de Cronstadt,0.118016,49.502934,,14,Rue de Cronstadt,,76620
+73 Rue Frédéric Bellanger Le Havre,,,,73,Rue Frédéric Bellanger,,76620
+73 Rue Frédéric Bellanger 76620,,,,73,Rue Frédéric Bellanger,Le Havre,
+73 Rue Frédéric Bellanger,0.098739,49.495559,,73,Rue Frédéric Bellanger,,76620
+100 Rue Jean Maridor Le Havre,,,,100,Rue Jean Maridor,,76620
+100 Rue Jean Maridor 76620,,,,100,Rue Jean Maridor,Le Havre,
+100 Rue Jean Maridor,0.161824,49.50167,,100,Rue Jean Maridor,,76620
+57 Place Maurice Blard Le Havre,,,,57,Place Maurice Blard,,76620
+57 Place Maurice Blard 76620,,,,57,Place Maurice Blard,Le Havre,
+57 Place Maurice Blard,0.161205,49.522488,,57,Place Maurice Blard,,76620
+176 Cours de la République Le Havre,,,,176,Cours de la République,,76620
+176 Cours de la République 76620,,,,176,Cours de la République,Le Havre,
+176 Cours de la République,0.130347,49.499782,,176,Cours de la République,,76620
+22 Rue Zamenhof Le Havre,,,,22,Rue Zamenhof,,76620
+22 Rue Zamenhof 76620,,,,22,Rue Zamenhof,Le Havre,
+22 Rue Zamenhof,0.110717,49.506427,,22,Rue Zamenhof,,76620
+1 Rue Kinkerville Lillebonne,,,,1,Rue Kinkerville,,76170
+1 Rue Kinkerville 76170,,,,1,Rue Kinkerville,Lillebonne,
+1 Rue Kinkerville,0.538023,49.517609,,1,Rue Kinkerville,,76170
+531 Rue Émile Zola Malaunay,,,,531,Rue Émile Zola,,76770
+531 Rue Émile Zola 76770,,,,531,Rue Émile Zola,Malaunay,
+531 Rue Émile Zola,1.027502,49.53225,,531,Rue Émile Zola,,76770
+116 Rue des Tisserands Mélamare,,,,116,Rue des Tisserands,,76170
+116 Rue des Tisserands 76170,,,,116,Rue des Tisserands,Mélamare,
+116 Rue des Tisserands,0.453998,49.53744,,116,Rue des Tisserands,,76170
+17 Rue Félix Faure Montivilliers,,,,17,Rue Félix Faure,,76290
+17 Rue Félix Faure 76290,,,,17,Rue Félix Faure,Montivilliers,
+17 Rue Félix Faure,0.194612,49.545841,,17,Rue Félix Faure,,76290
+12 Rue Jacques Boutrolles d'Estaimbuc Mont-Saint-Aignan,,,,12,Rue Jacques Boutrolles d'Estaimbuc,,76130
+12 Rue Jacques Boutrolles d'Estaimbuc 76130,,,,12,Rue Jacques Boutrolles d'Estaimbuc,Mont-Saint-Aignan,
+12 Rue Jacques Boutrolles d'Estaimbuc,1.077756,49.460585,,12,Rue Jacques Boutrolles d'Estaimbuc,,76130
+548 Rue du Froc aux Moines La Neuville-Chant-d'Oisel,,,,548,Rue du Froc aux Moines,,76520
+548 Rue du Froc aux Moines 76520,,,,548,Rue du Froc aux Moines,La Neuville-Chant-d'Oisel,
+548 Rue du Froc aux Moines,1.246127,49.372657,,548,Rue du Froc aux Moines,,76520
+22 Rue Antoine Laurent de Lavoisier Franqueville-Saint-Pierre,,,,22,Rue Antoine Laurent de Lavoisier,,76520
+22 Rue Antoine Laurent de Lavoisier 76520,,,,22,Rue Antoine Laurent de Lavoisier,Franqueville-Saint-Pierre,
+22 Rue Antoine Laurent de Lavoisier,1.162197,49.401051,,22,Rue Antoine Laurent de Lavoisier,,76520
+11 Rue Armand Salacrou Octeville-sur-Mer,,,,11,Rue Armand Salacrou,,76930
+11 Rue Armand Salacrou 76930,,,,11,Rue Armand Salacrou,Octeville-sur-Mer,
+11 Rue Armand Salacrou,0.128136,49.557246,,11,Rue Armand Salacrou,,76930
+344 Chemin du Hamelet Oudalle,,,,344,Chemin du Hamelet,,76430
+344 Chemin du Hamelet 76430,,,,344,Chemin du Hamelet,Oudalle,
+344 Chemin du Hamelet,0.316363,49.508413,,344,Chemin du Hamelet,,76430
+218 Avenue des Alliés Le Petit-Quevilly,,,,218,Avenue des Alliés,,76140
+218 Avenue des Alliés 76140,,,,218,Avenue des Alliés,Le Petit-Quevilly,
+218 Avenue des Alliés,1.054599,49.423888,,218,Avenue des Alliés,,76140
+1 Rue du Val du Tot Petiville,,,,1,Rue du Val du Tot,,76330
+1 Rue du Val du Tot 76330,,,,1,Rue du Val du Tot,Petiville,
+1 Rue du Val du Tot,0.59003,49.459649,,1,Rue du Val du Tot,,76330
+187 Rue Annie de Pène Rouen,,,,187,Rue Annie de Pène,,76000
+187 Rue Annie de Pène 76000,,,,187,Rue Annie de Pène,Rouen,
+187 Rue Annie de Pène,1.117021,49.433809,,187,Rue Annie de Pène,,76000
+18 Rue du Docteur Paul Hélot Rouen,,,,18,Rue du Docteur Paul Hélot,,76000
+18 Rue du Docteur Paul Hélot 76000,,,,18,Rue du Docteur Paul Hélot,Rouen,
+18 Rue du Docteur Paul Hélot,1.130281,49.444134,,18,Rue du Docteur Paul Hélot,,76000
+11 Cité Léveillé Rouen,,,,11,Cité Léveillé,,76000
+11 Cité Léveillé 76000,,,,11,Cité Léveillé,Rouen,
+11 Cité Léveillé,1.120472,49.43571,,11,Cité Léveillé,,76000
+13 Rue Repainville Rouen,,,,13,Rue Repainville,,76000
+13 Rue Repainville 76000,,,,13,Rue Repainville,Rouen,
+13 Rue Repainville,1.134594,49.435497,,13,Rue Repainville,,76000
+1 Impasse Douche Sainte-Adresse,,,,1,Impasse Douche,,76310
+1 Impasse Douche 76310,,,,1,Impasse Douche,Sainte-Adresse,
+1 Impasse Douche,0.08249,49.508955,,1,Impasse Douche,,76310
+22 Rue Prevost Saint-Aubin-lès-Elbeuf,,,,22,Rue Prevost,,76410
+22 Rue Prevost 76410,,,,22,Rue Prevost,Saint-Aubin-lès-Elbeuf,
+22 Rue Prevost,1.016989,49.298788,,22,Rue Prevost,,76410
+43 Rue Hubert Latham Saint-Étienne-du-Rouvray,,,,43,Rue Hubert Latham,,76800
+43 Rue Hubert Latham 76800,,,,43,Rue Hubert Latham,Saint-Étienne-du-Rouvray,
+43 Rue Hubert Latham,1.079453,49.396008,,43,Rue Hubert Latham,,76800
+3056 Rue des Canadiens Saint-Jacques-sur-Darnétal,,,,3056,Rue des Canadiens,,76160
+3056 Rue des Canadiens 76160,,,,3056,Rue des Canadiens,Saint-Jacques-sur-Darnétal,
+3056 Rue des Canadiens,1.207715,49.460822,,3056,Rue des Canadiens,,76160
+2 Chemin du Sapin Saint-Martin-du-Manoir,,,,2,Chemin du Sapin,,76290
+2 Chemin du Sapin 76290,,,,2,Chemin du Sapin,Saint-Martin-du-Manoir,
+2 Chemin du Sapin,0.233531,49.530025,,2,Chemin du Sapin,,76290
+224 Chemin de Villers Saint-Pierre-de-Varengeville,,,,224,Chemin de Villers,,76480
+224 Chemin de Villers 76480,,,,224,Chemin de Villers,Saint-Pierre-de-Varengeville,
+224 Chemin de Villers,0.916695,49.506322,,224,Chemin de Villers,,76480
+8 Rue Marcel Dupré Saint-Valery-en-Caux,,,,8,Rue Marcel Dupré,,76460
+8 Rue Marcel Dupré 76460,,,,8,Rue Marcel Dupré,Saint-Valery-en-Caux,
+8 Rue Marcel Dupré,0.717066,49.859225,,8,Rue Marcel Dupré,,76460
+40 Rue des Épis Sotteville-lès-Rouen,,,,40,Rue des Épis,,76300
+40 Rue des Épis 76300,,,,40,Rue des Épis,Sotteville-lès-Rouen,
+40 Rue des Épis,1.08574,49.417869,,40,Rue des Épis,,76300
+6 Rue du Rond-Point du 14 Juillet Sotteville-lès-Rouen,,,,6,Rue du Rond-Point du 14 Juillet,,76300
+6 Rue du Rond-Point du 14 Juillet 76300,,,,6,Rue du Rond-Point du 14 Juillet,Sotteville-lès-Rouen,
+6 Rue du Rond-Point du 14 Juillet,1.09161,49.406994,,6,Rue du Rond-Point du 14 Juillet,,76300
+113 Rue Gay Lussac Le Trait,,,,113,Rue Gay Lussac,,76580
+113 Rue Gay Lussac 76580,,,,113,Rue Gay Lussac,Le Trait,
+113 Rue Gay Lussac,0.815537,49.476693,,113,Rue Gay Lussac,,76580
+126 Impasse de la Forêt Vatteville-la-Rue,,,,126,Impasse de la Forêt,,76940
+126 Impasse de la Forêt 76940,,,,126,Impasse de la Forêt,Vatteville-la-Rue,
+126 Impasse de la Forêt,0.652682,49.445441,,126,Impasse de la Forêt,,76940
+4B Rue de la Croix-rouge Yvetot,,,,4B,Rue de la Croix-rouge,,76190
+4B Rue de la Croix-rouge 76190,,,,4B,Rue de la Croix-rouge,Yvetot,
+4B Rue de la Croix-rouge,0.760384,49.620362,,4B,Rue de la Croix-rouge,,76190

--- a/geocoder_tester/world/france/iledefrance/test_addresses.csv
+++ b/geocoder_tester/world/france/iledefrance/test_addresses.csv
@@ -1,937 +1,937 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-34 Avenue de l'Opéra Paris,,,,34 Avenue de l'Opéra,,,,75002
-34 Avenue de l'Opéra 75002,,,,34 Avenue de l'Opéra,,,Paris,
-34 Avenue de l'Opéra,2.333370,48.868659,,34 Avenue de l'Opéra,,,,75002
-19B Rue des Deux Ponts Paris,,,,19B Rue des Deux Ponts,,,,75004
-19B Rue des Deux Ponts 75004,,,,19B Rue des Deux Ponts,,,Paris,
-19B Rue des Deux Ponts,2.356355,48.851728,,19B Rue des Deux Ponts,,,,75004
-25 Quai de Montebello Paris,,,,25 Quai de Montebello,,,,75005
-25 Quai de Montebello 75005,,,,25 Quai de Montebello,,,Paris,
-25 Quai de Montebello,2.347712,48.852487,,25 Quai de Montebello,,,,75005
-7T Rue Servandoni Paris,,,,7T Rue Servandoni,,,,75006
-7T Rue Servandoni 75006,,,,7T Rue Servandoni,,,Paris,
-7T Rue Servandoni,2.334795,48.850291,,7T Rue Servandoni,,,,75006
-29 Rue de Bassano Paris,,,,29 Rue de Bassano,,,,75008
-29 Rue de Bassano 75008,,,,29 Rue de Bassano,,,Paris,
-29 Rue de Bassano,2.298874,48.870420,,29 Rue de Bassano,,,,75008
-104 Rue Blanche Paris,,,,104 Rue Blanche,,,,75009
-104 Rue Blanche 75009,,,,104 Rue Blanche,,,Paris,
-104 Rue Blanche,2.332395,48.883345,,104 Rue Blanche,,,,75009
-15 Rue du Buisson Saint-Louis Paris,,,,15 Rue du Buisson Saint-Louis,,,,75010
-15 Rue du Buisson Saint-Louis 75010,,,,15 Rue du Buisson Saint-Louis,,,Paris,
-15 Rue du Buisson Saint-Louis,2.373500,48.872447,,15 Rue du Buisson Saint-Louis,,,,75010
-39 Rue des Boulets Paris,,,,39 Rue des Boulets,,,,75011
-39 Rue des Boulets 75011,,,,39 Rue des Boulets,,,Paris,
-39 Rue des Boulets,2.389308,48.851710,,39 Rue des Boulets,,,,75011
-41 Avenue de la République Paris,,,,41 Avenue de la République,,,,75011
-41 Avenue de la République 75011,,,,41 Avenue de la République,,,Paris,
-41 Avenue de la République,2.374896,48.865338,,41 Avenue de la République,,,,75011
-91 Avenue Daumesnil Paris,,,,91 Avenue Daumesnil,,,,75012
-91 Avenue Daumesnil 75012,,,,91 Avenue Daumesnil,,,Paris,
-91 Avenue Daumesnil,2.379139,48.845647,,91 Avenue Daumesnil,,,,75012
-54 Avenue des Terroirs de France Paris,,,,54 Avenue des Terroirs de France,,,,75012
-54 Avenue des Terroirs de France 75012,,,,54 Avenue des Terroirs de France,,,Paris,
-54 Avenue des Terroirs de France,2.389139,48.832148,,54 Avenue des Terroirs de France,,,,75012
-11 Rue de l'Espérance Paris,,,,11 Rue de l'Espérance,,,,75013
-11 Rue de l'Espérance 75013,,,,11 Rue de l'Espérance,,,Paris,
-11 Rue de l'Espérance,2.348655,48.827233,,11 Rue de l'Espérance,,,,75013
-31 Rue Primo Levi Paris,,,,31 Rue Primo Levi,,,,75013
-31 Rue Primo Levi 75013,,,,31 Rue Primo Levi,,,Paris,
-31 Rue Primo Levi,2.377597,48.830024,,31 Rue Primo Levi,,,,75013
-9 Rue du Couédic Paris,,,,9 Rue du Couédic,,,,75014
-9 Rue du Couédic 75014,,,,9 Rue du Couédic,,,Paris,
-9 Rue du Couédic,2.333423,48.830178,,9 Rue du Couédic,,,,75014
-64 Rue de la Santé Paris,,,,64 Rue de la Santé,,,,75014
-64 Rue de la Santé 75014,,,,64 Rue de la Santé,,,Paris,
-64 Rue de la Santé,2.341136,48.830622,,64 Rue de la Santé,,,,75014
-35 Rue Duranton Paris,,,,35 Rue Duranton,,,,75015
-35 Rue Duranton 75015,,,,35 Rue Duranton,,,Paris,
-35 Rue Duranton,2.288023,48.839117,,35 Rue Duranton,,,,75015
-1 Rue Mathurin Régnier Paris,,,,1 Rue Mathurin Régnier,,,,75015
-1 Rue Mathurin Régnier 75015,,,,1 Rue Mathurin Régnier,,,Paris,
-1 Rue Mathurin Régnier,2.306889,48.840943,,1 Rue Mathurin Régnier,,,,75015
-49 Rue Boileau Paris,,,,49 Rue Boileau,,,,75016
-49 Rue Boileau 75016,,,,49 Rue Boileau,,,Paris,
-49 Rue Boileau,2.263469,48.843767,,49 Rue Boileau,,,,75016
-3 Place Léon Deubel Paris,,,,3 Place Léon Deubel,,,,75016
-3 Place Léon Deubel 75016,,,,3 Place Léon Deubel,,,Paris,
-3 Place Léon Deubel,2.259248,48.837899,,3 Place Léon Deubel,,,,75016
-31 Avenue de Versailles Paris,,,,31 Avenue de Versailles,,,,75016
-31 Avenue de Versailles 75016,,,,31 Avenue de Versailles,,,Paris,
-31 Avenue de Versailles,2.276102,48.849519,,31 Avenue de Versailles,,,,75016
-7 Rue Gustave Doré Paris,,,,7 Rue Gustave Doré,,,,75017
-7 Rue Gustave Doré 75017,,,,7 Rue Gustave Doré,,,Paris,
-7 Rue Gustave Doré,2.302565,48.886480,,7 Rue Gustave Doré,,,,75017
-12 Rue Vernier Paris,,,,12 Rue Vernier,,,,75017
-12 Rue Vernier 75017,,,,12 Rue Vernier,,,Paris,
-12 Rue Vernier,2.290906,48.883356,,12 Rue Vernier,,,,75017
-57 Rue de la Goutte d'Or Paris,,,,57 Rue de la Goutte d'Or,,,,75018
-57 Rue de la Goutte d'Or 75018,,,,57 Rue de la Goutte d'Or,,,Paris,
-57 Rue de la Goutte d'Or,2.350989,48.885028,,57 Rue de la Goutte d'Or,,,,75018
-80 Avenue de Saint-Ouen Paris,,,,80 Avenue de Saint-Ouen,,,,75018
-80 Avenue de Saint-Ouen 75018,,,,80 Avenue de Saint-Ouen,,,Paris,
-80 Avenue de Saint-Ouen,2.327333,48.892222,,80 Avenue de Saint-Ouen,,,,75018
-10 Rue du Général Brunet Paris,,,,10 Rue du Général Brunet,,,,75019
-10 Rue du Général Brunet 75019,,,,10 Rue du Général Brunet,,,Paris,
-10 Rue du Général Brunet,2.390874,48.880406,,10 Rue du Général Brunet,,,,75019
-18 Rue Suzanne Masson Paris,,,,18 Rue Suzanne Masson,,,,75019
-18 Rue Suzanne Masson 75019,,,,18 Rue Suzanne Masson,,,Paris,
-18 Rue Suzanne Masson,2.371374,48.888577,,18 Rue Suzanne Masson,,,,75019
-100 Rue des Haies Paris,,,,100 Rue des Haies,,,,75020
-100 Rue des Haies 75020,,,,100 Rue des Haies,,,Paris,
-100 Rue des Haies,2.404295,48.855644,,100 Rue des Haies,,,,75020
-4 Rue du Repos Paris,,,,4 Rue du Repos,,,,75020
-4 Rue du Repos 75020,,,,4 Rue du Repos,,,Paris,
-4 Rue du Repos,2.391937,48.858150,,4 Rue du Repos,,,,75020
-28 Rue de la Belle Marie Barbizon,,,,28 Rue de la Belle Marie,,,,77630
-28 Rue de la Belle Marie 77630,,,,28 Rue de la Belle Marie,,,Barbizon,
-28 Rue de la Belle Marie,2.601323,48.439768,,28 Rue de la Belle Marie,,,,77630
-3 Rue du Centre Boissy-le-Châtel,,,,3 Rue du Centre,,,,77169
-3 Rue du Centre 77169,,,,3 Rue du Centre,,,Boissy-le-Châtel,
-3 Rue du Centre,3.136898,48.821008,,3 Rue du Centre,,,,77169
-11 Rue de la Grenouillère Brie-Comte-Robert,,,,11 Rue de la Grenouillère,,,,77170
-11 Rue de la Grenouillère 77170,,,,11 Rue de la Grenouillère,,,Brie-Comte-Robert,
-11 Rue de la Grenouillère,2.611226,48.690539,,11 Rue de la Grenouillère,,,,77170
-25 Promenade des Golfeurs Bussy-Saint-Georges,,,,25 Promenade des Golfeurs,,,,77600
-25 Promenade des Golfeurs 77600,,,,25 Promenade des Golfeurs,,,Bussy-Saint-Georges,
-25 Promenade des Golfeurs,2.709096,48.848578,,25 Promenade des Golfeurs,,,,77600
-58 Rue des Epis d'Or Cerneux,,,,58 Rue des Épis d'Or,,,,77320
-58 Rue des Epis d'Or 77320,,,,58 Rue des Épis d'Or,,,Cerneux,
-58 Rue des Epis d'Or,3.351117,48.698393,,58 Rue des Épis d'Or,,,,77320
-96 Rue des Moulins Chalautre-la-Petite,,,,96 Rue des Moulins,,,,77160
-96 Rue des Moulins 77160,,,,96 Rue des Moulins,,,Chalautre-la-Petite,
-96 Rue des Moulins,3.312520,48.529170,,96 Rue des Moulins,,,,77160
-16 Rue Jean Moulin Champs-sur-Marne,,,,16 Rue Jean Moulin,,,,77420
-16 Rue Jean Moulin 77420,,,,16 Rue Jean Moulin,,,Champs-sur-Marne,
-16 Rue Jean Moulin,2.607726,48.850439,,16 Rue Jean Moulin,,,,77420
-25 Rue Aristide Briand Chartrettes,,,,25 Rue Aristide Briand,,,,77590
-25 Rue Aristide Briand 77590,,,,25 Rue Aristide Briand,,,Chartrettes,
-25 Rue Aristide Briand,2.694857,48.490361,,25 Rue Aristide Briand,,,,77590
-29BIS Avenue des Abbesses Chelles,,,,29BIS Avenue des Abbesses,,,,77500
-29BIS Avenue des Abbesses 77500,,,,29BIS Avenue des Abbesses,,,Chelles,
-29BIS Avenue des Abbesses,2.578605,48.875230,,29BIS Avenue des Abbesses,,,,77500
-1 Allée des Geais Chelles,,,,1 Allée des Geais,,,,77500
-1 Allée des Geais 77500,,,,1 Allée des Geais,,,Chelles,
-1 Allée des Geais,2.601246,48.886763,,1 Allée des Geais,,,,77500
-1 Rue du Rêve Chelles,,,,1 Rue du Rêve,,,,77500
-1 Rue du Rêve 77500,,,,1 Rue du Rêve,,,Chelles,
-1 Rue du Rêve,2.604386,48.879869,,1 Rue du Rêve,,,,77500
-6 Rue Romy Schneider Chevry-Cossigny,,,,6 Rue Romy Schneider,,,,77173
-6 Rue Romy Schneider 77173,,,,6 Rue Romy Schneider,,,Chevry-Cossigny,
-6 Rue Romy Schneider,2.661320,48.726746,,6 Rue Romy Schneider,,,,77173
-14 Rue des Brisaciers Collégien,,,,14 Rue des Brisaciers,,,,77090
-14 Rue des Brisaciers 77090,,,,14 Rue des Brisaciers,,,Collégien,
-14 Rue des Brisaciers,2.676648,48.836407,,14 Rue des Brisaciers,,,,77090
-13 Allée des Rouges Gorges Combs-la-Ville,,,,13 Allée des Rouges Gorges,,,,77380
-13 Allée des Rouges Gorges 77380,,,,13 Allée des Rouges Gorges,,,Combs-la-Ville,
-13 Allée des Rouges Gorges,2.562337,48.660754,,13 Allée des Rouges Gorges,,,,77380
-5 Place du Marché Coulommiers,,,,5 Place du Marché,,,,77120
-5 Place du Marché 77120,,,,5 Place du Marché,,,Coulommiers,
-5 Place du Marché,3.083966,48.814277,,5 Place du Marché,,,,77120
-5 Allée de la Résidence du Cavoy Courtry,,,,5 Allée de la Résidence du Cavoy,,,,77181
-5 Allée de la Résidence du Cavoy 77181,,,,5 Allée de la Résidence du Cavoy,,,Courtry,
-5 Allée de la Résidence du Cavoy,2.596807,48.912661,,5 Allée de la Résidence du Cavoy,,,,77181
-388D Avenue Émile Zola Dammarie-les-Lys,,,,388D Avenue Émile Zola,,,,77190
-388D Avenue Émile Zola 77190,,,,388D Avenue Émile Zola,,,Dammarie-les-Lys,
-388D Avenue Émile Zola,2.642424,48.517265,,388D Avenue Émile Zola,,,,77190
-12 Allée Saint-Rémy Dammartin-en-Goële,,,,12 Allée Saint-Rémy,,,,77230
-12 Allée Saint-Rémy 77230,,,,12 Allée Saint-Rémy,,,Dammartin-en-Goële,
-12 Allée Saint-Rémy,2.691440,49.053944,,12 Allée Saint-Rémy,,,,77230
-59 Avenue de l'Europe Émerainville,,,,59 Avenue de l'Europe,,,,77184
-59 Avenue de l'Europe 77184,,,,59 Avenue de l'Europe,,,Émerainville,
-59 Avenue de l'Europe,2.603183,48.829959,,59 Avenue de l'Europe,,,,77184
-36 Rue Robert Legraverend La Ferté-Gaucher,,,,36 Rue Robert Legraverend,,,,77320
-36 Rue Robert Legraverend 77320,,,,36 Rue Robert Legraverend,,,La Ferté-Gaucher,
-36 Rue Robert Legraverend,3.304499,48.786881,,36 Rue Robert Legraverend,,,,77320
-9 Rue de Fleury Fontainebleau,,,,9 Rue de Fleury,,,,77300
-9 Rue de Fleury 77300,,,,9 Rue de Fleury,,,Fontainebleau,
-9 Rue de Fleury,2.694572,48.404830,,9 Rue de Fleury,,,,77300
-418 Rue du Général de Gaulle Fouju,,,,418 Rue du Général de Gaulle,,,,77390
-418 Rue du Général de Gaulle 77390,,,,418 Rue du Général de Gaulle,,,Fouju,
-418 Rue du Général de Gaulle,2.776990,48.584491,,418 Rue du Général de Gaulle,,,,77390
-19 Avenue du Parc Gretz-Armainvilliers,,,,19 Avenue du Parc,,,,77220
-19 Avenue du Parc 77220,,,,19 Avenue du Parc,,,Gretz-Armainvilliers,
-19 Avenue du Parc,2.712342,48.738898,,19 Avenue du Parc,,,,77220
-1 Rue de la Fontaine du Sault Héricy,,,,1 Rue de la Fontaine du Sault,,,,77850
-1 Rue de la Fontaine du Sault 77850,,,,1 Rue de la Fontaine du Sault,,,Héricy,
-1 Rue de la Fontaine du Sault,2.766645,48.449632,,1 Rue de la Fontaine du Sault,,,,77850
-14 Ruelle du Moulin Brûlé Jouy-sur-Morin,,,,14 Ruelle du Moulin Brûlé,,,,77320
-14 Ruelle du Moulin Brûlé 77320,,,,14 Ruelle du Moulin Brûlé,,,Jouy-sur-Morin,
-14 Ruelle du Moulin Brûlé,3.283984,48.794960,,14 Ruelle du Moulin Brûlé,,,,77320
-27 Sentier Petite Sente Verte Lagny-sur-Marne,,,,27 Sentier Petite Sente Verte,,,,77400
-27 Sentier Petite Sente Verte 77400,,,,27 Sentier Petite Sente Verte,,,Lagny-sur-Marne,
-27 Sentier Petite Sente Verte,2.696427,48.869306,,27 Sentier Petite Sente Verte,,,,77400
-59 Rue du Colombier Lieusaint,,,,59 Rue du Colombier,,,,77127
-59 Rue du Colombier 77127,,,,59 Rue du Colombier,,,Lieusaint,
-59 Rue du Colombier,2.545728,48.631980,,59 Rue du Colombier,,,,77127
-2 Boulevard du Mandinet Lognes,,,,2 Boulevard du Mandinet,,,,77185
-2 Boulevard du Mandinet 77185,,,,2 Boulevard du Mandinet,,,Lognes,
-2 Boulevard du Mandinet,2.633376,48.834116,,2 Boulevard du Mandinet,,,,77185
-8 Rue du Pavé du Roy Maison-Rouge,,,,8 Rue du Pavé du Roy,,,,77370
-8 Rue du Pavé du Roy 77370,,,,8 Rue du Pavé du Roy,,,Maison-Rouge,
-8 Rue du Pavé du Roy,3.151995,48.559041,,8 Rue du Pavé du Roy,,,,77370
-41 Allée des Colibris Meaux,,,,41 Allée des Colibris,,,,77100
-41 Allée des Colibris 77100,,,,41 Allée des Colibris,,,Meaux,
-41 Allée des Colibris,2.897398,48.952428,,41 Allée des Colibris,,,,77100
-5 Impasse du Sabot Meaux,,,,5 Impasse du Sabot,,,,77100
-5 Impasse du Sabot 77100,,,,5 Impasse du Sabot,,,Meaux,
-5 Impasse du Sabot,2.877052,48.969322,,5 Impasse du Sabot,,,,77100
-15BIS Rue de l'Écluse Melun,,,,15BIS Rue de l'Écluse,,,,77000
-15BIS Rue de l'Écluse 77000,,,,15BIS Rue de l'Écluse,,,Melun,
-15BIS Rue de l'Écluse,2.649881,48.534508,,15BIS Rue de l'Écluse,,,,77000
-6 Rue Camille Desmoulins Mitry-Mory,,,,6 Rue Camille Desmoulins,,,,77290
-6 Rue Camille Desmoulins 77290,,,,6 Rue Camille Desmoulins,,,Mitry-Mory,
-6 Rue Camille Desmoulins,2.585772,48.963210,,6 Rue Camille Desmoulins,,,,77290
-23 Impasse du Cuché Moisenay,,,,23 Impasse du Cuché,,,,77950
-23 Impasse du Cuché 77950,,,,23 Impasse du Cuché,,,Moisenay,
-23 Impasse du Cuché,2.742529,48.562150,,23 Impasse du Cuché,,,,77950
-11TER Rue des Joncs Montereau-sur-le-Jard,,,,11TER Rue des Joncs,,,,77950
-11TER Rue des Joncs 77950,,,,11TER Rue des Joncs,,,Montereau-sur-le-Jard,
-11TER Rue des Joncs,2.687637,48.596864,,11TER Rue des Joncs,,,,77950
-6 Rue Turgot Montry,,,,6 Rue Turgot,,,,77450
-6 Rue Turgot 77450,,,,6 Rue Turgot,,,Montry,
-6 Rue Turgot,2.834731,48.886887,,6 Rue Turgot,,,,77450
-68 Rue du Pont de l'Amour Mouroux,,,,68 Rue du Pont de l'Amour,,,,77120
-68 Rue du Pont de l'Amour 77120,,,,68 Rue du Pont de l'Amour,,,Mouroux,
-68 Rue du Pont de l'Amour,3.051250,48.812266,,68 Rue du Pont de l'Amour,,,,77120
-1 Place de Violaine Nanteuil-sur-Marne,,,,1 Place de Violaine,,,,77730
-1 Place de Violaine 77730,,,,1 Place de Violaine,,,Nanteuil-sur-Marne,
-1 Place de Violaine,3.219987,48.978660,,1 Place de Violaine,,,,77730
-21 Rue Alphonse Allais Ozoir-la-Ferrière,,,,21 Rue Alphonse Allais,,,,77330
-21 Rue Alphonse Allais 77330,,,,21 Rue Alphonse Allais,,,Ozoir-la-Ferrière,
-21 Rue Alphonse Allais,2.678021,48.764851,,21 Rue Alphonse Allais,,,,77330
-38 Rue Salvadore Allende Ozoir-la-Ferrière,,,,38 Rue Salvador Allende,,,,77330
-38 Rue Salvadore Allende 77330,,,,38 Rue Salvador Allende,,,Ozoir-la-Ferrière,
-38 Rue Salvadore Allende,2.664067,48.761201,,38 Rue Salvador Allende,,,,77330
-70 Rue des Chênes Pomponne,,,,70 Rue des Chênes,,,,77400
-70 Rue des Chênes 77400,,,,70 Rue des Chênes,,,Pomponne,
-70 Rue des Chênes,2.692666,48.884409,,70 Rue des Chênes,,,,77400
-12 Rue Jean Charcot Pontault-Combault,,,,12 Rue Jean Charcot,,,,77340
-12 Rue Jean Charcot 77340,,,,12 Rue Jean Charcot,,,Pontault-Combault,
-12 Rue Jean Charcot,2.615703,48.788818,,12 Rue Jean Charcot,,,,77340
-121 Avenue de Fontainebleau Pringy,,,,121 Avenue de Fontainebleau,,,,77310
-121 Avenue de Fontainebleau 77310,,,,121 Avenue de Fontainebleau,,,Pringy,
-121 Avenue de Fontainebleau,2.563317,48.519226,,121 Avenue de Fontainebleau,,,,77310
-226 Avenue Foch Quincy-Voisins,,,,226 Avenue Foch,,,,77860
-226 Avenue Foch 77860,,,,226 Avenue Foch,,,Quincy-Voisins,
-226 Avenue Foch,2.879693,48.903778,,226 Avenue Foch,,,,77860
-1 Rue Dian Fossey Roissy-en-Brie,,,,1 Rue Dian Fossey,,,,77680
-1 Rue Dian Fossey 77680,,,,1 Rue Dian Fossey,,,Roissy-en-Brie,
-1 Rue Dian Fossey,2.636304,48.802602,,1 Rue Dian Fossey,,,,77680
-10 Chemin des Marêts Rupéreux,,,,10 Chemin des Marêts,,,,77560
-10 Chemin des Marêts 77560,,,,10 Chemin des Marêts,,,Rupéreux,
-10 Chemin des Marêts,3.328342,48.637860,,10 Chemin des Marêts,,,,77560
-27 Allée des Fougères Saint-Fargeau-Ponthierry,,,,27 Allée des Fougères,,,,77310
-27 Allée des Fougères 77310,,,,27 Allée des Fougères,,,Saint-Fargeau-Ponthierry,
-27 Allée des Fougères,2.527830,48.568169,,27 Allée des Fougères,,,,77310
-11 Chemin du Château Saint-Mard,,,,11 Chemin du Château,,,,77230
-11 Chemin du Château 77230,,,,11 Chemin du Château,,,Saint-Mard,
-11 Chemin du Château,2.686862,49.035977,,11 Chemin du Château,,,,77230
-20 Rue du Buat Saint-Soupplets,,,,20 Rue du Buat,,,,77165
-20 Rue du Buat 77165,,,,20 Rue du Buat,,,Saint-Soupplets,
-20 Rue du Buat,2.805044,49.036803,,20 Rue du Buat,,,,77165
-3 Rue du Nord Savigny-le-Temple,,,,3 Rue du Nord,,,,77176
-3 Rue du Nord 77176,,,,3 Rue du Nord,,,Savigny-le-Temple,
-3 Rue du Nord,2.578030,48.576265,,3 Rue du Nord,,,,77176
-9 Place des Tilleuls Savigny-le-Temple,,,,9 Place des Tilleuls,,,,77176
-9 Place des Tilleuls 77176,,,,9 Place des Tilleuls,,,Savigny-le-Temple,
-9 Place des Tilleuls,2.554402,48.603569,,9 Place des Tilleuls,,,,77176
-19 Rue des Étards Solers,,,,19 Rue des Étards,,,,77111
-19 Rue des Étards 77111,,,,19 Rue des Étards,,,Solers,
-19 Rue des Étards,2.723154,48.658812,,19 Rue des Étards,,,,77111
-3BIS Rue Jeanne d'Arc Thorigny-sur-Marne,,,,3BIS Rue Jeanne d'Arc,,,,77400
-3BIS Rue Jeanne d'Arc 77400,,,,3BIS Rue Jeanne d'Arc,,,Thorigny-sur-Marne,
-3BIS Rue Jeanne d'Arc,2.705756,48.885759,,3BIS Rue Jeanne d'Arc,,,,77400
-3 Rue du Martray Tournan-en-Brie,,,,3 Rue du Martray,,,,77220
-3 Rue du Martray 77220,,,,3 Rue du Martray,,,Tournan-en-Brie,
-3 Rue du Martray,2.768281,48.739259,,3 Rue du Martray,,,,77220
-11 Avenue Jean Jaurès Vaires-sur-Marne,,,,11 Avenue Jean Jaurès,,,,77360
-11 Avenue Jean Jaurès 77360,,,,11 Avenue Jean Jaurès,,,Vaires-sur-Marne,
-11 Avenue Jean Jaurès,2.638424,48.874141,,11 Avenue Jean Jaurès,,,,77360
-13 Rue du Grand Pressoir Vaux-le-Pénil,,,,13 Rue du Grand Pressoir,,,,77000
-13 Rue du Grand Pressoir 77000,,,,13 Rue du Grand Pressoir,,,Vaux-le-Pénil,
-13 Rue du Grand Pressoir,2.678439,48.527469,,13 Rue du Grand Pressoir,,,,77000
-1 Rue de la Madeleine Vert-Saint-Denis,,,,1 Rue de la Madeleine,,,,77240
-1 Rue de la Madeleine 77240,,,,1 Rue de la Madeleine,,,Vert-Saint-Denis,
-1 Rue de la Madeleine,2.653626,48.570361,,1 Rue de la Madeleine,,,,77240
-27 Rue René Lefebvre Villiers-sous-Grez,,,,27 Rue René Lefebvre,,,,77760
-27 Rue René Lefebvre 77760,,,,27 Rue René Lefebvre,,,Villiers-sous-Grez,
-27 Rue René Lefebvre,2.649723,48.320311,,27 Rue René Lefebvre,,,,77760
-1 Rue du Général Schweisguth Andrésy,,,,1 Rue du Général Schweisguth,,,,78570
-1 Rue du Général Schweisguth 78570,,,,1 Rue du Général Schweisguth,,,Andrésy,
-1 Rue du Général Schweisguth,2.070849,48.990886,,1 Rue du Général Schweisguth,,,,78570
-13 Rue de Maule Bazemont,,,,13 Rue de Maule,,,,78580
-13 Rue de Maule 78580,,,,13 Rue de Maule,,,Bazemont,
-13 Rue de Maule,1.867066,48.928404,,13 Rue de Maule,,,,78580
-1 Rue Raimu Bois-d'Arcy,,,,1 Rue Raimu,,,,78390
-1 Rue Raimu 78390,,,,1 Rue Raimu,,,Bois-d'Arcy,
-1 Rue Raimu,2.010724,48.805834,,1 Rue Raimu,,,,78390
-34 Rue Pasteur Buchelay,,,,34 Rue Pasteur,,,,78200
-34 Rue Pasteur 78200,,,,34 Rue Pasteur,,,Buchelay,
-34 Rue Pasteur,1.673060,48.982348,,34 Rue Pasteur,,,,78200
-21 Allée des Chardonnerets Cernay-la-Ville,,,,21 Allée des Chardonnerets,,,,78720
-21 Allée des Chardonnerets 78720,,,,21 Allée des Chardonnerets,,,Cernay-la-Ville,
-21 Allée des Chardonnerets,1.977011,48.671943,,21 Allée des Chardonnerets,,,,78720
-106 Avenue Gambetta Chatou,,,,106 Avenue Gambetta,,,,78400
-106 Avenue Gambetta 78400,,,,106 Avenue Gambetta,,,Chatou,
-106 Avenue Gambetta,2.170231,48.901294,,106 Avenue Gambetta,,,,78400
-28 Avenue de Montespan Le Chesnay,,,,28 Avenue de Montespan,,,,78150
-28 Avenue de Montespan 78150,,,,28 Avenue de Montespan,,,Le Chesnay,
-28 Avenue de Montespan,2.138017,48.821708,,28 Avenue de Montespan,,,,78150
-8 Rue du Hallier Condé-sur-Vesgre,,,,8 Rue du Hallier,,,,78113
-8 Rue du Hallier 78113,,,,8 Rue du Hallier,,,Condé-sur-Vesgre,
-8 Rue du Hallier,1.668307,48.740372,,8 Rue du Hallier,,,,78113
-1 Rue J B Drapier Conflans-Sainte-Honorine,,,,1 Rue Jean-Baptiste Drapier,,,,78700
-1 Rue J B Drapier 78700,,,,1 Rue Jean-Baptiste Drapier,,,Conflans-Sainte-Honorine,
-1 Rue J B Drapier,2.076490,48.996703,,1 Rue Jean-Baptiste Drapier,,,,78700
-58BIS Avenue de Verdun Croissy-sur-Seine,,,,58BIS Avenue de Verdun,,,,78290
-58BIS Avenue de Verdun 78290,,,,58BIS Avenue de Verdun,,,Croissy-sur-Seine,
-58BIS Avenue de Verdun,2.138273,48.882568,,58BIS Avenue de Verdun,,,,78290
-23 Rue du Pont Élancourt,,,,23 Rue du Pont,,,,78990
-23 Rue du Pont 78990,,,,23 Rue du Pont,,,Élancourt,
-23 Rue du Pont,1.957560,48.778507,,23 Rue du Pont,,,,78990
-15 Chemin du Clos Saint-Martin L'Étang-la-Ville,,,,15 Chemin du Clos Saint-Martin,,,,78620
-15 Chemin du Clos Saint-Martin 78620,,,,15 Chemin du Clos Saint-Martin,,,L'Étang-la-Ville,
-15 Chemin du Clos Saint-Martin,2.064458,48.866240,,15 Chemin du Clos Saint-Martin,,,,78620
-9 Rue des Vergers Freneuse,,,,9 Rue des Vergers,,,,78840
-9 Rue des Vergers 78840,,,,9 Rue des Vergers,,,Freneuse,
-9 Rue des Vergers,1.602650,49.042899,,9 Rue des Vergers,,,,78840
-56 Rue Molière Guyancourt,,,,56 Rue Molière,,,,78280
-56 Rue Molière 78280,,,,56 Rue Molière,,,Guyancourt,
-56 Rue Molière,2.062847,48.765592,,56 Rue Molière,,,,78280
-17BIS Rue Joseph Bara Houilles,,,,17BIS Rue Joseph Bara,,,,78800
-17BIS Rue Joseph Bara 78800,,,,17BIS Rue Joseph Bara,,,Houilles,
-17BIS Rue Joseph Bara,2.198203,48.925140,,17BIS Rue Joseph Bara,,,,78800
-38QUATER Route de la Roche Limetz-Villez,,,,38QUATER Route de la Roche,,,,78270
-38QUATER Route de la Roche 78270,,,,38QUATER Route de la Roche,,,Limetz-Villez,
-38QUATER Route de la Roche,1.553745,49.063118,,38QUATER Route de la Roche,,,,78270
-9 Allée des Droits de l'Homme Magny-les-Hameaux,,,,9 Allée des Droits de l'Homme,,,,78114
-9 Allée des Droits de l'Homme 78114,,,,9 Allée des Droits de l'Homme,,,Magny-les-Hameaux,
-9 Allée des Droits de l'Homme,2.080906,48.721113,,9 Allée des Droits de l'Homme,,,,78114
-19 Rue de l'Union Maisons-Laffitte,,,,19 Rue de l'Union,,,,78600
-19 Rue de l'Union 78600,,,,19 Rue de l'Union,,,Maisons-Laffitte,
-19 Rue de l'Union,2.137465,48.948797,,19 Rue de l'Union,,,,78600
-31 Rue de Bellevue Mantes-la-Ville,,,,31 Rue de Bellevue,,,,78711
-31 Rue de Bellevue 78711,,,,31 Rue de Bellevue,,,Mantes-la-Ville,
-31 Rue de Bellevue,1.717671,48.980143,,31 Rue de Bellevue,,,,78711
-30 Rue des Harias Mareil-sur-Mauldre,,,,30 Rue des Harias,,,,78124
-30 Rue des Harias 78124,,,,30 Rue des Harias,,,Mareil-sur-Mauldre,
-30 Rue des Harias,1.885278,48.886708,,30 Rue des Harias,,,,78124
-5 Square du Clermontois Maurepas,,,,5 Square du Clermontois,,,,78310
-5 Square du Clermontois 78310,,,,5 Square du Clermontois,,,Maurepas,
-5 Square du Clermontois,1.935409,48.771257,,5 Square du Clermontois,,,,78310
-19BIS Avenue de la République Le Mesnil-le-Roi,,,,19BIS Avenue de la République,,,,78600
-19BIS Avenue de la République 78600,,,,19BIS Avenue de la République,,,Le Mesnil-le-Roi,
-19BIS Avenue de la République,2.136457,48.938763,,19BIS Avenue de la République,,,,78600
-12 Quai George Sand Montesson,,,,12 Quai George Sand,,,,78360
-12 Quai George Sand 78360,,,,12 Quai George Sand,,,Montesson,
-12 Quai George Sand,2.137131,48.930695,,12 Quai George Sand,,,,78360
-5 Square de la Mare aux Renards Montigny-le-Bretonneux,,,,5 Square de la Mare aux Renards,,,,78180
-5 Square de la Mare aux Renards 78180,,,,5 Square de la Mare aux Renards,,,Montigny-le-Bretonneux,
-5 Square de la Mare aux Renards,2.031763,48.766802,,5 Square de la Mare aux Renards,,,,78180
-16BIS Rue des Cent Arpents Neauphle-le-Château,,,,16BIS Rue des Cent Arpents,,,,78640
-16BIS Rue des Cent Arpents 78640,,,,16BIS Rue des Cent Arpents,,,Neauphle-le-Château,
-16BIS Rue des Cent Arpents,1.904235,48.821573,,16BIS Rue des Cent Arpents,,,,78640
-2 Allée de la Reine des Reinettes Orgeval,,,,2 Allée de la Reine des Reinettes,,,,78630
-2 Allée de la Reine des Reinettes 78630,,,,2 Allée de la Reine des Reinettes,,,Orgeval,
-2 Allée de la Reine des Reinettes,1.974228,48.927248,,2 Allée de la Reine des Reinettes,,,,78630
-6 Rue Jean Giono Plaisir,,,,6 Rue Jean Giono,,,,78370
-6 Rue Jean Giono 78370,,,,6 Rue Jean Giono,,,Plaisir,
-6 Rue Jean Giono,1.927648,48.820644,,6 Rue Jean Giono,,,,78370
-6 Rue du 8 Mai 1945 Poissy,,,,6 Rue du 8 Mai 1945,,,,78300
-6 Rue du 8 Mai 1945 78300,,,,6 Rue du 8 Mai 1945,,,Poissy,
-6 Rue du 8 Mai 1945,2.044059,48.928205,,6 Rue du 8 Mai 1945,,,,78300
-30 Rue du Clos Batant Rambouillet,,,,30 Rue du Clos-Batant,,,,78120
-30 Rue du Clos Batant 78120,,,,30 Rue du Clos-Batant,,,Rambouillet,
-30 Rue du Clos Batant,1.855534,48.652697,,30 Rue du Clos-Batant,,,,78120
-21 Route de Houdan Richebourg,,,,21 Route de Houdan,,,,78550
-21 Route de Houdan 78550,,,,21 Route de Houdan,,,Richebourg,
-21 Route de Houdan,1.631829,48.818202,,21 Route de Houdan,,,,78550
-3 Rue Danès de Montardat Saint-Germain-en-Laye,,,,3 Rue Danès de Montardat,,,,78100
-3 Rue Danès de Montardat 78100,,,,3 Rue Danès de Montardat,,,Saint-Germain-en-Laye,
-3 Rue Danès de Montardat,2.090213,48.896754,,3 Rue Danès de Montardat,,,,78100
-11 Boulevard des Plants Saint-Nom-la-Bretèche,,,,11 Boulevard des Plants,,,,78860
-11 Boulevard des Plants 78860,,,,11 Boulevard des Plants,,,Saint-Nom-la-Bretèche,
-11 Boulevard des Plants,2.030803,48.863978,,11 Boulevard des Plants,,,,78860
-1 Rue Jean-Baptiste Clément Sartrouville,,,,1 Rue Jean-Baptiste Clément,,,,78500
-1 Rue Jean-Baptiste Clément 78500,,,,1 Rue Jean-Baptiste Clément,,,Sartrouville,
-1 Rue Jean-Baptiste Clément,2.172660,48.933436,,1 Rue Jean-Baptiste Clément,,,,78500
-32 Rue des Peupliers Septeuil,,,,32 Rue des Peupliers,,,,78790
-32 Rue des Peupliers 78790,,,,32 Rue des Peupliers,,,Septeuil,
-32 Rue des Peupliers,1.679875,48.888224,,32 Rue des Peupliers,,,,78790
-14 Rue de l'Echenet Triel-sur-Seine,,,,14 Rue de l'Echenet,,,,78510
-14 Rue de l'Echenet 78510,,,,14 Rue de l'Echenet,,,Triel-sur-Seine,
-14 Rue de l'Echenet,1.994298,48.989454,,14 Rue de l'Echenet,,,,78510
-113 Rue Mozart Vélizy-Villacoublay,,,,113 Rue Mozart,,,,78140
-113 Rue Mozart 78140,,,,113 Rue Mozart,,,Vélizy-Villacoublay,
-113 Rue Mozart,2.169868,48.785538,,113 Rue Mozart,,,,78140
-21 Avenue du Chemin Vert La Verrière,,,,21 Avenue du Chemin Vert,,,,78320
-21 Avenue du Chemin Vert 78320,,,,21 Avenue du Chemin Vert,,,La Verrière,
-21 Avenue du Chemin Vert,1.956724,48.752346,,21 Avenue du Chemin Vert,,,,78320
-4 Impasse Nattier Versailles,,,,4 Impasse Nattier,,,,78000
-4 Impasse Nattier 78000,,,,4 Impasse Nattier,,,Versailles,
-4 Impasse Nattier,2.135036,48.813061,,4 Impasse Nattier,,,,78000
-36BIS Avenue Georges Clemenceau Le Vésinet,,,,36BIS Avenue Georges Clemenceau,,,,78110
-36BIS Avenue Georges Clemenceau 78110,,,,36BIS Avenue Georges Clemenceau,,,Le Vésinet,
-36BIS Avenue Georges Clemenceau,2.134034,48.887017,,36BIS Avenue Georges Clemenceau,,,,78110
-4 Rue du Pavillon Villette,,,,4 Rue du Pavillon,,,,78930
-4 Rue du Pavillon 78930,,,,4 Rue du Pavillon,,,Villette,
-4 Rue du Pavillon,1.691405,48.927760,,4 Rue du Pavillon,,,,78930
-3 Rue Jean Mermoz Voisins-le-Bretonneux,,,,3 Rue Jean Mermoz,,,,78960
-3 Rue Jean Mermoz 78960,,,,3 Rue Jean Mermoz,,,Voisins-le-Bretonneux,
-3 Rue Jean Mermoz,2.040601,48.760333,,3 Rue Jean Mermoz,,,,78960
-26 Avenue de l'Europe Athis-Mons,,,,26 Avenue de l'Europe,,,,91200
-26 Avenue de l'Europe 91200,,,,26 Avenue de l'Europe,,,Athis-Mons,
-26 Avenue de l'Europe,2.408811,48.719534,,26 Avenue de l'Europe,,,,91200
-1 Route de Morigny Auvers-Saint-Georges,,,,1 Route de Morigny,,,,91580
-1 Route de Morigny 91580,,,,1 Route de Morigny,,,Auvers-Saint-Georges,
-1 Route de Morigny,2.198262,48.478983,,1 Route de Morigny,,,,91580
-38 Rue Odilon Redon Bièvres,,,,38 Rue Odilon Redon,,,,91570
-38 Rue Odilon Redon 91570,,,,38 Rue Odilon Redon,,,Bièvres,
-38 Rue Odilon Redon,2.214667,48.756643,,38 Rue Odilon Redon,,,,91570
-22 Rue du Petit Pont Bondoufle,,,,22 Rue du Petit Pont,,,,91070
-22 Rue du Petit Pont 91070,,,,22 Rue du Petit Pont,,,Bondoufle,
-22 Rue du Petit Pont,2.385285,48.611678,,22 Rue du Petit Pont,,,,91070
-4 Rue Ducrot Brétigny-sur-Orge,,,,4 Rue Ernest Ducros,,,,91220
-4 Rue Ducrot 91220,,,,4 Ernest Ducros,,,Brétigny-sur-Orge,
-4 Rue Ducrot,2.304230,48.612895,,4 Ernest Ducros,,,,91220
-5 Rue des Sarments Breuillet,,,,5 Rue des Sarments,,,,91650
-5 Rue des Sarments 91650,,,,5 Rue des Sarments,,,Breuillet,
-5 Rue des Sarments,2.179375,48.574880,,5 Rue des Sarments,,,,91650
-16 Avenue Montaigne Brunoy,,,,16 Avenue Montaigne,,,,91800
-16 Avenue Montaigne 91800,,,,16 Avenue Montaigne,,,Brunoy,
-16 Avenue Montaigne,2.509264,48.697386,,16 Avenue Montaigne,,,,91800
-41 Rue Max Ernst Bures-sur-Yvette,,,,41 Rue Max Ernst,,,,91440
-41 Rue Max Ernst 91440,,,,41 Rue Max Ernst,,,Bures-sur-Yvette,
-41 Rue Max Ernst,2.156776,48.679705,,41 Rue Max Ernst,,,,91440
-5 Rue de la Pierre Blanche Cheptainville,,,,5 Rue de la Pierre Blanche,,,,91630
-5 Rue de la Pierre Blanche 91630,,,,5 Rue de la Pierre Blanche,,,Cheptainville,
-5 Rue de la Pierre Blanche,2.285627,48.557539,,5 Rue de la Pierre Blanche,,,,91630
-114 Rue Georges Le Dû Corbeil-Essonnes,,,,114 Rue Georges Le Dû,,,,91100
-114 Rue Georges Le Dû 91100,,,,114 Rue Georges Le Dû,,,Corbeil-Essonnes,
-114 Rue Georges Le Dû,2.473044,48.593543,,114 Rue Georges Le Dû,,,,91100
-25 Allée des Libellules Le Coudray-Montceaux,,,,25 Allée des Libellules,,,,91830
-25 Allée des Libellules 91830,,,,25 Allée des Libellules,,,Le Coudray-Montceaux,
-25 Allée des Libellules,2.506447,48.567273,,25 Allée des Libellules,,,,91830
-60 Rue de l'Égalité D'Huison-Longueville,,,,60 Rue de l'Égalité,,,,91590
-60 Rue de l'Égalité 91590,,,,60 Rue de l'Égalité,,,D'Huison-Longueville,
-60 Rue de l'Égalité,2.336809,48.455205,,60 Rue de l'Égalité,,,,91590
-13 Rue Etienne Rabot Draveil,,,,13 Rue Etienne Rabot,,,,91210
-13 Rue Etienne Rabot 91210,,,,13 Rue Etienne Rabot,,,Draveil,
-13 Rue Etienne Rabot,2.420713,48.675950,,13 Rue Etienne Rabot,,,,91210
-17 Avenue d'Arpajon Égly,,,,17 Avenue d'Arpajon,,,,91520
-17 Avenue d'Arpajon 91520,,,,17 Avenue d'Arpajon,,,Égly,
-17 Avenue d'Arpajon,2.229800,48.582000,,17 Avenue d'Arpajon,,,,91520
-30 Rue Guillemette de Bure Étampes,,,,30 Rue Guillemette de Bure,,,,91150
-30 Rue Guillemette de Bure 91150,,,,30 Rue Guillemette de Bure,,,Étampes,
-30 Rue Guillemette de Bure,2.140833,48.431631,,30 Rue Guillemette de Bure,,,,91150
-32 Rue Alfred de Musset Étréchy,,,,32 Rue Alfred de Musset,,,,91580
-32 Rue Alfred de Musset 91580,,,,32 Rue Alfred de Musset,,,Étréchy,
-32 Rue Alfred de Musset,2.183701,48.486284,,32 Rue Alfred de Musset,,,,91580
-25 Rue du Bas Côt La Ferté-Alais,,,,25 Rue du Bas Côt,,,,91590
-25 Rue du Bas Côt 91590,,,,25 Rue du Bas Côt,,,La Ferté-Alais,
-25 Rue du Bas Côt,2.367180,48.480410,,25 Rue du Bas Côt,,,,91590
-60 Avenue du Général Leclerc Gif-sur-Yvette,,,,60 Avenue du Général Leclerc,,,,91190
-60 Avenue du Général Leclerc 91190,,,,60 Avenue du Général Leclerc,,,Gif-sur-Yvette,
-60 Avenue du Général Leclerc,2.123581,48.704754,,60 Avenue du Général Leclerc,,,,91190
-8 Allée du Signal Grigny,,,,8 Allée du Signal,,,,91350
-8 Allée du Signal 91350,,,,8 Allée du Signal,,,Grigny,
-8 Allée du Signal,2.368053,48.646693,,8 Allée du Signal,,,,91350
-1 Avenue Mozart Itteville,,,,1 Avenue Mozart,,,,91760
-1 Avenue Mozart 91760,,,,1 Avenue Mozart,,,Itteville,
-1 Avenue Mozart,2.342568,48.532450,,1 Avenue Mozart,,,,91760
-46 Rue de la Ferme Lardy,,,,46 Rue de la Ferme,,,,91510
-46 Rue de la Ferme 91510,,,,46 Rue de la Ferme,,,Lardy,
-46 Rue de la Ferme,2.297476,48.535438,,46 Rue de la Ferme,,,,91510
-71 Rue de la Division Leclerc Linas,,,,71 Rue de la Division Leclerc,,,,91310
-71 Rue de la Division Leclerc 91310,,,,71 Rue de la Division Leclerc,,,Linas,
-71 Rue de la Division Leclerc,2.266607,48.632622,,71 Rue de la Division Leclerc,,,,91310
-25 Rue des Glaneurs Longjumeau,,,,25 Rue des Glaneurs,,,,91160
-25 Rue des Glaneurs 91160,,,,25 Rue des Glaneurs,,,Longjumeau,
-25 Rue des Glaneurs,2.300980,48.680790,,25 Rue des Glaneurs,,,,91160
-10BIS Route de Briis Marcoussis,,,,10BIS Route de Briis,,,,91460
-10BIS Route de Briis 91460,,,,10BIS Route de Briis,,,Marcoussis,
-10BIS Route de Briis,2.221816,48.636926,,10BIS Route de Briis,,,,91460
-31 Rue Jean Mermoz Massy,,,,31 Rue Jean Mermoz,,,,91300
-31 Rue Jean Mermoz 91300,,,,31 Rue Jean Mermoz,,,Massy,
-31 Rue Jean Mermoz,2.280368,48.728678,,31 Rue Jean Mermoz,,,,91300
-82 Rue du Petit Mennecy Mennecy,,,,82 Rue du Petit Mennecy,,,,91540
-82 Rue du Petit Mennecy 91540,,,,82 Rue du Petit Mennecy,,,Mennecy,
-82 Rue du Petit Mennecy,2.443676,48.575897,,82 Rue du Petit Mennecy,,,,91540
-19 Rue de la Janvrerie Les Molières,,,,19 Rue de la Janvrerie,,,,91470
-19 Rue de la Janvrerie 91470,,,,19 Rue de la Janvrerie,,,Les Molières,
-19 Rue de la Janvrerie,2.072290,48.676280,,19 Rue de la Janvrerie,,,,91470
-43BIS Rue Raymond Paumier Montgeron,,,,43BIS Rue Raymond Paumier,,,,91230
-43BIS Rue Raymond Paumier 91230,,,,43BIS Rue Raymond Paumier,,,Montgeron,
-43BIS Rue Raymond Paumier,2.447216,48.704176,,43BIS Rue Raymond Paumier,,,,91230
-14 Rue Jean Moulin Morangis,,,,14 Rue Jean Moulin,,,,91420
-14 Rue Jean Moulin 91420,,,,14 Rue Jean Moulin,,,Morangis,
-14 Rue Jean Moulin,2.333888,48.705800,,14 Rue Jean Moulin,,,,91420
-16 Avenue Fernand Léger Morsang-sur-Orge,,,,16 Avenue Fernand Léger,,,,91390
-16 Avenue Fernand Léger 91390,,,,16 Avenue Fernand Léger,,,Morsang-sur-Orge,
-16 Avenue Fernand Léger,2.344638,48.651070,,16 Avenue Fernand Léger,,,,91390
-2 Rue Rosa Luxembourg La Norville,,,,2 Rue Rosa Luxembourg,,,,91290
-2 Rue Rosa Luxembourg 91290,,,,2 Rue Rosa Luxembourg,,,La Norville,
-2 Rue Rosa Luxembourg,2.261681,48.592445,,2 Rue Rosa Luxembourg,,,,91290
-13 Rue Florian Orsay,,,,13 Rue Florian,,,,91400
-13 Rue Florian 91400,,,,13 Rue Florian,,,Orsay,
-13 Rue Florian,2.195807,48.704238,,13 Rue Florian,,,,91400
-111 Boulevard de Lozère Palaiseau,,,,111 Boulevard de Lozère,,,,91120
-111 Boulevard de Lozère 91120,,,,111 Boulevard de Lozère,,,Palaiseau,
-111 Boulevard de Lozère,2.226641,48.706181,,111 Boulevard de Lozère,,,,91120
-75 Rue Romain Rolland Paray-Vieille-Poste,,,,75 Rue Romain Rolland,,,,91550
-75 Rue Romain Rolland 91550,,,,75 Rue Romain Rolland,,,Paray-Vieille-Poste,
-75 Rue Romain Rolland,2.365385,48.706465,,75 Rue Romain Rolland,,,,91550
-61 Avenue Daumesnil Ris-Orangis,,,,61 Avenue Daumesnil,,,,91130
-61 Avenue Daumesnil 91130,,,,61 Avenue Daumesnil,,,Ris-Orangis,
-61 Avenue Daumesnil,2.413883,48.652699,,61 Avenue Daumesnil,,,,91130
-79 Avenue de Dourdan Saint-Chéron,,,,79 Avenue de Dourdan,,,,91530
-79 Avenue de Dourdan 91530,,,,79 Avenue de Dourdan,,,Saint-Chéron,
-79 Avenue de Dourdan,2.111262,48.546852,,79 Avenue de Dourdan,,,,91530
-15 Rue Henri Sellier Sainte-Geneviève-des-Bois,,,,15 Rue Henri Sellier,,,,91700
-15 Rue Henri Sellier 91700,,,,15 Rue Henri Sellier,,,Sainte-Geneviève-des-Bois,
-15 Rue Henri Sellier,2.326752,48.635399,,15 Rue Henri Sellier,,,,91700
-25 Route de Corbeil Saint-Germain-lès-Arpajon,,,,25 Route de Corbeil,,,,91180
-25 Route de Corbeil 91180,,,,25 Route de Corbeil,,,Saint-Germain-lès-Arpajon,
-25 Route de Corbeil,2.263717,48.594748,,25 Route de Corbeil,,,,91180
-3BIS Rue Chopin Saint-Michel-sur-Orge,,,,3BIS Rue Chopin,,,,91240
-3BIS Rue Chopin 91240,,,,3BIS Rue Chopin,,,Saint-Michel-sur-Orge,
-3BIS Rue Chopin,2.309541,48.644930,,3BIS Rue Chopin,,,,91240
-8 Rue des Cottages Saintry-sur-Seine,,,,8 Rue des Cottages,,,,91250
-8 Rue des Cottages 91250,,,,8 Rue des Cottages,,,Saintry-sur-Seine,
-8 Rue des Cottages,2.501485,48.596520,,8 Rue des Cottages,,,,91250
-43 Rue d'Auerstaedt Savigny-sur-Orge,,,,43 Rue d'Auerstaedt,,,,91600
-43 Rue d'Auerstaedt 91600,,,,43 Rue d'Auerstaedt,,,Savigny-sur-Orge,
-43 Rue d'Auerstaedt,2.333478,48.688868,,43 Rue d'Auerstaedt,,,,91600
-15 Avenue Linné Savigny-sur-Orge,,,,15 Avenue Linné,,,,91600
-15 Avenue Linné 91600,,,,15 Avenue Linné,,,Savigny-sur-Orge,
-15 Avenue Linné,2.345229,48.688703,,15 Avenue Linné,,,,91600
-862 Rue des Sources Sermaise,,,,862 Rue des Sources,,,,91530
-862 Rue des Sources 91530,,,,862 Rue des Sources,,,Sermaise,
-862 Rue des Sources,2.101442,48.538864,,862 Rue des Sources,,,,91530
-12BIS Chemin d'Orveau Vayres-sur-Essonne,,,,12BIS Chemin d'Orveau,,,,91820
-12BIS Chemin d'Orveau 91820,,,,12BIS Chemin d'Orveau,,,Vayres-sur-Essonne,
-12BIS Chemin d'Orveau,2.351197,48.438203,,12BIS Chemin d'Orveau,,,,91820
-6 Rue Pierre Semard Vigneux-sur-Seine,,,,6 Rue Pierre Semard,,,,91270
-6 Rue Pierre Semard 91270,,,,6 Rue Pierre Semard,,,Vigneux-sur-Seine,
-6 Rue Pierre Semard,2.431447,48.695518,,6 Rue Pierre Semard,,,,91270
-8 Rue des Écoles La Ville-du-Bois,,,,8 Rue des Écoles,,,,91620
-8 Rue des Écoles 91620,,,,8 Rue des Écoles,,,La Ville-du-Bois,
-8 Rue des Écoles,2.268867,48.661650,,8 Rue des Écoles,,,,91620
-11 Allée des Cerisiers Villiers-sur-Orge,,,,11 Allée des Cerisiers,,,,91700
-11 Allée des Cerisiers 91700,,,,11 Allée des Cerisiers,,,Villiers-sur-Orge,
-11 Allée des Cerisiers,2.291457,48.655138,,11 Allée des Cerisiers,,,,91700
-34 Avenue du Pavillon Viry-Châtillon,,,,34 Avenue du Pavillon,,,,91170
-34 Avenue du Pavillon 91170,,,,34 Avenue du Pavillon,,,Viry-Châtillon,
-34 Avenue du Pavillon,2.364577,48.649220,,34 Avenue du Pavillon,,,,91170
-24 Rue des Faisans Yerres,,,,24 Rue des Faisans,,,,91330
-24 Rue des Faisans 91330,,,,24 Rue des Faisans,,,Yerres,
-24 Rue des Faisans,2.509156,48.719221,,24 Rue des Faisans,,,,91330
-10 Rue des Grouettes Antony,,,,10 Rue des Grouettes,,,,92160
-10 Rue des Grouettes 92160,,,,10 Rue des Grouettes,,,Antony,
-10 Rue des Grouettes,2.286678,48.756008,,10 Rue des Grouettes,,,,92160
-18 Rue Robert Doisy Antony,,,,18 Rue Robert Doisy,,,,92160
-18 Rue Robert Doisy 92160,,,,18 Rue Robert Doisy,,,Antony,
-18 Rue Robert Doisy,2.296120,48.756926,,18 Rue Robert Doisy,,,,92160
-22 Rue Jeanne d'Arc Asnières-sur-Seine,,,,22 Rue Jeanne d'Arc,,,,92600
-22 Rue Jeanne d'Arc 92600,,,,22 Rue Jeanne d'Arc,,,Asnières-sur-Seine,
-22 Rue Jeanne d'Arc,2.280829,48.921107,,22 Rue Jeanne d'Arc,,,,92600
-3 Rue Madame Curie Bagneux,,,,3 Rue Madame Curie,,,,92220
-3 Rue Madame Curie 92220,,,,3 Rue Madame Curie,,,Bagneux,
-3 Rue Madame Curie,2.315417,48.795933,,3 Rue Madame Curie,,,,92220
-9 Villa Schutz et Daumain Bois-Colombes,,,,9 Villa Schutz et Daumain,,,,92270
-9 Villa Schutz et Daumain 92270,,,,9 Villa Schutz et Daumain,,,Bois-Colombes,
-9 Villa Schutz et Daumain,2.274382,48.917142,,9 Villa Schutz et Daumain,,,,92270
-65 Rue Marcel Dassault Boulogne-Billancourt,,,,65 Rue Marcel Dassault,,,,92100
-65 Rue Marcel Dassault 92100,,,,65 Rue Marcel Dassault,,,Boulogne-Billancourt,
-65 Rue Marcel Dassault,2.250925,48.834668,,65 Rue Marcel Dassault,,,,92100
-4 Rue Pasteur Bourg-la-Reine,,,,4 Rue Pasteur,,,,92340
-4 Rue Pasteur 92340,,,,4 Rue Pasteur,,,Bourg-la-Reine,
-4 Rue Pasteur,2.314162,48.773352,,4 Rue Pasteur,,,,92340
-80 Rue Lasègue Châtillon,,,,80 Rue Lasègue,,,,92320
-80 Rue Lasègue 92320,,,,80 Rue Lasègue,,,Châtillon,
-80 Rue Lasègue,2.280198,48.802575,,80 Rue Lasègue,,,,92320
-5BIS Rue de Bièvres Clamart,,,,5BIS Rue de Bièvres,,,,92140
-5BIS Rue de Bièvres 92140,,,,5BIS Rue de Bièvres,,,Clamart,
-5BIS Rue de Bièvres,2.265419,48.799049,,5BIS Rue de Bièvres,,,,92140
-122 Rue Marie Fichet Clamart,,,,122 Rue Marie Fichet,,,,92140
-122 Rue Marie Fichet 92140,,,,122 Rue Marie Fichet,,,Clamart,
-122 Rue Marie Fichet,2.229741,48.779069,,122 Rue Marie Fichet,,,,92140
-80 Rue Martre Clichy,,,,80 Rue Martre,,,,92110
-80 Rue Martre 92110,,,,80 Rue Martre,,,Clichy,
-80 Rue Martre,2.306857,48.902501,,80 Rue Martre,,,,92110
-13 Villa Eugène Colombes,,,,13 Villa Eugène,,,,92700
-13 Villa Eugène 92700,,,,13 Villa Eugène,,,Colombes,
-13 Villa Eugène,2.260929,48.915812,,13 Villa Eugène,,,,92700
-10 Rue de la Paix Colombes,,,,10 Rue de la Paix,,,,92700
-10 Rue de la Paix 92700,,,,10 Rue de la Paix,,,Colombes,
-10 Rue de la Paix,2.242662,48.912737,,10 Rue de la Paix,,,,92700
-30BIS Rue Gaultier Courbevoie,,,,30BIS Rue Gaultier,,,,92400
-30BIS Rue Gaultier 92400,,,,30BIS Rue Gaultier,,,Courbevoie,
-30BIS Rue Gaultier,2.242143,48.898357,,30BIS Rue Gaultier,,,,92400
-8 Rue des Moulins à Vent Fontenay-aux-Roses,,,,8 Rue des Moulins à Vent,,,,92260
-8 Rue des Moulins à Vent 92260,,,,8 Rue des Moulins à Vent,,,Fontenay-aux-Roses,
-8 Rue des Moulins à Vent,2.278073,48.794179,,8 Rue des Moulins à Vent,,,,92260
-59 Rue de Plaisance La Garenne-Colombes,,,,59 Rue de Plaisance,,,,92250
-59 Rue de Plaisance 92250,,,,59 Rue de Plaisance,,,La Garenne-Colombes,
-59 Rue de Plaisance,2.252950,48.906330,,59 Rue de Plaisance,,,,92250
-42 Rue Danton Issy-les-Moulineaux,,,,42 Rue Danton,,,,92130
-42 Rue Danton 92130,,,,42 Rue Danton,,,Issy-les-Moulineaux,
-42 Rue Danton,2.271859,48.823909,,42 Rue Danton,,,,92130
-46 Rue Jules Guesde Levallois-Perret,,,,46 Rue Jules Guesde,,,,92300
-46 Rue Jules Guesde 92300,,,,46 Rue Jules Guesde,,,Levallois-Perret,
-46 Rue Jules Guesde,2.292734,48.893173,,46 Rue Jules Guesde,,,,92300
-19 Rue de la Tour Malakoff,,,,19 Rue de la Tour,,,,92240
-19 Rue de la Tour 92240,,,,19 Rue de la Tour,,,Malakoff,
-19 Rue de la Tour,2.305675,48.823213,,19 Rue de la Tour,,,,92240
-8 Rue Amaury Duval Montrouge,,,,8 Rue Amaury Duval,,,,92120
-8 Rue Amaury Duval 92120,,,,8 Rue Amaury Duval,,,Montrouge,
-8 Rue Amaury Duval,2.323514,48.816985,,8 Rue Amaury Duval,,,,92120
-31 Rue des Fleurs Nanterre,,,,31 Rue des Fleurs,,,,92000
-31 Rue des Fleurs 92000,,,,31 Rue des Fleurs,,,Nanterre,
-31 Rue des Fleurs,2.204486,48.885187,,31 Rue des Fleurs,,,,92000
-58 Rue de Suresnes Nanterre,,,,58 Rue de Suresnes,,,,92000
-58 Rue de Suresnes 92000,,,,58 Rue de Suresnes,,,Nanterre,
-58 Rue de Suresnes,2.211166,48.885495,,58 Rue de Suresnes,,,,92000
-19 Rue Amédée Usséglio Le Plessis-Robinson,,,,19 Rue Amédée Usséglio,,,,92350
-19 Rue Amédée Usséglio 92350,,,,19 Rue Amédée Usséglio,,,Le Plessis-Robinson,
-19 Rue Amédée Usséglio,2.254586,48.781121,,19 Rue Amédée Usséglio,,,,92350
-4 Rue des Alizes Rueil-Malmaison,,,,4 Rue des Alizes,,,,92500
-4 Rue des Alizes 92500,,,,4 Rue des Alizes,,,Rueil-Malmaison,
-4 Rue des Alizes,2.193308,48.860188,,4 Rue des Alizes,,,,92500
-22 Rue Haute Rueil-Malmaison,,,,22 Rue Haute,,,,92500
-22 Rue Haute 92500,,,,22 Rue Haute,,,Rueil-Malmaison,
-22 Rue Haute,2.183094,48.874937,,22 Rue Haute,,,,92500
-23 Rue Armengaud Saint-Cloud,,,,23 Rue Armengaud,,,,92210
-23 Rue Armengaud 92210,,,,23 Rue Armengaud,,,Saint-Cloud,
-23 Rue Armengaud,2.216710,48.848047,,23 Rue Armengaud,,,,92210
-9 Rue Massenet Sceaux,,,,9 Rue Massenet,,,,92330
-9 Rue Massenet 92330,,,,9 Rue Massenet,,,Sceaux,
-9 Rue Massenet,2.309102,48.783919,,9 Rue Massenet,,,,92330
-1 Rue Gustave Flourens Suresnes,,,,1 Rue Gustave Flourens,,,,92150
-1 Rue Gustave Flourens 92150,,,,1 Rue Gustave Flourens,,,Suresnes,
-1 Rue Gustave Flourens,2.229349,48.871257,,1 Rue Gustave Flourens,,,,92150
-6 Boulevard de Jardy Vaucresson,,,,6 Boulevard de Jardy,,,,92420
-6 Boulevard de Jardy 92420,,,,6 Boulevard de Jardy,,,Vaucresson,
-6 Boulevard de Jardy,2.155615,48.837116,,6 Boulevard de Jardy,,,,92420
-25 Rue d'Amiens Aulnay-sous-Bois,,,,25 Rue d'Amiens,,,,93600
-25 Rue d'Amiens 93600,,,,25 Rue d'Amiens,,,Aulnay-sous-Bois,
-25 Rue d'Amiens,2.485722,48.922312,,25 Rue d'Amiens,,,,93600
-10 Rue Frédéric Mistral Aulnay-sous-Bois,,,,10 Rue Frédéric Mistral,,,,93600
-10 Rue Frédéric Mistral 93600,,,,10 Rue Frédéric Mistral,,,Aulnay-sous-Bois,
-10 Rue Frédéric Mistral,2.489945,48.918039,,10 Rue Frédéric Mistral,,,,93600
-14 Rue Paul Fouquet Aulnay-sous-Bois,,,,14 Rue Paul Fouquet,,,,93600
-14 Rue Paul Fouquet 93600,,,,14 Rue Paul Fouquet,,,Aulnay-sous-Bois,
-14 Rue Paul Fouquet,2.483256,48.936786,,14 Rue Paul Fouquet,,,,93600
-6 Rue des Fossillons Bagnolet,,,,6 Rue des Fossillons,,,,93170
-6 Rue des Fossillons 93170,,,,6 Rue des Fossillons,,,Bagnolet,
-6 Rue des Fossillons,2.423188,48.868803,,6 Rue des Fossillons,,,,93170
-83 Rue Emile Paladilhe Le Blanc-Mesnil,,,,83 Rue Emile Paladilhe,,,,93150
-83 Rue Emile Paladilhe 93150,,,,83 Rue Emile Paladilhe,,,Le Blanc-Mesnil,
-83 Rue Emile Paladilhe,2.470884,48.939067,,83 Rue Emile Paladilhe,,,,93150
-29 Avenue Romain Rolland Le Blanc-Mesnil,,,,29 Avenue Romain Rolland,,,,93150
-29 Avenue Romain Rolland 93150,,,,29 Avenue Romain Rolland,,,Le Blanc-Mesnil,
-29 Avenue Romain Rolland,2.465491,48.934498,,29 Avenue Romain Rolland,,,,93150
-5 Rue de la Nouvelle Dehli Bobigny,,,,5 Rue de la Nouvelle Dehli,,,,93000
-5 Rue de la Nouvelle Dehli 93000,,,,5 Rue de la Nouvelle Dehli,,,Bobigny,
-5 Rue de la Nouvelle Dehli,2.473920,48.910320,,5 Rue de la Nouvelle Dehli,,,,93000
-23 Rue Jules Guesde Bondy,,,,23 Rue Jules Guesde,,,,93140
-23 Rue Jules Guesde 93140,,,,23 Rue Jules Guesde,,,Bondy,
-23 Rue Jules Guesde,2.475792,48.903883,,23 Rue Jules Guesde,,,,93140
-42 Allée de Bellevue Clichy-sous-Bois,,,,42 Allée de Bellevue,,,,93390
-42 Allée de Bellevue 93390,,,,42 Allée de Bellevue,,,Clichy-sous-Bois,
-42 Allée de Bellevue,2.548898,48.914918,,42 Allée de Bellevue,,,,93390
-30 Avenue Jean Mermoz La Courneuve,,,,30 Avenue Jean Mermoz,,,,93120
-30 Avenue Jean Mermoz 93120,,,,30 Avenue Jean Mermoz,,,La Courneuve,
-30 Avenue Jean Mermoz,2.402357,48.932070,,30 Avenue Jean Mermoz,,,,93120
-27 Rue de la Démocratie Drancy,,,,27 Rue de la Démocratie,,,,93700
-27 Rue de la Démocratie 93700,,,,27 Rue de la Démocratie,,,Drancy,
-27 Rue de la Démocratie,2.443509,48.917072,,27 Rue de la Démocratie,,,,93700
-15 Rue des Lilas Drancy,,,,15 Rue des Lilas,,,,93700
-15 Rue des Lilas 93700,,,,15 Rue des Lilas,,,Drancy,
-15 Rue des Lilas,2.434937,48.924877,,15 Rue des Lilas,,,,93700
-17 Rue Laetitia et Henri Tredez Dugny,,,,17 Rue Laetitia et Henri Tredez,,,,93440
-17 Rue Laetitia et Henri Tredez 93440,,,,17 Rue Laetitia et Henri Tredez,,,Dugny,
-17 Rue Laetitia et Henri Tredez,2.411917,48.950601,,17 Rue Laetitia et Henri Tredez,,,,93440
-7 Rue des Amandiers Gagny,,,,7 Rue des Amandiers,,,,93220
-7 Rue des Amandiers 93220,,,,7 Rue des Amandiers,,,Gagny,
-7 Rue des Amandiers,2.552309,48.875323,,7 Rue des Amandiers,,,,93220
-58 Avenue des Marronniers Gagny,,,,58 Avenue des Marronniers,,,,93220
-58 Avenue des Marronniers 93220,,,,58 Avenue des Marronniers,,,Gagny,
-58 Avenue des Marronniers,2.559416,48.872188,,58 Avenue des Marronniers,,,,93220
-24 Avenue des Princes Gournay-sur-Marne,,,,24 Avenue des Princes,,,,93460
-24 Avenue des Princes 93460,,,,24 Avenue des Princes,,,Gournay-sur-Marne,
-24 Avenue des Princes,2.581917,48.857715,,24 Avenue des Princes,,,,93460
-13 Rue de Simiane Livry-Gargan,,,,13 Rue de Simiane,,,,93190
-13 Rue de Simiane 93190,,,,13 Rue de Simiane,,,Livry-Gargan,
-13 Rue de Simiane,2.528842,48.914333,,13 Rue de Simiane,,,,93190
-38 Avenue Quesnay Livry-Gargan,,,,38 Avenue Quesnay,,,,93190
-38 Avenue Quesnay 93190,,,,38 Avenue Quesnay,,,Livry-Gargan,
-38 Avenue Quesnay,2.513375,48.912616,,38 Avenue Quesnay,,,,93190
-10 Boulevard Hardy Montfermeil,,,,10 Boulevard Hardy,,,,93370
-10 Boulevard Hardy 93370,,,,10 Boulevard Hardy,,,Montfermeil,
-10 Boulevard Hardy,2.564488,48.904038,,10 Boulevard Hardy,,,,93370
-55 Rue Carnot Montreuil,,,,55 Rue Carnot,,,,93100
-55 Rue Carnot 93100,,,,55 Rue Carnot,,,Montreuil,
-55 Rue Carnot,2.441415,48.854502,,55 Rue Carnot,,,,93100
-8 Rue Louise Montreuil,,,,8 Rue Louise,,,,93100
-8 Rue Louise 93100,,,,8 Rue Louise,,,Montreuil,
-8 Rue Louise,2.457656,48.872582,,8 Rue Louise,,,,93100
-40 Rue de Saint-Antoine Montreuil,,,,40 Rue de Saint-Antoine,,,,93100
-40 Rue de Saint-Antoine 93100,,,,40 Rue de Saint-Antoine,,,Montreuil,
-40 Rue de Saint-Antoine,2.456648,48.865159,,40 Rue de Saint-Antoine,,,,93100
-33TER Rue Raspail Neuilly-Plaisance,,,,33TER Rue Raspail,,,,93360
-33TER Rue Raspail 93360,,,,33TER Rue Raspail,,,Neuilly-Plaisance,
-33TER Rue Raspail,2.512366,48.856233,,33TER Rue Raspail,,,,93360
-28 Rue du Brayer Noisy-le-Grand,,,,28 Rue du Brayer,,,,93160
-28 Rue du Brayer 93160,,,,28 Rue du Brayer,,,Noisy-le-Grand,
-28 Rue du Brayer,2.546562,48.848766,,28 Rue du Brayer,,,,93160
-1 Rue Pierre Brossolette Noisy-le-Grand,,,,1 Rue Pierre Brossolette,,,,93160
-1 Rue Pierre Brossolette 93160,,,,1 Rue Pierre Brossolette,,,Noisy-le-Grand,
-1 Rue Pierre Brossolette,2.528870,48.843689,,1 Rue Pierre Brossolette,,,,93160
-1 Allée Klebert Noisy-le-Sec,,,,1 Allée Klebert,,,,93130
-1 Allée Klebert 93130,,,,1 Allée Klebert,,,Noisy-le-Sec,
-1 Allée Klebert,2.471885,48.897436,,1 Allée Klebert,,,,93130
-4 Rue Sainte-Marguerite Pantin,,,,4 Rue Sainte-Marguerite,,,,93500
-4 Rue Sainte-Marguerite 93500,,,,4 Rue Sainte-Marguerite,,,Pantin,
-4 Rue Sainte-Marguerite,2.391414,48.901062,,4 Rue Sainte-Marguerite,,,,93500
-4BIS Allée Thiesset Les Pavillons-sous-Bois,,,,4BIS Allée Thiesset,,,,93320
-4BIS Allée Thiesset 93320,,,,4BIS Allée Thiesset,,,Les Pavillons-sous-Bois,
-4BIS Allée Thiesset,2.506036,48.917058,,4BIS Allée Thiesset,,,,93320
-72 Avenue Édouard Vaillant Le Pré-Saint-Gervais,,,,72 Avenue Édouard Vaillant,,,,93310
-72 Avenue Édouard Vaillant 93310,,,,72 Avenue Édouard Vaillant,,,Le Pré-Saint-Gervais,
-72 Avenue Édouard Vaillant,2.409652,48.880999,,72 Avenue Édouard Vaillant,,,,93310
-84 Rue Jean Lemoine Romainville,,,,84 Rue Jean Lemoine,,,,93230
-84 Rue Jean Lemoine 93230,,,,84 Rue Jean Lemoine,,,Romainville,
-84 Rue Jean Lemoine,2.446053,48.878784,,84 Rue Jean Lemoine,,,,93230
-19 Avenue du Président John Kennedy Rosny-sous-Bois,,,,19 Avenue du Président John Kennedy,,,,93110
-19 Avenue du Président John Kennedy 93110,,,,19 Avenue du Président John Kennedy,,,Rosny-sous-Bois,
-19 Avenue du Président John Kennedy,2.487719,48.878153,,19 Avenue du Président John Kennedy,,,,93110
-39 Rue Loubet Saint-Denis,,,,39 Rue Loubet,,,,93200
-39 Rue Loubet 93200,,,,39 Rue Loubet,,,Saint-Denis,
-39 Rue Loubet,2.359363,48.948737,,39 Rue Loubet,,,,93200
-8 Rue Mathieu Saint-Ouen,,,,8 Rue Mathieu,,,,93400
-8 Rue Mathieu 93400,,,,8 Rue Mathieu,,,Saint-Ouen,
-8 Rue Mathieu,2.336726,48.905019,,8 Rue Mathieu,,,,93400
-48 Avenue de Livry Sevran,,,,48 Avenue de Livry,,,,93270
-48 Avenue de Livry 93270,,,,48 Avenue de Livry,,,Sevran,
-48 Avenue de Livry,2.537690,48.932286,,48 Avenue de Livry,,,,93270
-6 Avenue Jean Moulin Stains,,,,6 Avenue Jean Moulin,,,,93240
-6 Avenue Jean Moulin 93240,,,,6 Avenue Jean Moulin,,,Stains,
-6 Avenue Jean Moulin,2.392780,48.956541,,6 Avenue Jean Moulin,,,,93240
-13 Avenue Cuvier Tremblay-en-France,,,,13 Avenue Cuvier,,,,93290
-13 Avenue Cuvier 93290,,,,13 Avenue Cuvier,,,Tremblay-en-France,
-13 Avenue Cuvier,2.576959,48.959160,,13 Avenue Cuvier,,,,93290
-32BIS Rue des Vosges Tremblay-en-France,,,,32BIS Rue des Vosges,,,,93290
-32BIS Rue des Vosges 93290,,,,32BIS Rue des Vosges,,,Tremblay-en-France,
-32BIS Rue des Vosges,2.578161,48.942858,,32BIS Rue des Vosges,,,,93290
-20 Avenue Lespinasse Villemomble,,,,20 Avenue Lespinasse,,,,93250
-20 Avenue Lespinasse 93250,,,,20 Avenue Lespinasse,,,Villemomble,
-20 Avenue Lespinasse,2.517988,48.881659,,20 Avenue Lespinasse,,,,93250
-15 Rue Georges Bougault Villepinte,,,,15 Rue Georges Bougault,,,,93420
-15 Rue Georges Bougault 93420,,,,15 Rue Georges Bougault,,,Villepinte,
-15 Rue Georges Bougault,2.528761,48.968198,,15 Rue Georges Bougault,,,,93420
-4 Rue Maurice Paillard Villetaneuse,,,,4 Rue Maurice Paillard,,,,93430
-4 Rue Maurice Paillard 93430,,,,4 Rue Maurice Paillard,,,Villetaneuse,
-4 Rue Maurice Paillard,2.346720,48.955582,,4 Rue Maurice Paillard,,,,93430
-77 Rue Victor Hugo Alfortville,,,,77 Rue Victor Hugo,,,,94140
-77 Rue Victor Hugo 94140,,,,77 Rue Victor Hugo,,,Alfortville,
-77 Rue Victor Hugo,2.424299,48.803865,,77 Rue Victor Hugo,,,,94140
-8 Allée des Sources Boissy-Saint-Léger,,,,8 Allée des Sources,,,,94470
-8 Allée des Sources 94470,,,,8 Allée des Sources,,,Boissy-Saint-Léger,
-8 Allée des Sources,2.506852,48.750020,,8 Allée des Sources,,,,94470
-6 Rue Ange Rubaud Cachan,,,,6 Rue Ange Rubaud,,,,94230
-6 Rue Ange Rubaud 94230,,,,6 Rue Ange Rubaud,,,Cachan,
-6 Rue Ange Rubaud,2.331972,48.785616,,6 Rue Ange Rubaud,,,,94230
-51 Rue du Bois-l'Abbé Champigny-sur-Marne,,,,51 Rue du Bois-l'Abbé,,,,94500
-51 Rue du Bois-l'Abbé 94500,,,,51 Rue du Bois-l'Abbé,,,Champigny-sur-Marne,
-51 Rue du Bois-l'Abbé,2.542121,48.810435,,51 Rue du Bois-l'Abbé,,,,94500
-6 Villa Laversin Champigny-sur-Marne,,,,6 Villa Laversin,,,,94500
-6 Villa Laversin 94500,,,,6 Villa Laversin,,,Champigny-sur-Marne,
-6 Villa Laversin,2.505780,48.822390,,6 Villa Laversin,,,,94500
-11 Impasse des Vergers Champigny-sur-Marne,,,,11 Impasse des Vergers,,,,94500
-11 Impasse des Vergers 94500,,,,11 Impasse des Vergers,,,Champigny-sur-Marne,
-11 Impasse des Vergers,2.521424,48.813282,,11 Impasse des Vergers,,,,94500
-12 Avenue Thérèse Chennevières-sur-Marne,,,,12 Avenue Thérèse,,,,94430
-12 Avenue Thérèse 94430,,,,12 Avenue Thérèse,,,Chennevières-sur-Marne,
-12 Avenue Thérèse,2.538231,48.801484,,12 Avenue Thérèse,,,,94430
-89 Avenue du Maréchal de Lattre de Tassigny Choisy-le-Roi,,,,89 Avenue du Maréchal de Lattre de Tassigny,,,,94600
-89 Avenue du Maréchal de Lattre de Tassigny 94600,,,,89 Avenue du Maréchal de Lattre de Tassigny,,,Choisy-le-Roi,
-89 Avenue du Maréchal de Lattre de Tassigny,2.405060,48.755321,,89 Avenue du Maréchal de Lattre de Tassigny,,,,94600
-2 Avenue du Maréchal Foch Créteil,,,,2 Avenue du Maréchal Foch,,,,94000
-2 Avenue du Maréchal Foch 94000,,,,2 Avenue du Maréchal Foch,,,Créteil,
-2 Avenue du Maréchal Foch,2.440394,48.772065,,2 Avenue du Maréchal Foch,,,,94000
-5 Boulevard Henri Ruel Fontenay-sous-Bois,,,,5 Boulevard Henri Ruel,,,,94120
-5 Boulevard Henri Ruel 94120,,,,5 Boulevard Henri Ruel,,,Fontenay-sous-Bois,
-5 Boulevard Henri Ruel,2.466629,48.842771,,5 Boulevard Henri Ruel,,,,94120
-20 Rue Jules Guesde Fresnes,,,,20 Rue Jules Guesde,,,,94260
-20 Rue Jules Guesde 94260,,,,20 Rue Jules Guesde,,,Fresnes,
-20 Rue Jules Guesde,2.314301,48.760445,,20 Rue Jules Guesde,,,,94260
-9 Rue du 8 Mai 1945 L'Haÿ-les-Roses,,,,9 Rue du 8 Mai 1945,,,,94240
-9 Rue du 8 Mai 1945 94240,,,,9 Rue du 8 Mai 1945,,,L'Haÿ-les-Roses,
-9 Rue du 8 Mai 1945,2.330291,48.778614,,9 Rue du 8 Mai 1945,,,,94240
-30 Rue Pasteur Ivry-sur-Seine,,,,30 Rue Pasteur,,,,94200
-30 Rue Pasteur 94200,,,,30 Rue Pasteur,,,Ivry-sur-Seine,
-30 Rue Pasteur,2.382760,48.816849,,30 Rue Pasteur,,,,94200
-74 Rue du Général Leclerc Le Kremlin-Bicêtre,,,,74 Rue du Général Leclerc,,,,94270
-74 Rue du Général Leclerc 94270,,,,74 Rue du Général Leclerc,,,Le Kremlin-Bicêtre,
-74 Rue du Général Leclerc,2.358054,48.811095,,74 Rue du Général Leclerc,,,,94270
-42 Rue Edmond Nocard Maisons-Alfort,,,,42 Rue Edmond Nocard,,,,94700
-42 Rue Edmond Nocard 94700,,,,42 Rue Edmond Nocard,,,Maisons-Alfort,
-42 Rue Edmond Nocard,2.428785,48.812660,,42 Rue Edmond Nocard,,,,94700
-4 Rue des Perdrix Mandres-les-Roses,,,,4 Rue des Perdrix,,,,94520
-4 Rue des Perdrix 94520,,,,4 Rue des Perdrix,,,Mandres-les-Roses,
-4 Rue des Perdrix,2.558741,48.710072,,4 Rue des Perdrix,,,,94520
-8 Rue Saint-Sébastien Nogent-sur-Marne,,,,8 Rue Saint-Sébastien,,,,94130
-8 Rue Saint-Sébastien 94130,,,,8 Rue Saint-Sébastien,,,Nogent-sur-Marne,
-8 Rue Saint-Sébastien,2.485685,48.837408,,8 Rue Saint-Sébastien,,,,94130
-4 Rue de Bellevue Ormesson-sur-Marne,,,,4 Rue de Bellevue,,,,94490
-4 Rue de Bellevue 94490,,,,4 Rue de Bellevue,,,Ormesson-sur-Marne,
-4 Rue de Bellevue,2.523104,48.778971,,4 Rue de Bellevue,,,,94490
-28 Rue du Bel-Air Le Perreux-sur-Marne,,,,28 Rue du Bel-Air,,,,94170
-28 Rue du Bel-Air 94170,,,,28 Rue du Bel-Air,,,Le Perreux-sur-Marne,
-28 Rue du Bel-Air,2.498401,48.844630,,28 Rue du Bel-Air,,,,94170
-17 Rue Traversière Le Perreux-sur-Marne,,,,17 Rue Traversière,,,,94170
-17 Rue Traversière 94170,,,,17 Rue Traversière,,,Le Perreux-sur-Marne,
-17 Rue Traversière,2.510280,48.848700,,17 Rue Traversière,,,,94170
-23 Avenue Lamartine La Queue-en-Brie,,,,23 Avenue Lamartine,,,,94510
-23 Avenue Lamartine 94510,,,,23 Avenue Lamartine,,,La Queue-en-Brie,
-23 Avenue Lamartine,2.572509,48.794531,,23 Avenue Lamartine,,,,94510
-16 Rue de Beaujeu Saint-Maur-des-Fossés,,,,16 Rue de Beaujeu,,,,94100
-16 Rue de Beaujeu 94100,,,,16 Rue de Beaujeu,,,Saint-Maur-des-Fossés,
-16 Rue de Beaujeu,2.477810,48.797308,,16 Rue de Beaujeu,,,,94100
-24 Allée Ferret Briet Saint-Maur-des-Fossés,,,,24 Allée Ferret Briet,,,,94100
-24 Allée Ferret Briet 94100,,,,24 Allée Ferret Briet,,,Saint-Maur-des-Fossés,
-24 Allée Ferret Briet,2.472462,48.798063,,24 Allée Ferret Briet,,,,94100
-14 Avenue de la Mésange Saint-Maur-des-Fossés,,,,14 Avenue de la Mésange,,,,94100
-14 Avenue de la Mésange 94100,,,,14 Avenue de la Mésange,,,Saint-Maur-des-Fossés,
-14 Avenue de la Mésange,2.500070,48.801484,,14 Avenue de la Mésange,,,,94100
-43 Boulevard Voltaire Saint-Maur-des-Fossés,,,,43 Boulevard Voltaire,,,,94100
-43 Boulevard Voltaire 94100,,,,43 Boulevard Voltaire,,,Saint-Maur-des-Fossés,
-43 Boulevard Voltaire,2.508060,48.790674,,43 Boulevard Voltaire,,,,94100
-33 Sentier des Clos Sucy-en-Brie,,,,33 Sentier des Clos,,,,94370
-33 Sentier des Clos 94370,,,,33 Sentier des Clos,,,Sucy-en-Brie,
-33 Sentier des Clos,2.518731,48.767132,,33 Sentier des Clos,,,,94370
-25 Avenue Léon Marchand Thiais,,,,25 Avenue Léon Marchand,,,,94320
-25 Avenue Léon Marchand 94320,,,,25 Avenue Léon Marchand,,,Thiais,
-25 Avenue Léon Marchand,2.388859,48.766059,,25 Avenue Léon Marchand,,,,94320
-30 Rue des Mardelles Villecresnes,,,,30 Rue des Mardelles,,,,94440
-30 Rue des Mardelles 94440,,,,30 Rue des Mardelles,,,Villecresnes,
-30 Rue des Mardelles,2.525679,48.711904,,30 Rue des Mardelles,,,,94440
-73 Boulevard Maxime Gorki Villejuif,,,,73 Boulevard Maxime Gorki,,,,94800
-73 Boulevard Maxime Gorki 94800,,,,73 Boulevard Maxime Gorki,,,Villejuif,
-73 Boulevard Maxime Gorki,2.369059,48.794894,,73 Boulevard Maxime Gorki,,,,94800
-2 Place Louis Jacquart Villeneuve-le-Roi,,,,2 Place Louis Jacquart,,,,94290
-2 Place Louis Jacquart 94290,,,,2 Place Louis Jacquart,,,Villeneuve-le-Roi,
-2 Place Louis Jacquart,2.416746,48.734077,,2 Place Louis Jacquart,,,,94290
-3 Rue Jacquard Villeneuve-Saint-Georges,,,,3 Rue Jacquard,,,,94190
-3 Rue Jacquard 94190,,,,3 Rue Jacquard,,,Villeneuve-Saint-Georges,
-3 Rue Jacquard,2.447333,48.746102,,3 Rue Jacquard,,,,94190
-24 Rue J J Rousseau Villiers-sur-Marne,,,,24 Rue Jean-Jacques Rousseau,,,,94350
-24 Rue J J Rousseau 94350,,,,24 Rue Jean-Jacques Rousseau,,,Villiers-sur-Marne,
-24 Rue J J Rousseau,2.533222,48.820029,,24 Rue Jean-Jacques Rousseau,,,,94350
-47 Rue de la Prévoyance Vincennes,,,,47 Rue de la Prévoyance,,,,94300
-47 Rue de la Prévoyance 94300,,,,47 Rue de la Prévoyance,,,Vincennes,
-47 Rue de la Prévoyance,2.420582,48.848496,,47 Rue de la Prévoyance,,,,94300
-32 Avenue Eugène Pelletan Vitry-sur-Seine,,,,32 Avenue Eugène Pelletan,,,,94400
-32 Avenue Eugène Pelletan 94400,,,,32 Avenue Eugène Pelletan,,,Vitry-sur-Seine,
-32 Avenue Eugène Pelletan,2.385079,48.794448,,32 Avenue Eugène Pelletan,,,,94400
-25 Avenue Pierre Brossolette Vitry-sur-Seine,,,,25 Avenue Pierre Brossolette,,,,94400
-25 Avenue Pierre Brossolette 94400,,,,25 Avenue Pierre Brossolette,,,Vitry-sur-Seine,
-25 Avenue Pierre Brossolette,2.403031,48.803379,,25 Avenue Pierre Brossolette,,,,94400
-13 Rue du Docteur Roux Argenteuil,,,,13 Rue du Docteur Roux,,,,95100
-13 Rue du Docteur Roux 95100,,,,13 Rue du Docteur Roux,,,Argenteuil,
-13 Rue du Docteur Roux,2.227171,48.942175,,13 Rue du Docteur Roux,,,,95100
-28 Rue de la Luitte Argenteuil,,,,28 Rue de la Luitte,,,,95100
-28 Rue de la Luitte 95100,,,,28 Rue de la Luitte,,,Argenteuil,
-28 Rue de la Luitte,2.277504,48.959994,,28 Rue de la Luitte,,,,95100
-6 Rue de la Rosière Argenteuil,,,,6 Rue de la Rosière,,,,95100
-6 Rue de la Rosière 95100,,,,6 Rue de la Rosière,,,Argenteuil,
-6 Rue de la Rosière,2.236446,48.961134,,6 Rue de la Rosière,,,,95100
-12 Rue Schmitz Auvers-sur-Oise,,,,12 Rue Schmitz,,,,95430
-12 Rue Schmitz 95430,,,,12 Rue Schmitz,,,Auvers-sur-Oise,
-12 Rue Schmitz,2.126431,49.066041,,12 Rue Schmitz,,,,95430
-2 Rue du Maréchal Foch Bezons,,,,2 Rue du Maréchal Foch,,,,95870
-2 Rue du Maréchal Foch 95870,,,,2 Rue du Maréchal Foch,,,Bezons,
-2 Rue du Maréchal Foch,2.205703,48.928269,,2 Rue du Maréchal Foch,,,,95870
-34 Rue des Heuruelles Pourpres Cergy,,,,34 Rue des Heuruelles Pourpres,,,,95000
-34 Rue des Heuruelles Pourpres 95000,,,,34 Rue des Heuruelles Pourpres,,,Cergy,
-34 Rue des Heuruelles Pourpres,2.056722,49.046782,,34 Rue des Heuruelles Pourpres,,,,95000
-36 Rue des Brûlis Chaumontel,,,,36 Rue des Brûlis,,,,95270
-36 Rue des Brûlis 95270,,,,36 Rue des Brûlis,,,Chaumontel,
-36 Rue des Brûlis,2.435961,49.123668,,36 Rue des Brûlis,,,,95270
-1 Rue Jonas Deuil-la-Barre,,,,1 Rue Jonas,,,,95170
-1 Rue Jonas 95170,,,,1 Rue Jonas,,,Deuil-la-Barre,
-1 Rue Jonas,2.325579,48.963833,,1 Rue Jonas,,,,95170
-11 Avenue de l'Alliance Eaubonne,,,,11 Avenue de l'Alliance,,,,95600
-11 Avenue de l'Alliance 95600,,,,11 Avenue de l'Alliance,,,Eaubonne,
-11 Avenue de l'Alliance,2.288625,48.978438,,11 Avenue de l'Alliance,,,,95600
-8BIS Boulevard Cotte Enghien-les-Bains,,,,8BIS Boulevard Cotte,,,,95880
-8BIS Boulevard Cotte 95880,,,,8BIS Boulevard Cotte,,,Enghien-les-Bains,
-8BIS Boulevard Cotte,2.307069,48.967950,,8BIS Boulevard Cotte,,,,95880
-3 Rue Constant Coquelin Ermont,,,,3 Rue Constant Coquelin,,,,95120
-3 Rue Constant Coquelin 95120,,,,3 Rue Constant Coquelin,,,Ermont,
-3 Rue Constant Coquelin,2.252361,49.000971,,3 Rue Constant Coquelin,,,,95120
-7 Allée Paul Cézanne Ézanville,,,,7 Allée Paul Cézanne,,,,95460
-7 Allée Paul Cézanne 95460,,,,7 Allée Paul Cézanne,,,Ézanville,
-7 Allée Paul Cézanne,2.341404,49.037278,,7 Allée Paul Cézanne,,,,95460
-15 Allée des Érables Franconville,,,,15 Allée des Érables,,,,95130
-15 Allée des Érables 95130,,,,15 Allée des Érables,,,Franconville,
-15 Allée des Érables,2.213699,48.988501,,15 Allée des Érables,,,,95130
-15 Rue Pasteur Garges-lès-Gonesse,,,,15 Rue Pasteur,,,,95140
-15 Rue Pasteur 95140,,,,15 Rue Pasteur,,,Garges-lès-Gonesse,
-15 Rue Pasteur,2.398733,48.961269,,15 Rue Pasteur,,,,95140
-23 Rue Armand Carrel Goussainville,,,,23 Rue Armand Carrel,,,,95190
-23 Rue Armand Carrel 95190,,,,23 Rue Armand Carrel,,,Goussainville,
-23 Rue Armand Carrel,2.480700,49.032815,,23 Rue Armand Carrel,,,,95190
-9 Rue des Pensées Goussainville,,,,9 Rue des Pensées,,,,95190
-9 Rue des Pensées 95190,,,,9 Rue des Pensées,,,Goussainville,
-9 Rue des Pensées,2.470030,49.026778,,9 Rue des Pensées,,,,95190
-21 Avenue de la Chesnaie Herblay,,,,21 Avenue de la Chesnaie,,,,95220
-21 Avenue de la Chesnaie 95220,,,,21 Avenue de la Chesnaie,,,Herblay,
-21 Avenue de la Chesnaie,2.158023,49.000849,,21 Avenue de la Chesnaie,,,,95220
-2 Place du Truffier Herblay,,,,2 Place du Truffier,,,,95220
-2 Place du Truffier 95220,,,,2 Place du Truffier,,,Herblay,
-2 Place du Truffier,2.154336,49.002014,,2 Place du Truffier,,,,95220
-9 Place de la Hayette Jouy-le-Moutier,,,,9 Place de la Hayette,,,,95280
-9 Place de la Hayette 95280,,,,9 Place de la Hayette,,,Jouy-le-Moutier,
-9 Place de la Hayette,2.038193,49.007774,,9 Place de la Hayette,,,,95280
-8 Allée du Pré Aux Cerfs Luzarches,,,,8 Allée du Pré aux Cerfs,,,,95270
-8 Allée du Pré Aux Cerfs 95270,,,,8 Allée du Pré aux Cerfs,,,Luzarches,
-8 Allée du Pré Aux Cerfs,2.419913,49.119635,,8 Allée du Pré aux Cerfs,,,,95270
-63 Avenue Joliot Curie Mériel,,,,63 Avenue Joliot Curie,,,,95630
-63 Avenue Joliot Curie 95630,,,,63 Avenue Joliot Curie,,,Mériel,
-63 Avenue Joliot Curie,2.218536,49.073935,,63 Avenue Joliot Curie,,,,95630
-20 Chemin du Clos Prie Montmagny,,,,20 Chemin du Clos Prie,,,,95360
-20 Chemin du Clos Prie 95360,,,,20 Chemin du Clos Prie,,,Montmagny,
-20 Chemin du Clos Prie,2.358622,48.975244,,20 Chemin du Clos Prie,,,,95360
-65 Rue de la République Montmorency,,,,65 Rue de la République,,,,95160
-65 Rue de la République 95160,,,,65 Rue de la République,,,Montmorency,
-65 Rue de la République,2.309600,48.979099,,65 Rue de la République,,,,95160
-10 Rue des Voltigeurs Osny,,,,10 Rue des Voltigeurs,,,,95520
-10 Rue des Voltigeurs 95520,,,,10 Rue des Voltigeurs,,,Osny,
-10 Rue des Voltigeurs,2.069673,49.068445,,10 Rue des Voltigeurs,,,,95520
-54 Rue des Etannets Pontoise,,,,54 Rue des Etannets,,,,95000
-54 Rue des Etannets 95000,,,,54 Rue des Etannets,,,Pontoise,
-54 Rue des Etannets,2.090192,49.050837,,54 Rue des Etannets,,,,95000
-29 Avenue Lacour Saint-Gratien,,,,29 Avenue Lacour,,,,95210
-29 Avenue Lacour 95210,,,,29 Avenue Lacour,,,Saint-Gratien,
-29 Avenue Lacour,2.286127,48.973875,,29 Avenue Lacour,,,,95210
-4 Allée de la Paix Saint-Leu-la-Forêt,,,,4 Allée de la Paix,,,,95320
-4 Allée de la Paix 95320,,,,4 Allée de la Paix,,,Saint-Leu-la-Forêt,
-4 Allée de la Paix,2.238786,49.019158,,4 Allée de la Paix,,,,95320
-47 Rue d'Ermont Saint-Prix,,,,47 Rue d'Ermont,,,,95390
-47 Rue d'Ermont 95390,,,,47 Rue d'Ermont,,,Saint-Prix,
-47 Rue d'Ermont,2.261729,49.006435,,47 Rue d'Ermont,,,,95390
-79 Rue du Maréchal Joffre Sannois,,,,79 Rue du Maréchal Joffre,,,,95110
-79 Rue du Maréchal Joffre 95110,,,,79 Rue du Maréchal Joffre,,,Sannois,
-79 Rue du Maréchal Joffre,2.263790,48.974390,,79 Rue du Maréchal Joffre,,,,95110
-21BIS Rue des Saules Soisy-sous-Montmorency,,,,21BIS Rue des Saules,,,,95230
-21BIS Rue des Saules 95230,,,,21BIS Rue des Saules,,,Soisy-sous-Montmorency,
-21BIS Rue des Saules,2.310314,48.991199,,21BIS Rue des Saules,,,,95230
-45 Chemin des Petits Sentiers Taverny,,,,45 Chemin des Petits Sentiers,,,,95150
-45 Chemin des Petits Sentiers 95150,,,,45 Chemin des Petits Sentiers,,,Taverny,
-45 Chemin des Petits Sentiers,2.222019,49.017998,,45 Chemin des Petits Sentiers,,,,95150
-28 Rue Messidor Vauréal,,,,28 Rue Messidor,,,,95490
-28 Rue Messidor 95490,,,,28 Rue Messidor,,,Vauréal,
-28 Rue Messidor,2.013060,49.028342,,28 Rue Messidor,,,,95490
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+34 Avenue de l'Opéra Paris,,,,34,Avenue de l'Opéra,,75002
+34 Avenue de l'Opéra 75002,,,,34,Avenue de l'Opéra,Paris,
+34 Avenue de l'Opéra,2.33337,48.868659,,34,Avenue de l'Opéra,,75002
+19B Rue des Deux Ponts Paris,,,,19B,Rue des Deux Ponts,,75004
+19B Rue des Deux Ponts 75004,,,,19B,Rue des Deux Ponts,Paris,
+19B Rue des Deux Ponts,2.356355,48.851728,,19B,Rue des Deux Ponts,,75004
+25 Quai de Montebello Paris,,,,25,Quai de Montebello,,75005
+25 Quai de Montebello 75005,,,,25,Quai de Montebello,Paris,
+25 Quai de Montebello,2.347712,48.852487,,25,Quai de Montebello,,75005
+7T Rue Servandoni Paris,,,,7T,Rue Servandoni,,75006
+7T Rue Servandoni 75006,,,,7T,Rue Servandoni,Paris,
+7T Rue Servandoni,2.334795,48.850291,,7T,Rue Servandoni,,75006
+29 Rue de Bassano Paris,,,,29,Rue de Bassano,,75008
+29 Rue de Bassano 75008,,,,29,Rue de Bassano,Paris,
+29 Rue de Bassano,2.298874,48.87042,,29,Rue de Bassano,,75008
+104 Rue Blanche Paris,,,,104,Rue Blanche,,75009
+104 Rue Blanche 75009,,,,104,Rue Blanche,Paris,
+104 Rue Blanche,2.332395,48.883345,,104,Rue Blanche,,75009
+15 Rue du Buisson Saint-Louis Paris,,,,15,Rue du Buisson Saint-Louis,,75010
+15 Rue du Buisson Saint-Louis 75010,,,,15,Rue du Buisson Saint-Louis,Paris,
+15 Rue du Buisson Saint-Louis,2.3735,48.872447,,15,Rue du Buisson Saint-Louis,,75010
+39 Rue des Boulets Paris,,,,39,Rue des Boulets,,75011
+39 Rue des Boulets 75011,,,,39,Rue des Boulets,Paris,
+39 Rue des Boulets,2.389308,48.85171,,39,Rue des Boulets,,75011
+41 Avenue de la République Paris,,,,41,Avenue de la République,,75011
+41 Avenue de la République 75011,,,,41,Avenue de la République,Paris,
+41 Avenue de la République,2.374896,48.865338,,41,Avenue de la République,,75011
+91 Avenue Daumesnil Paris,,,,91,Avenue Daumesnil,,75012
+91 Avenue Daumesnil 75012,,,,91,Avenue Daumesnil,Paris,
+91 Avenue Daumesnil,2.379139,48.845647,,91,Avenue Daumesnil,,75012
+54 Avenue des Terroirs de France Paris,,,,54,Avenue des Terroirs de France,,75012
+54 Avenue des Terroirs de France 75012,,,,54,Avenue des Terroirs de France,Paris,
+54 Avenue des Terroirs de France,2.389139,48.832148,,54,Avenue des Terroirs de France,,75012
+11 Rue de l'Espérance Paris,,,,11,Rue de l'Espérance,,75013
+11 Rue de l'Espérance 75013,,,,11,Rue de l'Espérance,Paris,
+11 Rue de l'Espérance,2.348655,48.827233,,11,Rue de l'Espérance,,75013
+31 Rue Primo Levi Paris,,,,31,Rue Primo Levi,,75013
+31 Rue Primo Levi 75013,,,,31,Rue Primo Levi,Paris,
+31 Rue Primo Levi,2.377597,48.830024,,31,Rue Primo Levi,,75013
+9 Rue du Couédic Paris,,,,9,Rue du Couédic,,75014
+9 Rue du Couédic 75014,,,,9,Rue du Couédic,Paris,
+9 Rue du Couédic,2.333423,48.830178,,9,Rue du Couédic,,75014
+64 Rue de la Santé Paris,,,,64,Rue de la Santé,,75014
+64 Rue de la Santé 75014,,,,64,Rue de la Santé,Paris,
+64 Rue de la Santé,2.341136,48.830622,,64,Rue de la Santé,,75014
+35 Rue Duranton Paris,,,,35,Rue Duranton,,75015
+35 Rue Duranton 75015,,,,35,Rue Duranton,Paris,
+35 Rue Duranton,2.288023,48.839117,,35,Rue Duranton,,75015
+1 Rue Mathurin Régnier Paris,,,,1,Rue Mathurin Régnier,,75015
+1 Rue Mathurin Régnier 75015,,,,1,Rue Mathurin Régnier,Paris,
+1 Rue Mathurin Régnier,2.306889,48.840943,,1,Rue Mathurin Régnier,,75015
+49 Rue Boileau Paris,,,,49,Rue Boileau,,75016
+49 Rue Boileau 75016,,,,49,Rue Boileau,Paris,
+49 Rue Boileau,2.263469,48.843767,,49,Rue Boileau,,75016
+3 Place Léon Deubel Paris,,,,3,Place Léon Deubel,,75016
+3 Place Léon Deubel 75016,,,,3,Place Léon Deubel,Paris,
+3 Place Léon Deubel,2.259248,48.837899,,3,Place Léon Deubel,,75016
+31 Avenue de Versailles Paris,,,,31,Avenue de Versailles,,75016
+31 Avenue de Versailles 75016,,,,31,Avenue de Versailles,Paris,
+31 Avenue de Versailles,2.276102,48.849519,,31,Avenue de Versailles,,75016
+7 Rue Gustave Doré Paris,,,,7,Rue Gustave Doré,,75017
+7 Rue Gustave Doré 75017,,,,7,Rue Gustave Doré,Paris,
+7 Rue Gustave Doré,2.302565,48.88648,,7,Rue Gustave Doré,,75017
+12 Rue Vernier Paris,,,,12,Rue Vernier,,75017
+12 Rue Vernier 75017,,,,12,Rue Vernier,Paris,
+12 Rue Vernier,2.290906,48.883356,,12,Rue Vernier,,75017
+57 Rue de la Goutte d'Or Paris,,,,57,Rue de la Goutte d'Or,,75018
+57 Rue de la Goutte d'Or 75018,,,,57,Rue de la Goutte d'Or,Paris,
+57 Rue de la Goutte d'Or,2.350989,48.885028,,57,Rue de la Goutte d'Or,,75018
+80 Avenue de Saint-Ouen Paris,,,,80,Avenue de Saint-Ouen,,75018
+80 Avenue de Saint-Ouen 75018,,,,80,Avenue de Saint-Ouen,Paris,
+80 Avenue de Saint-Ouen,2.327333,48.892222,,80,Avenue de Saint-Ouen,,75018
+10 Rue du Général Brunet Paris,,,,10,Rue du Général Brunet,,75019
+10 Rue du Général Brunet 75019,,,,10,Rue du Général Brunet,Paris,
+10 Rue du Général Brunet,2.390874,48.880406,,10,Rue du Général Brunet,,75019
+18 Rue Suzanne Masson Paris,,,,18,Rue Suzanne Masson,,75019
+18 Rue Suzanne Masson 75019,,,,18,Rue Suzanne Masson,Paris,
+18 Rue Suzanne Masson,2.371374,48.888577,,18,Rue Suzanne Masson,,75019
+100 Rue des Haies Paris,,,,100,Rue des Haies,,75020
+100 Rue des Haies 75020,,,,100,Rue des Haies,Paris,
+100 Rue des Haies,2.404295,48.855644,,100,Rue des Haies,,75020
+4 Rue du Repos Paris,,,,4,Rue du Repos,,75020
+4 Rue du Repos 75020,,,,4,Rue du Repos,Paris,
+4 Rue du Repos,2.391937,48.85815,,4,Rue du Repos,,75020
+28 Rue de la Belle Marie Barbizon,,,,28,Rue de la Belle Marie,,77630
+28 Rue de la Belle Marie 77630,,,,28,Rue de la Belle Marie,Barbizon,
+28 Rue de la Belle Marie,2.601323,48.439768,,28,Rue de la Belle Marie,,77630
+3 Rue du Centre Boissy-le-Châtel,,,,3,Rue du Centre,,77169
+3 Rue du Centre 77169,,,,3,Rue du Centre,Boissy-le-Châtel,
+3 Rue du Centre,3.136898,48.821008,,3,Rue du Centre,,77169
+11 Rue de la Grenouillère Brie-Comte-Robert,,,,11,Rue de la Grenouillère,,77170
+11 Rue de la Grenouillère 77170,,,,11,Rue de la Grenouillère,Brie-Comte-Robert,
+11 Rue de la Grenouillère,2.611226,48.690539,,11,Rue de la Grenouillère,,77170
+25 Promenade des Golfeurs Bussy-Saint-Georges,,,,25,Promenade des Golfeurs,,77600
+25 Promenade des Golfeurs 77600,,,,25,Promenade des Golfeurs,Bussy-Saint-Georges,
+25 Promenade des Golfeurs,2.709096,48.848578,,25,Promenade des Golfeurs,,77600
+58 Rue des Epis d'Or Cerneux,,,,58,Rue des Épis d'Or,,77320
+58 Rue des Epis d'Or 77320,,,,58,Rue des Épis d'Or,Cerneux,
+58 Rue des Epis d'Or,3.351117,48.698393,,58,Rue des Épis d'Or,,77320
+96 Rue des Moulins Chalautre-la-Petite,,,,96,Rue des Moulins,,77160
+96 Rue des Moulins 77160,,,,96,Rue des Moulins,Chalautre-la-Petite,
+96 Rue des Moulins,3.31252,48.52917,,96,Rue des Moulins,,77160
+16 Rue Jean Moulin Champs-sur-Marne,,,,16,Rue Jean Moulin,,77420
+16 Rue Jean Moulin 77420,,,,16,Rue Jean Moulin,Champs-sur-Marne,
+16 Rue Jean Moulin,2.607726,48.850439,,16,Rue Jean Moulin,,77420
+25 Rue Aristide Briand Chartrettes,,,,25,Rue Aristide Briand,,77590
+25 Rue Aristide Briand 77590,,,,25,Rue Aristide Briand,Chartrettes,
+25 Rue Aristide Briand,2.694857,48.490361,,25,Rue Aristide Briand,,77590
+29BIS Avenue des Abbesses Chelles,,,,29BIS,Avenue des Abbesses,,77500
+29BIS Avenue des Abbesses 77500,,,,29BIS,Avenue des Abbesses,Chelles,
+29BIS Avenue des Abbesses,2.578605,48.87523,,29BIS,Avenue des Abbesses,,77500
+1 Allée des Geais Chelles,,,,1,Allée des Geais,,77500
+1 Allée des Geais 77500,,,,1,Allée des Geais,Chelles,
+1 Allée des Geais,2.601246,48.886763,,1,Allée des Geais,,77500
+1 Rue du Rêve Chelles,,,,1,Rue du Rêve,,77500
+1 Rue du Rêve 77500,,,,1,Rue du Rêve,Chelles,
+1 Rue du Rêve,2.604386,48.879869,,1,Rue du Rêve,,77500
+6 Rue Romy Schneider Chevry-Cossigny,,,,6,Rue Romy Schneider,,77173
+6 Rue Romy Schneider 77173,,,,6,Rue Romy Schneider,Chevry-Cossigny,
+6 Rue Romy Schneider,2.66132,48.726746,,6,Rue Romy Schneider,,77173
+14 Rue des Brisaciers Collégien,,,,14,Rue des Brisaciers,,77090
+14 Rue des Brisaciers 77090,,,,14,Rue des Brisaciers,Collégien,
+14 Rue des Brisaciers,2.676648,48.836407,,14,Rue des Brisaciers,,77090
+13 Allée des Rouges Gorges Combs-la-Ville,,,,13,Allée des Rouges Gorges,,77380
+13 Allée des Rouges Gorges 77380,,,,13,Allée des Rouges Gorges,Combs-la-Ville,
+13 Allée des Rouges Gorges,2.562337,48.660754,,13,Allée des Rouges Gorges,,77380
+5 Place du Marché Coulommiers,,,,5,Place du Marché,,77120
+5 Place du Marché 77120,,,,5,Place du Marché,Coulommiers,
+5 Place du Marché,3.083966,48.814277,,5,Place du Marché,,77120
+5 Allée de la Résidence du Cavoy Courtry,,,,5,Allée de la Résidence du Cavoy,,77181
+5 Allée de la Résidence du Cavoy 77181,,,,5,Allée de la Résidence du Cavoy,Courtry,
+5 Allée de la Résidence du Cavoy,2.596807,48.912661,,5,Allée de la Résidence du Cavoy,,77181
+388D Avenue Émile Zola Dammarie-les-Lys,,,,388D,Avenue Émile Zola,,77190
+388D Avenue Émile Zola 77190,,,,388D,Avenue Émile Zola,Dammarie-les-Lys,
+388D Avenue Émile Zola,2.642424,48.517265,,388D,Avenue Émile Zola,,77190
+12 Allée Saint-Rémy Dammartin-en-Goële,,,,12,Allée Saint-Rémy,,77230
+12 Allée Saint-Rémy 77230,,,,12,Allée Saint-Rémy,Dammartin-en-Goële,
+12 Allée Saint-Rémy,2.69144,49.053944,,12,Allée Saint-Rémy,,77230
+59 Avenue de l'Europe Émerainville,,,,59,Avenue de l'Europe,,77184
+59 Avenue de l'Europe 77184,,,,59,Avenue de l'Europe,Émerainville,
+59 Avenue de l'Europe,2.603183,48.829959,,59,Avenue de l'Europe,,77184
+36 Rue Robert Legraverend La Ferté-Gaucher,,,,36,Rue Robert Legraverend,,77320
+36 Rue Robert Legraverend 77320,,,,36,Rue Robert Legraverend,La Ferté-Gaucher,
+36 Rue Robert Legraverend,3.304499,48.786881,,36,Rue Robert Legraverend,,77320
+9 Rue de Fleury Fontainebleau,,,,9,Rue de Fleury,,77300
+9 Rue de Fleury 77300,,,,9,Rue de Fleury,Fontainebleau,
+9 Rue de Fleury,2.694572,48.40483,,9,Rue de Fleury,,77300
+418 Rue du Général de Gaulle Fouju,,,,418,Rue du Général de Gaulle,,77390
+418 Rue du Général de Gaulle 77390,,,,418,Rue du Général de Gaulle,Fouju,
+418 Rue du Général de Gaulle,2.77699,48.584491,,418,Rue du Général de Gaulle,,77390
+19 Avenue du Parc Gretz-Armainvilliers,,,,19,Avenue du Parc,,77220
+19 Avenue du Parc 77220,,,,19,Avenue du Parc,Gretz-Armainvilliers,
+19 Avenue du Parc,2.712342,48.738898,,19,Avenue du Parc,,77220
+1 Rue de la Fontaine du Sault Héricy,,,,1,Rue de la Fontaine du Sault,,77850
+1 Rue de la Fontaine du Sault 77850,,,,1,Rue de la Fontaine du Sault,Héricy,
+1 Rue de la Fontaine du Sault,2.766645,48.449632,,1,Rue de la Fontaine du Sault,,77850
+14 Ruelle du Moulin Brûlé Jouy-sur-Morin,,,,14,Ruelle du Moulin Brûlé,,77320
+14 Ruelle du Moulin Brûlé 77320,,,,14,Ruelle du Moulin Brûlé,Jouy-sur-Morin,
+14 Ruelle du Moulin Brûlé,3.283984,48.79496,,14,Ruelle du Moulin Brûlé,,77320
+27 Sentier Petite Sente Verte Lagny-sur-Marne,,,,27,Sentier Petite Sente Verte,,77400
+27 Sentier Petite Sente Verte 77400,,,,27,Sentier Petite Sente Verte,Lagny-sur-Marne,
+27 Sentier Petite Sente Verte,2.696427,48.869306,,27,Sentier Petite Sente Verte,,77400
+59 Rue du Colombier Lieusaint,,,,59,Rue du Colombier,,77127
+59 Rue du Colombier 77127,,,,59,Rue du Colombier,Lieusaint,
+59 Rue du Colombier,2.545728,48.63198,,59,Rue du Colombier,,77127
+2 Boulevard du Mandinet Lognes,,,,2,Boulevard du Mandinet,,77185
+2 Boulevard du Mandinet 77185,,,,2,Boulevard du Mandinet,Lognes,
+2 Boulevard du Mandinet,2.633376,48.834116,,2,Boulevard du Mandinet,,77185
+8 Rue du Pavé du Roy Maison-Rouge,,,,8,Rue du Pavé du Roy,,77370
+8 Rue du Pavé du Roy 77370,,,,8,Rue du Pavé du Roy,Maison-Rouge,
+8 Rue du Pavé du Roy,3.151995,48.559041,,8,Rue du Pavé du Roy,,77370
+41 Allée des Colibris Meaux,,,,41,Allée des Colibris,,77100
+41 Allée des Colibris 77100,,,,41,Allée des Colibris,Meaux,
+41 Allée des Colibris,2.897398,48.952428,,41,Allée des Colibris,,77100
+5 Impasse du Sabot Meaux,,,,5,Impasse du Sabot,,77100
+5 Impasse du Sabot 77100,,,,5,Impasse du Sabot,Meaux,
+5 Impasse du Sabot,2.877052,48.969322,,5,Impasse du Sabot,,77100
+15BIS Rue de l'Écluse Melun,,,,15BIS,Rue de l'Écluse,,77000
+15BIS Rue de l'Écluse 77000,,,,15BIS,Rue de l'Écluse,Melun,
+15BIS Rue de l'Écluse,2.649881,48.534508,,15BIS,Rue de l'Écluse,,77000
+6 Rue Camille Desmoulins Mitry-Mory,,,,6,Rue Camille Desmoulins,,77290
+6 Rue Camille Desmoulins 77290,,,,6,Rue Camille Desmoulins,Mitry-Mory,
+6 Rue Camille Desmoulins,2.585772,48.96321,,6,Rue Camille Desmoulins,,77290
+23 Impasse du Cuché Moisenay,,,,23,Impasse du Cuché,,77950
+23 Impasse du Cuché 77950,,,,23,Impasse du Cuché,Moisenay,
+23 Impasse du Cuché,2.742529,48.56215,,23,Impasse du Cuché,,77950
+11TER Rue des Joncs Montereau-sur-le-Jard,,,,11TER,Rue des Joncs,,77950
+11TER Rue des Joncs 77950,,,,11TER,Rue des Joncs,Montereau-sur-le-Jard,
+11TER Rue des Joncs,2.687637,48.596864,,11TER,Rue des Joncs,,77950
+6 Rue Turgot Montry,,,,6,Rue Turgot,,77450
+6 Rue Turgot 77450,,,,6,Rue Turgot,Montry,
+6 Rue Turgot,2.834731,48.886887,,6,Rue Turgot,,77450
+68 Rue du Pont de l'Amour Mouroux,,,,68,Rue du Pont de l'Amour,,77120
+68 Rue du Pont de l'Amour 77120,,,,68,Rue du Pont de l'Amour,Mouroux,
+68 Rue du Pont de l'Amour,3.05125,48.812266,,68,Rue du Pont de l'Amour,,77120
+1 Place de Violaine Nanteuil-sur-Marne,,,,1,Place de Violaine,,77730
+1 Place de Violaine 77730,,,,1,Place de Violaine,Nanteuil-sur-Marne,
+1 Place de Violaine,3.219987,48.97866,,1,Place de Violaine,,77730
+21 Rue Alphonse Allais Ozoir-la-Ferrière,,,,21,Rue Alphonse Allais,,77330
+21 Rue Alphonse Allais 77330,,,,21,Rue Alphonse Allais,Ozoir-la-Ferrière,
+21 Rue Alphonse Allais,2.678021,48.764851,,21,Rue Alphonse Allais,,77330
+38 Rue Salvadore Allende Ozoir-la-Ferrière,,,,38,Rue Salvador Allende,,77330
+38 Rue Salvadore Allende 77330,,,,38,Rue Salvador Allende,Ozoir-la-Ferrière,
+38 Rue Salvadore Allende,2.664067,48.761201,,38,Rue Salvador Allende,,77330
+70 Rue des Chênes Pomponne,,,,70,Rue des Chênes,,77400
+70 Rue des Chênes 77400,,,,70,Rue des Chênes,Pomponne,
+70 Rue des Chênes,2.692666,48.884409,,70,Rue des Chênes,,77400
+12 Rue Jean Charcot Pontault-Combault,,,,12,Rue Jean Charcot,,77340
+12 Rue Jean Charcot 77340,,,,12,Rue Jean Charcot,Pontault-Combault,
+12 Rue Jean Charcot,2.615703,48.788818,,12,Rue Jean Charcot,,77340
+121 Avenue de Fontainebleau Pringy,,,,121,Avenue de Fontainebleau,,77310
+121 Avenue de Fontainebleau 77310,,,,121,Avenue de Fontainebleau,Pringy,
+121 Avenue de Fontainebleau,2.563317,48.519226,,121,Avenue de Fontainebleau,,77310
+226 Avenue Foch Quincy-Voisins,,,,226,Avenue Foch,,77860
+226 Avenue Foch 77860,,,,226,Avenue Foch,Quincy-Voisins,
+226 Avenue Foch,2.879693,48.903778,,226,Avenue Foch,,77860
+1 Rue Dian Fossey Roissy-en-Brie,,,,1,Rue Dian Fossey,,77680
+1 Rue Dian Fossey 77680,,,,1,Rue Dian Fossey,Roissy-en-Brie,
+1 Rue Dian Fossey,2.636304,48.802602,,1,Rue Dian Fossey,,77680
+10 Chemin des Marêts Rupéreux,,,,10,Chemin des Marêts,,77560
+10 Chemin des Marêts 77560,,,,10,Chemin des Marêts,Rupéreux,
+10 Chemin des Marêts,3.328342,48.63786,,10,Chemin des Marêts,,77560
+27 Allée des Fougères Saint-Fargeau-Ponthierry,,,,27,Allée des Fougères,,77310
+27 Allée des Fougères 77310,,,,27,Allée des Fougères,Saint-Fargeau-Ponthierry,
+27 Allée des Fougères,2.52783,48.568169,,27,Allée des Fougères,,77310
+11 Chemin du Château Saint-Mard,,,,11,Chemin du Château,,77230
+11 Chemin du Château 77230,,,,11,Chemin du Château,Saint-Mard,
+11 Chemin du Château,2.686862,49.035977,,11,Chemin du Château,,77230
+20 Rue du Buat Saint-Soupplets,,,,20,Rue du Buat,,77165
+20 Rue du Buat 77165,,,,20,Rue du Buat,Saint-Soupplets,
+20 Rue du Buat,2.805044,49.036803,,20,Rue du Buat,,77165
+3 Rue du Nord Savigny-le-Temple,,,,3,Rue du Nord,,77176
+3 Rue du Nord 77176,,,,3,Rue du Nord,Savigny-le-Temple,
+3 Rue du Nord,2.57803,48.576265,,3,Rue du Nord,,77176
+9 Place des Tilleuls Savigny-le-Temple,,,,9,Place des Tilleuls,,77176
+9 Place des Tilleuls 77176,,,,9,Place des Tilleuls,Savigny-le-Temple,
+9 Place des Tilleuls,2.554402,48.603569,,9,Place des Tilleuls,,77176
+19 Rue des Étards Solers,,,,19,Rue des Étards,,77111
+19 Rue des Étards 77111,,,,19,Rue des Étards,Solers,
+19 Rue des Étards,2.723154,48.658812,,19,Rue des Étards,,77111
+3BIS Rue Jeanne d'Arc Thorigny-sur-Marne,,,,3BIS,Rue Jeanne d'Arc,,77400
+3BIS Rue Jeanne d'Arc 77400,,,,3BIS,Rue Jeanne d'Arc,Thorigny-sur-Marne,
+3BIS Rue Jeanne d'Arc,2.705756,48.885759,,3BIS,Rue Jeanne d'Arc,,77400
+3 Rue du Martray Tournan-en-Brie,,,,3,Rue du Martray,,77220
+3 Rue du Martray 77220,,,,3,Rue du Martray,Tournan-en-Brie,
+3 Rue du Martray,2.768281,48.739259,,3,Rue du Martray,,77220
+11 Avenue Jean Jaurès Vaires-sur-Marne,,,,11,Avenue Jean Jaurès,,77360
+11 Avenue Jean Jaurès 77360,,,,11,Avenue Jean Jaurès,Vaires-sur-Marne,
+11 Avenue Jean Jaurès,2.638424,48.874141,,11,Avenue Jean Jaurès,,77360
+13 Rue du Grand Pressoir Vaux-le-Pénil,,,,13,Rue du Grand Pressoir,,77000
+13 Rue du Grand Pressoir 77000,,,,13,Rue du Grand Pressoir,Vaux-le-Pénil,
+13 Rue du Grand Pressoir,2.678439,48.527469,,13,Rue du Grand Pressoir,,77000
+1 Rue de la Madeleine Vert-Saint-Denis,,,,1,Rue de la Madeleine,,77240
+1 Rue de la Madeleine 77240,,,,1,Rue de la Madeleine,Vert-Saint-Denis,
+1 Rue de la Madeleine,2.653626,48.570361,,1,Rue de la Madeleine,,77240
+27 Rue René Lefebvre Villiers-sous-Grez,,,,27,Rue René Lefebvre,,77760
+27 Rue René Lefebvre 77760,,,,27,Rue René Lefebvre,Villiers-sous-Grez,
+27 Rue René Lefebvre,2.649723,48.320311,,27,Rue René Lefebvre,,77760
+1 Rue du Général Schweisguth Andrésy,,,,1,Rue du Général Schweisguth,,78570
+1 Rue du Général Schweisguth 78570,,,,1,Rue du Général Schweisguth,Andrésy,
+1 Rue du Général Schweisguth,2.070849,48.990886,,1,Rue du Général Schweisguth,,78570
+13 Rue de Maule Bazemont,,,,13,Rue de Maule,,78580
+13 Rue de Maule 78580,,,,13,Rue de Maule,Bazemont,
+13 Rue de Maule,1.867066,48.928404,,13,Rue de Maule,,78580
+1 Rue Raimu Bois-d'Arcy,,,,1,Rue Raimu,,78390
+1 Rue Raimu 78390,,,,1,Rue Raimu,Bois-d'Arcy,
+1 Rue Raimu,2.010724,48.805834,,1,Rue Raimu,,78390
+34 Rue Pasteur Buchelay,,,,34,Rue Pasteur,,78200
+34 Rue Pasteur 78200,,,,34,Rue Pasteur,Buchelay,
+34 Rue Pasteur,1.67306,48.982348,,34,Rue Pasteur,,78200
+21 Allée des Chardonnerets Cernay-la-Ville,,,,21,Allée des Chardonnerets,,78720
+21 Allée des Chardonnerets 78720,,,,21,Allée des Chardonnerets,Cernay-la-Ville,
+21 Allée des Chardonnerets,1.977011,48.671943,,21,Allée des Chardonnerets,,78720
+106 Avenue Gambetta Chatou,,,,106,Avenue Gambetta,,78400
+106 Avenue Gambetta 78400,,,,106,Avenue Gambetta,Chatou,
+106 Avenue Gambetta,2.170231,48.901294,,106,Avenue Gambetta,,78400
+28 Avenue de Montespan Le Chesnay,,,,28,Avenue de Montespan,,78150
+28 Avenue de Montespan 78150,,,,28,Avenue de Montespan,Le Chesnay,
+28 Avenue de Montespan,2.138017,48.821708,,28,Avenue de Montespan,,78150
+8 Rue du Hallier Condé-sur-Vesgre,,,,8,Rue du Hallier,,78113
+8 Rue du Hallier 78113,,,,8,Rue du Hallier,Condé-sur-Vesgre,
+8 Rue du Hallier,1.668307,48.740372,,8,Rue du Hallier,,78113
+1 Rue J B Drapier Conflans-Sainte-Honorine,,,,1,Rue Jean-Baptiste Drapier,,78700
+1 Rue J B Drapier 78700,,,,1,Rue Jean-Baptiste Drapier,Conflans-Sainte-Honorine,
+1 Rue J B Drapier,2.07649,48.996703,,1,Rue Jean-Baptiste Drapier,,78700
+58BIS Avenue de Verdun Croissy-sur-Seine,,,,58BIS,Avenue de Verdun,,78290
+58BIS Avenue de Verdun 78290,,,,58BIS,Avenue de Verdun,Croissy-sur-Seine,
+58BIS Avenue de Verdun,2.138273,48.882568,,58BIS,Avenue de Verdun,,78290
+23 Rue du Pont Élancourt,,,,23,Rue du Pont,,78990
+23 Rue du Pont 78990,,,,23,Rue du Pont,Élancourt,
+23 Rue du Pont,1.95756,48.778507,,23,Rue du Pont,,78990
+15 Chemin du Clos Saint-Martin L'Étang-la-Ville,,,,15,Chemin du Clos Saint-Martin,,78620
+15 Chemin du Clos Saint-Martin 78620,,,,15,Chemin du Clos Saint-Martin,L'Étang-la-Ville,
+15 Chemin du Clos Saint-Martin,2.064458,48.86624,,15,Chemin du Clos Saint-Martin,,78620
+9 Rue des Vergers Freneuse,,,,9,Rue des Vergers,,78840
+9 Rue des Vergers 78840,,,,9,Rue des Vergers,Freneuse,
+9 Rue des Vergers,1.60265,49.042899,,9,Rue des Vergers,,78840
+56 Rue Molière Guyancourt,,,,56,Rue Molière,,78280
+56 Rue Molière 78280,,,,56,Rue Molière,Guyancourt,
+56 Rue Molière,2.062847,48.765592,,56,Rue Molière,,78280
+17BIS Rue Joseph Bara Houilles,,,,17BIS,Rue Joseph Bara,,78800
+17BIS Rue Joseph Bara 78800,,,,17BIS,Rue Joseph Bara,Houilles,
+17BIS Rue Joseph Bara,2.198203,48.92514,,17BIS,Rue Joseph Bara,,78800
+38QUATER Route de la Roche Limetz-Villez,,,,38QUATER,Route de la Roche,,78270
+38QUATER Route de la Roche 78270,,,,38QUATER,Route de la Roche,Limetz-Villez,
+38QUATER Route de la Roche,1.553745,49.063118,,38QUATER,Route de la Roche,,78270
+9 Allée des Droits de l'Homme Magny-les-Hameaux,,,,9,Allée des Droits de l'Homme,,78114
+9 Allée des Droits de l'Homme 78114,,,,9,Allée des Droits de l'Homme,Magny-les-Hameaux,
+9 Allée des Droits de l'Homme,2.080906,48.721113,,9,Allée des Droits de l'Homme,,78114
+19 Rue de l'Union Maisons-Laffitte,,,,19,Rue de l'Union,,78600
+19 Rue de l'Union 78600,,,,19,Rue de l'Union,Maisons-Laffitte,
+19 Rue de l'Union,2.137465,48.948797,,19,Rue de l'Union,,78600
+31 Rue de Bellevue Mantes-la-Ville,,,,31,Rue de Bellevue,,78711
+31 Rue de Bellevue 78711,,,,31,Rue de Bellevue,Mantes-la-Ville,
+31 Rue de Bellevue,1.717671,48.980143,,31,Rue de Bellevue,,78711
+30 Rue des Harias Mareil-sur-Mauldre,,,,30,Rue des Harias,,78124
+30 Rue des Harias 78124,,,,30,Rue des Harias,Mareil-sur-Mauldre,
+30 Rue des Harias,1.885278,48.886708,,30,Rue des Harias,,78124
+5 Square du Clermontois Maurepas,,,,5,Square du Clermontois,,78310
+5 Square du Clermontois 78310,,,,5,Square du Clermontois,Maurepas,
+5 Square du Clermontois,1.935409,48.771257,,5,Square du Clermontois,,78310
+19BIS Avenue de la République Le Mesnil-le-Roi,,,,19BIS,Avenue de la République,,78600
+19BIS Avenue de la République 78600,,,,19BIS,Avenue de la République,Le Mesnil-le-Roi,
+19BIS Avenue de la République,2.136457,48.938763,,19BIS,Avenue de la République,,78600
+12 Quai George Sand Montesson,,,,12,Quai George Sand,,78360
+12 Quai George Sand 78360,,,,12,Quai George Sand,Montesson,
+12 Quai George Sand,2.137131,48.930695,,12,Quai George Sand,,78360
+5 Square de la Mare aux Renards Montigny-le-Bretonneux,,,,5,Square de la Mare aux Renards,,78180
+5 Square de la Mare aux Renards 78180,,,,5,Square de la Mare aux Renards,Montigny-le-Bretonneux,
+5 Square de la Mare aux Renards,2.031763,48.766802,,5,Square de la Mare aux Renards,,78180
+16BIS Rue des Cent Arpents Neauphle-le-Château,,,,16BIS,Rue des Cent Arpents,,78640
+16BIS Rue des Cent Arpents 78640,,,,16BIS,Rue des Cent Arpents,Neauphle-le-Château,
+16BIS Rue des Cent Arpents,1.904235,48.821573,,16BIS,Rue des Cent Arpents,,78640
+2 Allée de la Reine des Reinettes Orgeval,,,,2,Allée de la Reine des Reinettes,,78630
+2 Allée de la Reine des Reinettes 78630,,,,2,Allée de la Reine des Reinettes,Orgeval,
+2 Allée de la Reine des Reinettes,1.974228,48.927248,,2,Allée de la Reine des Reinettes,,78630
+6 Rue Jean Giono Plaisir,,,,6,Rue Jean Giono,,78370
+6 Rue Jean Giono 78370,,,,6,Rue Jean Giono,Plaisir,
+6 Rue Jean Giono,1.927648,48.820644,,6,Rue Jean Giono,,78370
+6 Rue du 8 Mai 1945 Poissy,,,,6,Rue du 8 Mai 1945,,78300
+6 Rue du 8 Mai 1945 78300,,,,6,Rue du 8 Mai 1945,Poissy,
+6 Rue du 8 Mai 1945,2.044059,48.928205,,6,Rue du 8 Mai 1945,,78300
+30 Rue du Clos Batant Rambouillet,,,,30,Rue du Clos-Batant,,78120
+30 Rue du Clos Batant 78120,,,,30,Rue du Clos-Batant,Rambouillet,
+30 Rue du Clos Batant,1.855534,48.652697,,30,Rue du Clos-Batant,,78120
+21 Route de Houdan Richebourg,,,,21,Route de Houdan,,78550
+21 Route de Houdan 78550,,,,21,Route de Houdan,Richebourg,
+21 Route de Houdan,1.631829,48.818202,,21,Route de Houdan,,78550
+3 Rue Danès de Montardat Saint-Germain-en-Laye,,,,3,Rue Danès de Montardat,,78100
+3 Rue Danès de Montardat 78100,,,,3,Rue Danès de Montardat,Saint-Germain-en-Laye,
+3 Rue Danès de Montardat,2.090213,48.896754,,3,Rue Danès de Montardat,,78100
+11 Boulevard des Plants Saint-Nom-la-Bretèche,,,,11,Boulevard des Plants,,78860
+11 Boulevard des Plants 78860,,,,11,Boulevard des Plants,Saint-Nom-la-Bretèche,
+11 Boulevard des Plants,2.030803,48.863978,,11,Boulevard des Plants,,78860
+1 Rue Jean-Baptiste Clément Sartrouville,,,,1,Rue Jean-Baptiste Clément,,78500
+1 Rue Jean-Baptiste Clément 78500,,,,1,Rue Jean-Baptiste Clément,Sartrouville,
+1 Rue Jean-Baptiste Clément,2.17266,48.933436,,1,Rue Jean-Baptiste Clément,,78500
+32 Rue des Peupliers Septeuil,,,,32,Rue des Peupliers,,78790
+32 Rue des Peupliers 78790,,,,32,Rue des Peupliers,Septeuil,
+32 Rue des Peupliers,1.679875,48.888224,,32,Rue des Peupliers,,78790
+14 Rue de l'Echenet Triel-sur-Seine,,,,14,Rue de l'Echenet,,78510
+14 Rue de l'Echenet 78510,,,,14,Rue de l'Echenet,Triel-sur-Seine,
+14 Rue de l'Echenet,1.994298,48.989454,,14,Rue de l'Echenet,,78510
+113 Rue Mozart Vélizy-Villacoublay,,,,113,Rue Mozart,,78140
+113 Rue Mozart 78140,,,,113,Rue Mozart,Vélizy-Villacoublay,
+113 Rue Mozart,2.169868,48.785538,,113,Rue Mozart,,78140
+21 Avenue du Chemin Vert La Verrière,,,,21,Avenue du Chemin Vert,,78320
+21 Avenue du Chemin Vert 78320,,,,21,Avenue du Chemin Vert,La Verrière,
+21 Avenue du Chemin Vert,1.956724,48.752346,,21,Avenue du Chemin Vert,,78320
+4 Impasse Nattier Versailles,,,,4,Impasse Nattier,,78000
+4 Impasse Nattier 78000,,,,4,Impasse Nattier,Versailles,
+4 Impasse Nattier,2.135036,48.813061,,4,Impasse Nattier,,78000
+36BIS Avenue Georges Clemenceau Le Vésinet,,,,36BIS,Avenue Georges Clemenceau,,78110
+36BIS Avenue Georges Clemenceau 78110,,,,36BIS,Avenue Georges Clemenceau,Le Vésinet,
+36BIS Avenue Georges Clemenceau,2.134034,48.887017,,36BIS,Avenue Georges Clemenceau,,78110
+4 Rue du Pavillon Villette,,,,4,Rue du Pavillon,,78930
+4 Rue du Pavillon 78930,,,,4,Rue du Pavillon,Villette,
+4 Rue du Pavillon,1.691405,48.92776,,4,Rue du Pavillon,,78930
+3 Rue Jean Mermoz Voisins-le-Bretonneux,,,,3,Rue Jean Mermoz,,78960
+3 Rue Jean Mermoz 78960,,,,3,Rue Jean Mermoz,Voisins-le-Bretonneux,
+3 Rue Jean Mermoz,2.040601,48.760333,,3,Rue Jean Mermoz,,78960
+26 Avenue de l'Europe Athis-Mons,,,,26,Avenue de l'Europe,,91200
+26 Avenue de l'Europe 91200,,,,26,Avenue de l'Europe,Athis-Mons,
+26 Avenue de l'Europe,2.408811,48.719534,,26,Avenue de l'Europe,,91200
+1 Route de Morigny Auvers-Saint-Georges,,,,1,Route de Morigny,,91580
+1 Route de Morigny 91580,,,,1,Route de Morigny,Auvers-Saint-Georges,
+1 Route de Morigny,2.198262,48.478983,,1,Route de Morigny,,91580
+38 Rue Odilon Redon Bièvres,,,,38,Rue Odilon Redon,,91570
+38 Rue Odilon Redon 91570,,,,38,Rue Odilon Redon,Bièvres,
+38 Rue Odilon Redon,2.214667,48.756643,,38,Rue Odilon Redon,,91570
+22 Rue du Petit Pont Bondoufle,,,,22,Rue du Petit Pont,,91070
+22 Rue du Petit Pont 91070,,,,22,Rue du Petit Pont,Bondoufle,
+22 Rue du Petit Pont,2.385285,48.611678,,22,Rue du Petit Pont,,91070
+4 Rue Ducrot Brétigny-sur-Orge,,,,4,Rue Ernest Ducros,,91220
+4 Rue Ducrot 91220,,,,4,Ernest Ducros,Brétigny-sur-Orge,
+4 Rue Ducrot,2.30423,48.612895,,4,Ernest Ducros,,91220
+5 Rue des Sarments Breuillet,,,,5,Rue des Sarments,,91650
+5 Rue des Sarments 91650,,,,5,Rue des Sarments,Breuillet,
+5 Rue des Sarments,2.179375,48.57488,,5,Rue des Sarments,,91650
+16 Avenue Montaigne Brunoy,,,,16,Avenue Montaigne,,91800
+16 Avenue Montaigne 91800,,,,16,Avenue Montaigne,Brunoy,
+16 Avenue Montaigne,2.509264,48.697386,,16,Avenue Montaigne,,91800
+41 Rue Max Ernst Bures-sur-Yvette,,,,41,Rue Max Ernst,,91440
+41 Rue Max Ernst 91440,,,,41,Rue Max Ernst,Bures-sur-Yvette,
+41 Rue Max Ernst,2.156776,48.679705,,41,Rue Max Ernst,,91440
+5 Rue de la Pierre Blanche Cheptainville,,,,5,Rue de la Pierre Blanche,,91630
+5 Rue de la Pierre Blanche 91630,,,,5,Rue de la Pierre Blanche,Cheptainville,
+5 Rue de la Pierre Blanche,2.285627,48.557539,,5,Rue de la Pierre Blanche,,91630
+114 Rue Georges Le Dû Corbeil-Essonnes,,,,114,Rue Georges Le Dû,,91100
+114 Rue Georges Le Dû 91100,,,,114,Rue Georges Le Dû,Corbeil-Essonnes,
+114 Rue Georges Le Dû,2.473044,48.593543,,114,Rue Georges Le Dû,,91100
+25 Allée des Libellules Le Coudray-Montceaux,,,,25,Allée des Libellules,,91830
+25 Allée des Libellules 91830,,,,25,Allée des Libellules,Le Coudray-Montceaux,
+25 Allée des Libellules,2.506447,48.567273,,25,Allée des Libellules,,91830
+60 Rue de l'Égalité D'Huison-Longueville,,,,60,Rue de l'Égalité,,91590
+60 Rue de l'Égalité 91590,,,,60,Rue de l'Égalité,D'Huison-Longueville,
+60 Rue de l'Égalité,2.336809,48.455205,,60,Rue de l'Égalité,,91590
+13 Rue Etienne Rabot Draveil,,,,13,Rue Etienne Rabot,,91210
+13 Rue Etienne Rabot 91210,,,,13,Rue Etienne Rabot,Draveil,
+13 Rue Etienne Rabot,2.420713,48.67595,,13,Rue Etienne Rabot,,91210
+17 Avenue d'Arpajon Égly,,,,17,Avenue d'Arpajon,,91520
+17 Avenue d'Arpajon 91520,,,,17,Avenue d'Arpajon,Égly,
+17 Avenue d'Arpajon,2.2298,48.582,,17,Avenue d'Arpajon,,91520
+30 Rue Guillemette de Bure Étampes,,,,30,Rue Guillemette de Bure,,91150
+30 Rue Guillemette de Bure 91150,,,,30,Rue Guillemette de Bure,Étampes,
+30 Rue Guillemette de Bure,2.140833,48.431631,,30,Rue Guillemette de Bure,,91150
+32 Rue Alfred de Musset Étréchy,,,,32,Rue Alfred de Musset,,91580
+32 Rue Alfred de Musset 91580,,,,32,Rue Alfred de Musset,Étréchy,
+32 Rue Alfred de Musset,2.183701,48.486284,,32,Rue Alfred de Musset,,91580
+25 Rue du Bas Côt La Ferté-Alais,,,,25,Rue du Bas Côt,,91590
+25 Rue du Bas Côt 91590,,,,25,Rue du Bas Côt,La Ferté-Alais,
+25 Rue du Bas Côt,2.36718,48.48041,,25,Rue du Bas Côt,,91590
+60 Avenue du Général Leclerc Gif-sur-Yvette,,,,60,Avenue du Général Leclerc,,91190
+60 Avenue du Général Leclerc 91190,,,,60,Avenue du Général Leclerc,Gif-sur-Yvette,
+60 Avenue du Général Leclerc,2.123581,48.704754,,60,Avenue du Général Leclerc,,91190
+8 Allée du Signal Grigny,,,,8,Allée du Signal,,91350
+8 Allée du Signal 91350,,,,8,Allée du Signal,Grigny,
+8 Allée du Signal,2.368053,48.646693,,8,Allée du Signal,,91350
+1 Avenue Mozart Itteville,,,,1,Avenue Mozart,,91760
+1 Avenue Mozart 91760,,,,1,Avenue Mozart,Itteville,
+1 Avenue Mozart,2.342568,48.53245,,1,Avenue Mozart,,91760
+46 Rue de la Ferme Lardy,,,,46,Rue de la Ferme,,91510
+46 Rue de la Ferme 91510,,,,46,Rue de la Ferme,Lardy,
+46 Rue de la Ferme,2.297476,48.535438,,46,Rue de la Ferme,,91510
+71 Rue de la Division Leclerc Linas,,,,71,Rue de la Division Leclerc,,91310
+71 Rue de la Division Leclerc 91310,,,,71,Rue de la Division Leclerc,Linas,
+71 Rue de la Division Leclerc,2.266607,48.632622,,71,Rue de la Division Leclerc,,91310
+25 Rue des Glaneurs Longjumeau,,,,25,Rue des Glaneurs,,91160
+25 Rue des Glaneurs 91160,,,,25,Rue des Glaneurs,Longjumeau,
+25 Rue des Glaneurs,2.30098,48.68079,,25,Rue des Glaneurs,,91160
+10BIS Route de Briis Marcoussis,,,,10BIS,Route de Briis,,91460
+10BIS Route de Briis 91460,,,,10BIS,Route de Briis,Marcoussis,
+10BIS Route de Briis,2.221816,48.636926,,10BIS,Route de Briis,,91460
+31 Rue Jean Mermoz Massy,,,,31,Rue Jean Mermoz,,91300
+31 Rue Jean Mermoz 91300,,,,31,Rue Jean Mermoz,Massy,
+31 Rue Jean Mermoz,2.280368,48.728678,,31,Rue Jean Mermoz,,91300
+82 Rue du Petit Mennecy Mennecy,,,,82,Rue du Petit Mennecy,,91540
+82 Rue du Petit Mennecy 91540,,,,82,Rue du Petit Mennecy,Mennecy,
+82 Rue du Petit Mennecy,2.443676,48.575897,,82,Rue du Petit Mennecy,,91540
+19 Rue de la Janvrerie Les Molières,,,,19,Rue de la Janvrerie,,91470
+19 Rue de la Janvrerie 91470,,,,19,Rue de la Janvrerie,Les Molières,
+19 Rue de la Janvrerie,2.07229,48.67628,,19,Rue de la Janvrerie,,91470
+43BIS Rue Raymond Paumier Montgeron,,,,43BIS,Rue Raymond Paumier,,91230
+43BIS Rue Raymond Paumier 91230,,,,43BIS,Rue Raymond Paumier,Montgeron,
+43BIS Rue Raymond Paumier,2.447216,48.704176,,43BIS,Rue Raymond Paumier,,91230
+14 Rue Jean Moulin Morangis,,,,14,Rue Jean Moulin,,91420
+14 Rue Jean Moulin 91420,,,,14,Rue Jean Moulin,Morangis,
+14 Rue Jean Moulin,2.333888,48.7058,,14,Rue Jean Moulin,,91420
+16 Avenue Fernand Léger Morsang-sur-Orge,,,,16,Avenue Fernand Léger,,91390
+16 Avenue Fernand Léger 91390,,,,16,Avenue Fernand Léger,Morsang-sur-Orge,
+16 Avenue Fernand Léger,2.344638,48.65107,,16,Avenue Fernand Léger,,91390
+2 Rue Rosa Luxembourg La Norville,,,,2,Rue Rosa Luxembourg,,91290
+2 Rue Rosa Luxembourg 91290,,,,2,Rue Rosa Luxembourg,La Norville,
+2 Rue Rosa Luxembourg,2.261681,48.592445,,2,Rue Rosa Luxembourg,,91290
+13 Rue Florian Orsay,,,,13,Rue Florian,,91400
+13 Rue Florian 91400,,,,13,Rue Florian,Orsay,
+13 Rue Florian,2.195807,48.704238,,13,Rue Florian,,91400
+111 Boulevard de Lozère Palaiseau,,,,111,Boulevard de Lozère,,91120
+111 Boulevard de Lozère 91120,,,,111,Boulevard de Lozère,Palaiseau,
+111 Boulevard de Lozère,2.226641,48.706181,,111,Boulevard de Lozère,,91120
+75 Rue Romain Rolland Paray-Vieille-Poste,,,,75,Rue Romain Rolland,,91550
+75 Rue Romain Rolland 91550,,,,75,Rue Romain Rolland,Paray-Vieille-Poste,
+75 Rue Romain Rolland,2.365385,48.706465,,75,Rue Romain Rolland,,91550
+61 Avenue Daumesnil Ris-Orangis,,,,61,Avenue Daumesnil,,91130
+61 Avenue Daumesnil 91130,,,,61,Avenue Daumesnil,Ris-Orangis,
+61 Avenue Daumesnil,2.413883,48.652699,,61,Avenue Daumesnil,,91130
+79 Avenue de Dourdan Saint-Chéron,,,,79,Avenue de Dourdan,,91530
+79 Avenue de Dourdan 91530,,,,79,Avenue de Dourdan,Saint-Chéron,
+79 Avenue de Dourdan,2.111262,48.546852,,79,Avenue de Dourdan,,91530
+15 Rue Henri Sellier Sainte-Geneviève-des-Bois,,,,15,Rue Henri Sellier,,91700
+15 Rue Henri Sellier 91700,,,,15,Rue Henri Sellier,Sainte-Geneviève-des-Bois,
+15 Rue Henri Sellier,2.326752,48.635399,,15,Rue Henri Sellier,,91700
+25 Route de Corbeil Saint-Germain-lès-Arpajon,,,,25,Route de Corbeil,,91180
+25 Route de Corbeil 91180,,,,25,Route de Corbeil,Saint-Germain-lès-Arpajon,
+25 Route de Corbeil,2.263717,48.594748,,25,Route de Corbeil,,91180
+3BIS Rue Chopin Saint-Michel-sur-Orge,,,,3BIS,Rue Chopin,,91240
+3BIS Rue Chopin 91240,,,,3BIS,Rue Chopin,Saint-Michel-sur-Orge,
+3BIS Rue Chopin,2.309541,48.64493,,3BIS,Rue Chopin,,91240
+8 Rue des Cottages Saintry-sur-Seine,,,,8,Rue des Cottages,,91250
+8 Rue des Cottages 91250,,,,8,Rue des Cottages,Saintry-sur-Seine,
+8 Rue des Cottages,2.501485,48.59652,,8,Rue des Cottages,,91250
+43 Rue d'Auerstaedt Savigny-sur-Orge,,,,43,Rue d'Auerstaedt,,91600
+43 Rue d'Auerstaedt 91600,,,,43,Rue d'Auerstaedt,Savigny-sur-Orge,
+43 Rue d'Auerstaedt,2.333478,48.688868,,43,Rue d'Auerstaedt,,91600
+15 Avenue Linné Savigny-sur-Orge,,,,15,Avenue Linné,,91600
+15 Avenue Linné 91600,,,,15,Avenue Linné,Savigny-sur-Orge,
+15 Avenue Linné,2.345229,48.688703,,15,Avenue Linné,,91600
+862 Rue des Sources Sermaise,,,,862,Rue des Sources,,91530
+862 Rue des Sources 91530,,,,862,Rue des Sources,Sermaise,
+862 Rue des Sources,2.101442,48.538864,,862,Rue des Sources,,91530
+12BIS Chemin d'Orveau Vayres-sur-Essonne,,,,12BIS,Chemin d'Orveau,,91820
+12BIS Chemin d'Orveau 91820,,,,12BIS,Chemin d'Orveau,Vayres-sur-Essonne,
+12BIS Chemin d'Orveau,2.351197,48.438203,,12BIS,Chemin d'Orveau,,91820
+6 Rue Pierre Semard Vigneux-sur-Seine,,,,6,Rue Pierre Semard,,91270
+6 Rue Pierre Semard 91270,,,,6,Rue Pierre Semard,Vigneux-sur-Seine,
+6 Rue Pierre Semard,2.431447,48.695518,,6,Rue Pierre Semard,,91270
+8 Rue des Écoles La Ville-du-Bois,,,,8,Rue des Écoles,,91620
+8 Rue des Écoles 91620,,,,8,Rue des Écoles,La Ville-du-Bois,
+8 Rue des Écoles,2.268867,48.66165,,8,Rue des Écoles,,91620
+11 Allée des Cerisiers Villiers-sur-Orge,,,,11,Allée des Cerisiers,,91700
+11 Allée des Cerisiers 91700,,,,11,Allée des Cerisiers,Villiers-sur-Orge,
+11 Allée des Cerisiers,2.291457,48.655138,,11,Allée des Cerisiers,,91700
+34 Avenue du Pavillon Viry-Châtillon,,,,34,Avenue du Pavillon,,91170
+34 Avenue du Pavillon 91170,,,,34,Avenue du Pavillon,Viry-Châtillon,
+34 Avenue du Pavillon,2.364577,48.64922,,34,Avenue du Pavillon,,91170
+24 Rue des Faisans Yerres,,,,24,Rue des Faisans,,91330
+24 Rue des Faisans 91330,,,,24,Rue des Faisans,Yerres,
+24 Rue des Faisans,2.509156,48.719221,,24,Rue des Faisans,,91330
+10 Rue des Grouettes Antony,,,,10,Rue des Grouettes,,92160
+10 Rue des Grouettes 92160,,,,10,Rue des Grouettes,Antony,
+10 Rue des Grouettes,2.286678,48.756008,,10,Rue des Grouettes,,92160
+18 Rue Robert Doisy Antony,,,,18,Rue Robert Doisy,,92160
+18 Rue Robert Doisy 92160,,,,18,Rue Robert Doisy,Antony,
+18 Rue Robert Doisy,2.29612,48.756926,,18,Rue Robert Doisy,,92160
+22 Rue Jeanne d'Arc Asnières-sur-Seine,,,,22,Rue Jeanne d'Arc,,92600
+22 Rue Jeanne d'Arc 92600,,,,22,Rue Jeanne d'Arc,Asnières-sur-Seine,
+22 Rue Jeanne d'Arc,2.280829,48.921107,,22,Rue Jeanne d'Arc,,92600
+3 Rue Madame Curie Bagneux,,,,3,Rue Madame Curie,,92220
+3 Rue Madame Curie 92220,,,,3,Rue Madame Curie,Bagneux,
+3 Rue Madame Curie,2.315417,48.795933,,3,Rue Madame Curie,,92220
+9 Villa Schutz et Daumain Bois-Colombes,,,,9,Villa Schutz et Daumain,,92270
+9 Villa Schutz et Daumain 92270,,,,9,Villa Schutz et Daumain,Bois-Colombes,
+9 Villa Schutz et Daumain,2.274382,48.917142,,9,Villa Schutz et Daumain,,92270
+65 Rue Marcel Dassault Boulogne-Billancourt,,,,65,Rue Marcel Dassault,,92100
+65 Rue Marcel Dassault 92100,,,,65,Rue Marcel Dassault,Boulogne-Billancourt,
+65 Rue Marcel Dassault,2.250925,48.834668,,65,Rue Marcel Dassault,,92100
+4 Rue Pasteur Bourg-la-Reine,,,,4,Rue Pasteur,,92340
+4 Rue Pasteur 92340,,,,4,Rue Pasteur,Bourg-la-Reine,
+4 Rue Pasteur,2.314162,48.773352,,4,Rue Pasteur,,92340
+80 Rue Lasègue Châtillon,,,,80,Rue Lasègue,,92320
+80 Rue Lasègue 92320,,,,80,Rue Lasègue,Châtillon,
+80 Rue Lasègue,2.280198,48.802575,,80,Rue Lasègue,,92320
+5BIS Rue de Bièvres Clamart,,,,5BIS,Rue de Bièvres,,92140
+5BIS Rue de Bièvres 92140,,,,5BIS,Rue de Bièvres,Clamart,
+5BIS Rue de Bièvres,2.265419,48.799049,,5BIS,Rue de Bièvres,,92140
+122 Rue Marie Fichet Clamart,,,,122,Rue Marie Fichet,,92140
+122 Rue Marie Fichet 92140,,,,122,Rue Marie Fichet,Clamart,
+122 Rue Marie Fichet,2.229741,48.779069,,122,Rue Marie Fichet,,92140
+80 Rue Martre Clichy,,,,80,Rue Martre,,92110
+80 Rue Martre 92110,,,,80,Rue Martre,Clichy,
+80 Rue Martre,2.306857,48.902501,,80,Rue Martre,,92110
+13 Villa Eugène Colombes,,,,13,Villa Eugène,,92700
+13 Villa Eugène 92700,,,,13,Villa Eugène,Colombes,
+13 Villa Eugène,2.260929,48.915812,,13,Villa Eugène,,92700
+10 Rue de la Paix Colombes,,,,10,Rue de la Paix,,92700
+10 Rue de la Paix 92700,,,,10,Rue de la Paix,Colombes,
+10 Rue de la Paix,2.242662,48.912737,,10,Rue de la Paix,,92700
+30BIS Rue Gaultier Courbevoie,,,,30BIS,Rue Gaultier,,92400
+30BIS Rue Gaultier 92400,,,,30BIS,Rue Gaultier,Courbevoie,
+30BIS Rue Gaultier,2.242143,48.898357,,30BIS,Rue Gaultier,,92400
+8 Rue des Moulins à Vent Fontenay-aux-Roses,,,,8,Rue des Moulins à Vent,,92260
+8 Rue des Moulins à Vent 92260,,,,8,Rue des Moulins à Vent,Fontenay-aux-Roses,
+8 Rue des Moulins à Vent,2.278073,48.794179,,8,Rue des Moulins à Vent,,92260
+59 Rue de Plaisance La Garenne-Colombes,,,,59,Rue de Plaisance,,92250
+59 Rue de Plaisance 92250,,,,59,Rue de Plaisance,La Garenne-Colombes,
+59 Rue de Plaisance,2.25295,48.90633,,59,Rue de Plaisance,,92250
+42 Rue Danton Issy-les-Moulineaux,,,,42,Rue Danton,,92130
+42 Rue Danton 92130,,,,42,Rue Danton,Issy-les-Moulineaux,
+42 Rue Danton,2.271859,48.823909,,42,Rue Danton,,92130
+46 Rue Jules Guesde Levallois-Perret,,,,46,Rue Jules Guesde,,92300
+46 Rue Jules Guesde 92300,,,,46,Rue Jules Guesde,Levallois-Perret,
+46 Rue Jules Guesde,2.292734,48.893173,,46,Rue Jules Guesde,,92300
+19 Rue de la Tour Malakoff,,,,19,Rue de la Tour,,92240
+19 Rue de la Tour 92240,,,,19,Rue de la Tour,Malakoff,
+19 Rue de la Tour,2.305675,48.823213,,19,Rue de la Tour,,92240
+8 Rue Amaury Duval Montrouge,,,,8,Rue Amaury Duval,,92120
+8 Rue Amaury Duval 92120,,,,8,Rue Amaury Duval,Montrouge,
+8 Rue Amaury Duval,2.323514,48.816985,,8,Rue Amaury Duval,,92120
+31 Rue des Fleurs Nanterre,,,,31,Rue des Fleurs,,92000
+31 Rue des Fleurs 92000,,,,31,Rue des Fleurs,Nanterre,
+31 Rue des Fleurs,2.204486,48.885187,,31,Rue des Fleurs,,92000
+58 Rue de Suresnes Nanterre,,,,58,Rue de Suresnes,,92000
+58 Rue de Suresnes 92000,,,,58,Rue de Suresnes,Nanterre,
+58 Rue de Suresnes,2.211166,48.885495,,58,Rue de Suresnes,,92000
+19 Rue Amédée Usséglio Le Plessis-Robinson,,,,19,Rue Amédée Usséglio,,92350
+19 Rue Amédée Usséglio 92350,,,,19,Rue Amédée Usséglio,Le Plessis-Robinson,
+19 Rue Amédée Usséglio,2.254586,48.781121,,19,Rue Amédée Usséglio,,92350
+4 Rue des Alizes Rueil-Malmaison,,,,4,Rue des Alizes,,92500
+4 Rue des Alizes 92500,,,,4,Rue des Alizes,Rueil-Malmaison,
+4 Rue des Alizes,2.193308,48.860188,,4,Rue des Alizes,,92500
+22 Rue Haute Rueil-Malmaison,,,,22,Rue Haute,,92500
+22 Rue Haute 92500,,,,22,Rue Haute,Rueil-Malmaison,
+22 Rue Haute,2.183094,48.874937,,22,Rue Haute,,92500
+23 Rue Armengaud Saint-Cloud,,,,23,Rue Armengaud,,92210
+23 Rue Armengaud 92210,,,,23,Rue Armengaud,Saint-Cloud,
+23 Rue Armengaud,2.21671,48.848047,,23,Rue Armengaud,,92210
+9 Rue Massenet Sceaux,,,,9,Rue Massenet,,92330
+9 Rue Massenet 92330,,,,9,Rue Massenet,Sceaux,
+9 Rue Massenet,2.309102,48.783919,,9,Rue Massenet,,92330
+1 Rue Gustave Flourens Suresnes,,,,1,Rue Gustave Flourens,,92150
+1 Rue Gustave Flourens 92150,,,,1,Rue Gustave Flourens,Suresnes,
+1 Rue Gustave Flourens,2.229349,48.871257,,1,Rue Gustave Flourens,,92150
+6 Boulevard de Jardy Vaucresson,,,,6,Boulevard de Jardy,,92420
+6 Boulevard de Jardy 92420,,,,6,Boulevard de Jardy,Vaucresson,
+6 Boulevard de Jardy,2.155615,48.837116,,6,Boulevard de Jardy,,92420
+25 Rue d'Amiens Aulnay-sous-Bois,,,,25,Rue d'Amiens,,93600
+25 Rue d'Amiens 93600,,,,25,Rue d'Amiens,Aulnay-sous-Bois,
+25 Rue d'Amiens,2.485722,48.922312,,25,Rue d'Amiens,,93600
+10 Rue Frédéric Mistral Aulnay-sous-Bois,,,,10,Rue Frédéric Mistral,,93600
+10 Rue Frédéric Mistral 93600,,,,10,Rue Frédéric Mistral,Aulnay-sous-Bois,
+10 Rue Frédéric Mistral,2.489945,48.918039,,10,Rue Frédéric Mistral,,93600
+14 Rue Paul Fouquet Aulnay-sous-Bois,,,,14,Rue Paul Fouquet,,93600
+14 Rue Paul Fouquet 93600,,,,14,Rue Paul Fouquet,Aulnay-sous-Bois,
+14 Rue Paul Fouquet,2.483256,48.936786,,14,Rue Paul Fouquet,,93600
+6 Rue des Fossillons Bagnolet,,,,6,Rue des Fossillons,,93170
+6 Rue des Fossillons 93170,,,,6,Rue des Fossillons,Bagnolet,
+6 Rue des Fossillons,2.423188,48.868803,,6,Rue des Fossillons,,93170
+83 Rue Emile Paladilhe Le Blanc-Mesnil,,,,83,Rue Emile Paladilhe,,93150
+83 Rue Emile Paladilhe 93150,,,,83,Rue Emile Paladilhe,Le Blanc-Mesnil,
+83 Rue Emile Paladilhe,2.470884,48.939067,,83,Rue Emile Paladilhe,,93150
+29 Avenue Romain Rolland Le Blanc-Mesnil,,,,29,Avenue Romain Rolland,,93150
+29 Avenue Romain Rolland 93150,,,,29,Avenue Romain Rolland,Le Blanc-Mesnil,
+29 Avenue Romain Rolland,2.465491,48.934498,,29,Avenue Romain Rolland,,93150
+5 Rue de la Nouvelle Dehli Bobigny,,,,5,Rue de la Nouvelle Dehli,,93000
+5 Rue de la Nouvelle Dehli 93000,,,,5,Rue de la Nouvelle Dehli,Bobigny,
+5 Rue de la Nouvelle Dehli,2.47392,48.91032,,5,Rue de la Nouvelle Dehli,,93000
+23 Rue Jules Guesde Bondy,,,,23,Rue Jules Guesde,,93140
+23 Rue Jules Guesde 93140,,,,23,Rue Jules Guesde,Bondy,
+23 Rue Jules Guesde,2.475792,48.903883,,23,Rue Jules Guesde,,93140
+42 Allée de Bellevue Clichy-sous-Bois,,,,42,Allée de Bellevue,,93390
+42 Allée de Bellevue 93390,,,,42,Allée de Bellevue,Clichy-sous-Bois,
+42 Allée de Bellevue,2.548898,48.914918,,42,Allée de Bellevue,,93390
+30 Avenue Jean Mermoz La Courneuve,,,,30,Avenue Jean Mermoz,,93120
+30 Avenue Jean Mermoz 93120,,,,30,Avenue Jean Mermoz,La Courneuve,
+30 Avenue Jean Mermoz,2.402357,48.93207,,30,Avenue Jean Mermoz,,93120
+27 Rue de la Démocratie Drancy,,,,27,Rue de la Démocratie,,93700
+27 Rue de la Démocratie 93700,,,,27,Rue de la Démocratie,Drancy,
+27 Rue de la Démocratie,2.443509,48.917072,,27,Rue de la Démocratie,,93700
+15 Rue des Lilas Drancy,,,,15,Rue des Lilas,,93700
+15 Rue des Lilas 93700,,,,15,Rue des Lilas,Drancy,
+15 Rue des Lilas,2.434937,48.924877,,15,Rue des Lilas,,93700
+17 Rue Laetitia et Henri Tredez Dugny,,,,17,Rue Laetitia et Henri Tredez,,93440
+17 Rue Laetitia et Henri Tredez 93440,,,,17,Rue Laetitia et Henri Tredez,Dugny,
+17 Rue Laetitia et Henri Tredez,2.411917,48.950601,,17,Rue Laetitia et Henri Tredez,,93440
+7 Rue des Amandiers Gagny,,,,7,Rue des Amandiers,,93220
+7 Rue des Amandiers 93220,,,,7,Rue des Amandiers,Gagny,
+7 Rue des Amandiers,2.552309,48.875323,,7,Rue des Amandiers,,93220
+58 Avenue des Marronniers Gagny,,,,58,Avenue des Marronniers,,93220
+58 Avenue des Marronniers 93220,,,,58,Avenue des Marronniers,Gagny,
+58 Avenue des Marronniers,2.559416,48.872188,,58,Avenue des Marronniers,,93220
+24 Avenue des Princes Gournay-sur-Marne,,,,24,Avenue des Princes,,93460
+24 Avenue des Princes 93460,,,,24,Avenue des Princes,Gournay-sur-Marne,
+24 Avenue des Princes,2.581917,48.857715,,24,Avenue des Princes,,93460
+13 Rue de Simiane Livry-Gargan,,,,13,Rue de Simiane,,93190
+13 Rue de Simiane 93190,,,,13,Rue de Simiane,Livry-Gargan,
+13 Rue de Simiane,2.528842,48.914333,,13,Rue de Simiane,,93190
+38 Avenue Quesnay Livry-Gargan,,,,38,Avenue Quesnay,,93190
+38 Avenue Quesnay 93190,,,,38,Avenue Quesnay,Livry-Gargan,
+38 Avenue Quesnay,2.513375,48.912616,,38,Avenue Quesnay,,93190
+10 Boulevard Hardy Montfermeil,,,,10,Boulevard Hardy,,93370
+10 Boulevard Hardy 93370,,,,10,Boulevard Hardy,Montfermeil,
+10 Boulevard Hardy,2.564488,48.904038,,10,Boulevard Hardy,,93370
+55 Rue Carnot Montreuil,,,,55,Rue Carnot,,93100
+55 Rue Carnot 93100,,,,55,Rue Carnot,Montreuil,
+55 Rue Carnot,2.441415,48.854502,,55,Rue Carnot,,93100
+8 Rue Louise Montreuil,,,,8,Rue Louise,,93100
+8 Rue Louise 93100,,,,8,Rue Louise,Montreuil,
+8 Rue Louise,2.457656,48.872582,,8,Rue Louise,,93100
+40 Rue de Saint-Antoine Montreuil,,,,40,Rue de Saint-Antoine,,93100
+40 Rue de Saint-Antoine 93100,,,,40,Rue de Saint-Antoine,Montreuil,
+40 Rue de Saint-Antoine,2.456648,48.865159,,40,Rue de Saint-Antoine,,93100
+33TER Rue Raspail Neuilly-Plaisance,,,,33TER,Rue Raspail,,93360
+33TER Rue Raspail 93360,,,,33TER,Rue Raspail,Neuilly-Plaisance,
+33TER Rue Raspail,2.512366,48.856233,,33TER,Rue Raspail,,93360
+28 Rue du Brayer Noisy-le-Grand,,,,28,Rue du Brayer,,93160
+28 Rue du Brayer 93160,,,,28,Rue du Brayer,Noisy-le-Grand,
+28 Rue du Brayer,2.546562,48.848766,,28,Rue du Brayer,,93160
+1 Rue Pierre Brossolette Noisy-le-Grand,,,,1,Rue Pierre Brossolette,,93160
+1 Rue Pierre Brossolette 93160,,,,1,Rue Pierre Brossolette,Noisy-le-Grand,
+1 Rue Pierre Brossolette,2.52887,48.843689,,1,Rue Pierre Brossolette,,93160
+1 Allée Klebert Noisy-le-Sec,,,,1,Allée Klebert,,93130
+1 Allée Klebert 93130,,,,1,Allée Klebert,Noisy-le-Sec,
+1 Allée Klebert,2.471885,48.897436,,1,Allée Klebert,,93130
+4 Rue Sainte-Marguerite Pantin,,,,4,Rue Sainte-Marguerite,,93500
+4 Rue Sainte-Marguerite 93500,,,,4,Rue Sainte-Marguerite,Pantin,
+4 Rue Sainte-Marguerite,2.391414,48.901062,,4,Rue Sainte-Marguerite,,93500
+4BIS Allée Thiesset Les Pavillons-sous-Bois,,,,4BIS,Allée Thiesset,,93320
+4BIS Allée Thiesset 93320,,,,4BIS,Allée Thiesset,Les Pavillons-sous-Bois,
+4BIS Allée Thiesset,2.506036,48.917058,,4BIS,Allée Thiesset,,93320
+72 Avenue Édouard Vaillant Le Pré-Saint-Gervais,,,,72,Avenue Édouard Vaillant,,93310
+72 Avenue Édouard Vaillant 93310,,,,72,Avenue Édouard Vaillant,Le Pré-Saint-Gervais,
+72 Avenue Édouard Vaillant,2.409652,48.880999,,72,Avenue Édouard Vaillant,,93310
+84 Rue Jean Lemoine Romainville,,,,84,Rue Jean Lemoine,,93230
+84 Rue Jean Lemoine 93230,,,,84,Rue Jean Lemoine,Romainville,
+84 Rue Jean Lemoine,2.446053,48.878784,,84,Rue Jean Lemoine,,93230
+19 Avenue du Président John Kennedy Rosny-sous-Bois,,,,19,Avenue du Président John Kennedy,,93110
+19 Avenue du Président John Kennedy 93110,,,,19,Avenue du Président John Kennedy,Rosny-sous-Bois,
+19 Avenue du Président John Kennedy,2.487719,48.878153,,19,Avenue du Président John Kennedy,,93110
+39 Rue Loubet Saint-Denis,,,,39,Rue Loubet,,93200
+39 Rue Loubet 93200,,,,39,Rue Loubet,Saint-Denis,
+39 Rue Loubet,2.359363,48.948737,,39,Rue Loubet,,93200
+8 Rue Mathieu Saint-Ouen,,,,8,Rue Mathieu,,93400
+8 Rue Mathieu 93400,,,,8,Rue Mathieu,Saint-Ouen,
+8 Rue Mathieu,2.336726,48.905019,,8,Rue Mathieu,,93400
+48 Avenue de Livry Sevran,,,,48,Avenue de Livry,,93270
+48 Avenue de Livry 93270,,,,48,Avenue de Livry,Sevran,
+48 Avenue de Livry,2.53769,48.932286,,48,Avenue de Livry,,93270
+6 Avenue Jean Moulin Stains,,,,6,Avenue Jean Moulin,,93240
+6 Avenue Jean Moulin 93240,,,,6,Avenue Jean Moulin,Stains,
+6 Avenue Jean Moulin,2.39278,48.956541,,6,Avenue Jean Moulin,,93240
+13 Avenue Cuvier Tremblay-en-France,,,,13,Avenue Cuvier,,93290
+13 Avenue Cuvier 93290,,,,13,Avenue Cuvier,Tremblay-en-France,
+13 Avenue Cuvier,2.576959,48.95916,,13,Avenue Cuvier,,93290
+32BIS Rue des Vosges Tremblay-en-France,,,,32BIS,Rue des Vosges,,93290
+32BIS Rue des Vosges 93290,,,,32BIS,Rue des Vosges,Tremblay-en-France,
+32BIS Rue des Vosges,2.578161,48.942858,,32BIS,Rue des Vosges,,93290
+20 Avenue Lespinasse Villemomble,,,,20,Avenue Lespinasse,,93250
+20 Avenue Lespinasse 93250,,,,20,Avenue Lespinasse,Villemomble,
+20 Avenue Lespinasse,2.517988,48.881659,,20,Avenue Lespinasse,,93250
+15 Rue Georges Bougault Villepinte,,,,15,Rue Georges Bougault,,93420
+15 Rue Georges Bougault 93420,,,,15,Rue Georges Bougault,Villepinte,
+15 Rue Georges Bougault,2.528761,48.968198,,15,Rue Georges Bougault,,93420
+4 Rue Maurice Paillard Villetaneuse,,,,4,Rue Maurice Paillard,,93430
+4 Rue Maurice Paillard 93430,,,,4,Rue Maurice Paillard,Villetaneuse,
+4 Rue Maurice Paillard,2.34672,48.955582,,4,Rue Maurice Paillard,,93430
+77 Rue Victor Hugo Alfortville,,,,77,Rue Victor Hugo,,94140
+77 Rue Victor Hugo 94140,,,,77,Rue Victor Hugo,Alfortville,
+77 Rue Victor Hugo,2.424299,48.803865,,77,Rue Victor Hugo,,94140
+8 Allée des Sources Boissy-Saint-Léger,,,,8,Allée des Sources,,94470
+8 Allée des Sources 94470,,,,8,Allée des Sources,Boissy-Saint-Léger,
+8 Allée des Sources,2.506852,48.75002,,8,Allée des Sources,,94470
+6 Rue Ange Rubaud Cachan,,,,6,Rue Ange Rubaud,,94230
+6 Rue Ange Rubaud 94230,,,,6,Rue Ange Rubaud,Cachan,
+6 Rue Ange Rubaud,2.331972,48.785616,,6,Rue Ange Rubaud,,94230
+51 Rue du Bois-l'Abbé Champigny-sur-Marne,,,,51,Rue du Bois-l'Abbé,,94500
+51 Rue du Bois-l'Abbé 94500,,,,51,Rue du Bois-l'Abbé,Champigny-sur-Marne,
+51 Rue du Bois-l'Abbé,2.542121,48.810435,,51,Rue du Bois-l'Abbé,,94500
+6 Villa Laversin Champigny-sur-Marne,,,,6,Villa Laversin,,94500
+6 Villa Laversin 94500,,,,6,Villa Laversin,Champigny-sur-Marne,
+6 Villa Laversin,2.50578,48.82239,,6,Villa Laversin,,94500
+11 Impasse des Vergers Champigny-sur-Marne,,,,11,Impasse des Vergers,,94500
+11 Impasse des Vergers 94500,,,,11,Impasse des Vergers,Champigny-sur-Marne,
+11 Impasse des Vergers,2.521424,48.813282,,11,Impasse des Vergers,,94500
+12 Avenue Thérèse Chennevières-sur-Marne,,,,12,Avenue Thérèse,,94430
+12 Avenue Thérèse 94430,,,,12,Avenue Thérèse,Chennevières-sur-Marne,
+12 Avenue Thérèse,2.538231,48.801484,,12,Avenue Thérèse,,94430
+89 Avenue du Maréchal de Lattre de Tassigny Choisy-le-Roi,,,,89,Avenue du Maréchal de Lattre de Tassigny,,94600
+89 Avenue du Maréchal de Lattre de Tassigny 94600,,,,89,Avenue du Maréchal de Lattre de Tassigny,Choisy-le-Roi,
+89 Avenue du Maréchal de Lattre de Tassigny,2.40506,48.755321,,89,Avenue du Maréchal de Lattre de Tassigny,,94600
+2 Avenue du Maréchal Foch Créteil,,,,2,Avenue du Maréchal Foch,,94000
+2 Avenue du Maréchal Foch 94000,,,,2,Avenue du Maréchal Foch,Créteil,
+2 Avenue du Maréchal Foch,2.440394,48.772065,,2,Avenue du Maréchal Foch,,94000
+5 Boulevard Henri Ruel Fontenay-sous-Bois,,,,5,Boulevard Henri Ruel,,94120
+5 Boulevard Henri Ruel 94120,,,,5,Boulevard Henri Ruel,Fontenay-sous-Bois,
+5 Boulevard Henri Ruel,2.466629,48.842771,,5,Boulevard Henri Ruel,,94120
+20 Rue Jules Guesde Fresnes,,,,20,Rue Jules Guesde,,94260
+20 Rue Jules Guesde 94260,,,,20,Rue Jules Guesde,Fresnes,
+20 Rue Jules Guesde,2.314301,48.760445,,20,Rue Jules Guesde,,94260
+9 Rue du 8 Mai 1945 L'Haÿ-les-Roses,,,,9,Rue du 8 Mai 1945,,94240
+9 Rue du 8 Mai 1945 94240,,,,9,Rue du 8 Mai 1945,L'Haÿ-les-Roses,
+9 Rue du 8 Mai 1945,2.330291,48.778614,,9,Rue du 8 Mai 1945,,94240
+30 Rue Pasteur Ivry-sur-Seine,,,,30,Rue Pasteur,,94200
+30 Rue Pasteur 94200,,,,30,Rue Pasteur,Ivry-sur-Seine,
+30 Rue Pasteur,2.38276,48.816849,,30,Rue Pasteur,,94200
+74 Rue du Général Leclerc Le Kremlin-Bicêtre,,,,74,Rue du Général Leclerc,,94270
+74 Rue du Général Leclerc 94270,,,,74,Rue du Général Leclerc,Le Kremlin-Bicêtre,
+74 Rue du Général Leclerc,2.358054,48.811095,,74,Rue du Général Leclerc,,94270
+42 Rue Edmond Nocard Maisons-Alfort,,,,42,Rue Edmond Nocard,,94700
+42 Rue Edmond Nocard 94700,,,,42,Rue Edmond Nocard,Maisons-Alfort,
+42 Rue Edmond Nocard,2.428785,48.81266,,42,Rue Edmond Nocard,,94700
+4 Rue des Perdrix Mandres-les-Roses,,,,4,Rue des Perdrix,,94520
+4 Rue des Perdrix 94520,,,,4,Rue des Perdrix,Mandres-les-Roses,
+4 Rue des Perdrix,2.558741,48.710072,,4,Rue des Perdrix,,94520
+8 Rue Saint-Sébastien Nogent-sur-Marne,,,,8,Rue Saint-Sébastien,,94130
+8 Rue Saint-Sébastien 94130,,,,8,Rue Saint-Sébastien,Nogent-sur-Marne,
+8 Rue Saint-Sébastien,2.485685,48.837408,,8,Rue Saint-Sébastien,,94130
+4 Rue de Bellevue Ormesson-sur-Marne,,,,4,Rue de Bellevue,,94490
+4 Rue de Bellevue 94490,,,,4,Rue de Bellevue,Ormesson-sur-Marne,
+4 Rue de Bellevue,2.523104,48.778971,,4,Rue de Bellevue,,94490
+28 Rue du Bel-Air Le Perreux-sur-Marne,,,,28,Rue du Bel-Air,,94170
+28 Rue du Bel-Air 94170,,,,28,Rue du Bel-Air,Le Perreux-sur-Marne,
+28 Rue du Bel-Air,2.498401,48.84463,,28,Rue du Bel-Air,,94170
+17 Rue Traversière Le Perreux-sur-Marne,,,,17,Rue Traversière,,94170
+17 Rue Traversière 94170,,,,17,Rue Traversière,Le Perreux-sur-Marne,
+17 Rue Traversière,2.51028,48.8487,,17,Rue Traversière,,94170
+23 Avenue Lamartine La Queue-en-Brie,,,,23,Avenue Lamartine,,94510
+23 Avenue Lamartine 94510,,,,23,Avenue Lamartine,La Queue-en-Brie,
+23 Avenue Lamartine,2.572509,48.794531,,23,Avenue Lamartine,,94510
+16 Rue de Beaujeu Saint-Maur-des-Fossés,,,,16,Rue de Beaujeu,,94100
+16 Rue de Beaujeu 94100,,,,16,Rue de Beaujeu,Saint-Maur-des-Fossés,
+16 Rue de Beaujeu,2.47781,48.797308,,16,Rue de Beaujeu,,94100
+24 Allée Ferret Briet Saint-Maur-des-Fossés,,,,24,Allée Ferret Briet,,94100
+24 Allée Ferret Briet 94100,,,,24,Allée Ferret Briet,Saint-Maur-des-Fossés,
+24 Allée Ferret Briet,2.472462,48.798063,,24,Allée Ferret Briet,,94100
+14 Avenue de la Mésange Saint-Maur-des-Fossés,,,,14,Avenue de la Mésange,,94100
+14 Avenue de la Mésange 94100,,,,14,Avenue de la Mésange,Saint-Maur-des-Fossés,
+14 Avenue de la Mésange,2.50007,48.801484,,14,Avenue de la Mésange,,94100
+43 Boulevard Voltaire Saint-Maur-des-Fossés,,,,43,Boulevard Voltaire,,94100
+43 Boulevard Voltaire 94100,,,,43,Boulevard Voltaire,Saint-Maur-des-Fossés,
+43 Boulevard Voltaire,2.50806,48.790674,,43,Boulevard Voltaire,,94100
+33 Sentier des Clos Sucy-en-Brie,,,,33,Sentier des Clos,,94370
+33 Sentier des Clos 94370,,,,33,Sentier des Clos,Sucy-en-Brie,
+33 Sentier des Clos,2.518731,48.767132,,33,Sentier des Clos,,94370
+25 Avenue Léon Marchand Thiais,,,,25,Avenue Léon Marchand,,94320
+25 Avenue Léon Marchand 94320,,,,25,Avenue Léon Marchand,Thiais,
+25 Avenue Léon Marchand,2.388859,48.766059,,25,Avenue Léon Marchand,,94320
+30 Rue des Mardelles Villecresnes,,,,30,Rue des Mardelles,,94440
+30 Rue des Mardelles 94440,,,,30,Rue des Mardelles,Villecresnes,
+30 Rue des Mardelles,2.525679,48.711904,,30,Rue des Mardelles,,94440
+73 Boulevard Maxime Gorki Villejuif,,,,73,Boulevard Maxime Gorki,,94800
+73 Boulevard Maxime Gorki 94800,,,,73,Boulevard Maxime Gorki,Villejuif,
+73 Boulevard Maxime Gorki,2.369059,48.794894,,73,Boulevard Maxime Gorki,,94800
+2 Place Louis Jacquart Villeneuve-le-Roi,,,,2,Place Louis Jacquart,,94290
+2 Place Louis Jacquart 94290,,,,2,Place Louis Jacquart,Villeneuve-le-Roi,
+2 Place Louis Jacquart,2.416746,48.734077,,2,Place Louis Jacquart,,94290
+3 Rue Jacquard Villeneuve-Saint-Georges,,,,3,Rue Jacquard,,94190
+3 Rue Jacquard 94190,,,,3,Rue Jacquard,Villeneuve-Saint-Georges,
+3 Rue Jacquard,2.447333,48.746102,,3,Rue Jacquard,,94190
+24 Rue J J Rousseau Villiers-sur-Marne,,,,24,Rue Jean-Jacques Rousseau,,94350
+24 Rue J J Rousseau 94350,,,,24,Rue Jean-Jacques Rousseau,Villiers-sur-Marne,
+24 Rue J J Rousseau,2.533222,48.820029,,24,Rue Jean-Jacques Rousseau,,94350
+47 Rue de la Prévoyance Vincennes,,,,47,Rue de la Prévoyance,,94300
+47 Rue de la Prévoyance 94300,,,,47,Rue de la Prévoyance,Vincennes,
+47 Rue de la Prévoyance,2.420582,48.848496,,47,Rue de la Prévoyance,,94300
+32 Avenue Eugène Pelletan Vitry-sur-Seine,,,,32,Avenue Eugène Pelletan,,94400
+32 Avenue Eugène Pelletan 94400,,,,32,Avenue Eugène Pelletan,Vitry-sur-Seine,
+32 Avenue Eugène Pelletan,2.385079,48.794448,,32,Avenue Eugène Pelletan,,94400
+25 Avenue Pierre Brossolette Vitry-sur-Seine,,,,25,Avenue Pierre Brossolette,,94400
+25 Avenue Pierre Brossolette 94400,,,,25,Avenue Pierre Brossolette,Vitry-sur-Seine,
+25 Avenue Pierre Brossolette,2.403031,48.803379,,25,Avenue Pierre Brossolette,,94400
+13 Rue du Docteur Roux Argenteuil,,,,13,Rue du Docteur Roux,,95100
+13 Rue du Docteur Roux 95100,,,,13,Rue du Docteur Roux,Argenteuil,
+13 Rue du Docteur Roux,2.227171,48.942175,,13,Rue du Docteur Roux,,95100
+28 Rue de la Luitte Argenteuil,,,,28,Rue de la Luitte,,95100
+28 Rue de la Luitte 95100,,,,28,Rue de la Luitte,Argenteuil,
+28 Rue de la Luitte,2.277504,48.959994,,28,Rue de la Luitte,,95100
+6 Rue de la Rosière Argenteuil,,,,6,Rue de la Rosière,,95100
+6 Rue de la Rosière 95100,,,,6,Rue de la Rosière,Argenteuil,
+6 Rue de la Rosière,2.236446,48.961134,,6,Rue de la Rosière,,95100
+12 Rue Schmitz Auvers-sur-Oise,,,,12,Rue Schmitz,,95430
+12 Rue Schmitz 95430,,,,12,Rue Schmitz,Auvers-sur-Oise,
+12 Rue Schmitz,2.126431,49.066041,,12,Rue Schmitz,,95430
+2 Rue du Maréchal Foch Bezons,,,,2,Rue du Maréchal Foch,,95870
+2 Rue du Maréchal Foch 95870,,,,2,Rue du Maréchal Foch,Bezons,
+2 Rue du Maréchal Foch,2.205703,48.928269,,2,Rue du Maréchal Foch,,95870
+34 Rue des Heuruelles Pourpres Cergy,,,,34,Rue des Heuruelles Pourpres,,95000
+34 Rue des Heuruelles Pourpres 95000,,,,34,Rue des Heuruelles Pourpres,Cergy,
+34 Rue des Heuruelles Pourpres,2.056722,49.046782,,34,Rue des Heuruelles Pourpres,,95000
+36 Rue des Brûlis Chaumontel,,,,36,Rue des Brûlis,,95270
+36 Rue des Brûlis 95270,,,,36,Rue des Brûlis,Chaumontel,
+36 Rue des Brûlis,2.435961,49.123668,,36,Rue des Brûlis,,95270
+1 Rue Jonas Deuil-la-Barre,,,,1,Rue Jonas,,95170
+1 Rue Jonas 95170,,,,1,Rue Jonas,Deuil-la-Barre,
+1 Rue Jonas,2.325579,48.963833,,1,Rue Jonas,,95170
+11 Avenue de l'Alliance Eaubonne,,,,11,Avenue de l'Alliance,,95600
+11 Avenue de l'Alliance 95600,,,,11,Avenue de l'Alliance,Eaubonne,
+11 Avenue de l'Alliance,2.288625,48.978438,,11,Avenue de l'Alliance,,95600
+8BIS Boulevard Cotte Enghien-les-Bains,,,,8BIS,Boulevard Cotte,,95880
+8BIS Boulevard Cotte 95880,,,,8BIS,Boulevard Cotte,Enghien-les-Bains,
+8BIS Boulevard Cotte,2.307069,48.96795,,8BIS,Boulevard Cotte,,95880
+3 Rue Constant Coquelin Ermont,,,,3,Rue Constant Coquelin,,95120
+3 Rue Constant Coquelin 95120,,,,3,Rue Constant Coquelin,Ermont,
+3 Rue Constant Coquelin,2.252361,49.000971,,3,Rue Constant Coquelin,,95120
+7 Allée Paul Cézanne Ézanville,,,,7,Allée Paul Cézanne,,95460
+7 Allée Paul Cézanne 95460,,,,7,Allée Paul Cézanne,Ézanville,
+7 Allée Paul Cézanne,2.341404,49.037278,,7,Allée Paul Cézanne,,95460
+15 Allée des Érables Franconville,,,,15,Allée des Érables,,95130
+15 Allée des Érables 95130,,,,15,Allée des Érables,Franconville,
+15 Allée des Érables,2.213699,48.988501,,15,Allée des Érables,,95130
+15 Rue Pasteur Garges-lès-Gonesse,,,,15,Rue Pasteur,,95140
+15 Rue Pasteur 95140,,,,15,Rue Pasteur,Garges-lès-Gonesse,
+15 Rue Pasteur,2.398733,48.961269,,15,Rue Pasteur,,95140
+23 Rue Armand Carrel Goussainville,,,,23,Rue Armand Carrel,,95190
+23 Rue Armand Carrel 95190,,,,23,Rue Armand Carrel,Goussainville,
+23 Rue Armand Carrel,2.4807,49.032815,,23,Rue Armand Carrel,,95190
+9 Rue des Pensées Goussainville,,,,9,Rue des Pensées,,95190
+9 Rue des Pensées 95190,,,,9,Rue des Pensées,Goussainville,
+9 Rue des Pensées,2.47003,49.026778,,9,Rue des Pensées,,95190
+21 Avenue de la Chesnaie Herblay,,,,21,Avenue de la Chesnaie,,95220
+21 Avenue de la Chesnaie 95220,,,,21,Avenue de la Chesnaie,Herblay,
+21 Avenue de la Chesnaie,2.158023,49.000849,,21,Avenue de la Chesnaie,,95220
+2 Place du Truffier Herblay,,,,2,Place du Truffier,,95220
+2 Place du Truffier 95220,,,,2,Place du Truffier,Herblay,
+2 Place du Truffier,2.154336,49.002014,,2,Place du Truffier,,95220
+9 Place de la Hayette Jouy-le-Moutier,,,,9,Place de la Hayette,,95280
+9 Place de la Hayette 95280,,,,9,Place de la Hayette,Jouy-le-Moutier,
+9 Place de la Hayette,2.038193,49.007774,,9,Place de la Hayette,,95280
+8 Allée du Pré Aux Cerfs Luzarches,,,,8,Allée du Pré aux Cerfs,,95270
+8 Allée du Pré Aux Cerfs 95270,,,,8,Allée du Pré aux Cerfs,Luzarches,
+8 Allée du Pré Aux Cerfs,2.419913,49.119635,,8,Allée du Pré aux Cerfs,,95270
+63 Avenue Joliot Curie Mériel,,,,63,Avenue Joliot Curie,,95630
+63 Avenue Joliot Curie 95630,,,,63,Avenue Joliot Curie,Mériel,
+63 Avenue Joliot Curie,2.218536,49.073935,,63,Avenue Joliot Curie,,95630
+20 Chemin du Clos Prie Montmagny,,,,20,Chemin du Clos Prie,,95360
+20 Chemin du Clos Prie 95360,,,,20,Chemin du Clos Prie,Montmagny,
+20 Chemin du Clos Prie,2.358622,48.975244,,20,Chemin du Clos Prie,,95360
+65 Rue de la République Montmorency,,,,65,Rue de la République,,95160
+65 Rue de la République 95160,,,,65,Rue de la République,Montmorency,
+65 Rue de la République,2.3096,48.979099,,65,Rue de la République,,95160
+10 Rue des Voltigeurs Osny,,,,10,Rue des Voltigeurs,,95520
+10 Rue des Voltigeurs 95520,,,,10,Rue des Voltigeurs,Osny,
+10 Rue des Voltigeurs,2.069673,49.068445,,10,Rue des Voltigeurs,,95520
+54 Rue des Etannets Pontoise,,,,54,Rue des Etannets,,95000
+54 Rue des Etannets 95000,,,,54,Rue des Etannets,Pontoise,
+54 Rue des Etannets,2.090192,49.050837,,54,Rue des Etannets,,95000
+29 Avenue Lacour Saint-Gratien,,,,29,Avenue Lacour,,95210
+29 Avenue Lacour 95210,,,,29,Avenue Lacour,Saint-Gratien,
+29 Avenue Lacour,2.286127,48.973875,,29,Avenue Lacour,,95210
+4 Allée de la Paix Saint-Leu-la-Forêt,,,,4,Allée de la Paix,,95320
+4 Allée de la Paix 95320,,,,4,Allée de la Paix,Saint-Leu-la-Forêt,
+4 Allée de la Paix,2.238786,49.019158,,4,Allée de la Paix,,95320
+47 Rue d'Ermont Saint-Prix,,,,47,Rue d'Ermont,,95390
+47 Rue d'Ermont 95390,,,,47,Rue d'Ermont,Saint-Prix,
+47 Rue d'Ermont,2.261729,49.006435,,47,Rue d'Ermont,,95390
+79 Rue du Maréchal Joffre Sannois,,,,79,Rue du Maréchal Joffre,,95110
+79 Rue du Maréchal Joffre 95110,,,,79,Rue du Maréchal Joffre,Sannois,
+79 Rue du Maréchal Joffre,2.26379,48.97439,,79,Rue du Maréchal Joffre,,95110
+21BIS Rue des Saules Soisy-sous-Montmorency,,,,21BIS,Rue des Saules,,95230
+21BIS Rue des Saules 95230,,,,21BIS,Rue des Saules,Soisy-sous-Montmorency,
+21BIS Rue des Saules,2.310314,48.991199,,21BIS,Rue des Saules,,95230
+45 Chemin des Petits Sentiers Taverny,,,,45,Chemin des Petits Sentiers,,95150
+45 Chemin des Petits Sentiers 95150,,,,45,Chemin des Petits Sentiers,Taverny,
+45 Chemin des Petits Sentiers,2.222019,49.017998,,45,Chemin des Petits Sentiers,,95150
+28 Rue Messidor Vauréal,,,,28,Rue Messidor,,95490
+28 Rue Messidor 95490,,,,28,Rue Messidor,Vauréal,
+28 Rue Messidor,2.01306,49.028342,,28,Rue Messidor,,95490

--- a/geocoder_tester/world/france/languedocroussillon/test_addresses.csv
+++ b/geocoder_tester/world/france/languedocroussillon/test_addresses.csv
@@ -1,451 +1,451 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-11 Rue du Fort Barbaira,,,,11 Rue du Fort,,,,11800
-11 Rue du Fort 11800,,,,11 Rue du Fort,,,Barbaira,
-11 Rue du Fort,2.509534,43.183902,,11 Rue du Fort,,,,11800
-34 Avenue des Anciens Combattants Capendu,,,,34 Avenue des Anciens Combattants,,,,11700
-34 Avenue des Anciens Combattants 11700,,,,34 Avenue des Anciens Combattants,,,Capendu,
-34 Avenue des Anciens Combattants,2.555346,43.185447,,34 Avenue des Anciens Combattants,,,,11700
-9 Rue des Études Carcassonne,,,,9 Rue des Études,,,,11000
-9 Rue des Études 11000,,,,9 Rue des Études,,,Carcassonne,
-9 Rue des Études,2.348515,43.211265,,9 Rue des Études,,,,11000
-7 Place Marcou Carcassonne,,,,7 Place Marcou,,,,11000
-7 Place Marcou 11000,,,,7 Place Marcou,,,Carcassonne,
-7 Place Marcou,2.364929,43.206461,,7 Place Marcou,,,,11000
-102 Rue Trivalle Carcassonne,,,,102 Rue Trivalle,,,,11000
-102 Rue Trivalle 11000,,,,102 Rue Trivalle,,,Carcassonne,
-102 Rue Trivalle,2.364638,43.209361,,102 Rue Trivalle,,,,11000
-9 Avenue des Bosquets Caux-et-Sauzens,,,,9 Avenue des Bosquets,,,,11170
-9 Avenue des Bosquets 11170,,,,9 Avenue des Bosquets,,,Caux-et-Sauzens,
-9 Avenue des Bosquets,2.257166,43.220486,,9 Avenue des Bosquets,,,,11170
-13 Avenue Frédéric Mistral Coursan,,,,13 Avenue Frédéric Mistral,,,,11110
-13 Avenue Frédéric Mistral 11110,,,,13 Avenue Frédéric Mistral,,,Coursan,
-13 Avenue Frédéric Mistral,3.057388,43.234421,,13 Avenue Frédéric Mistral,,,,11110
-225 Rue de l'Égalité Espéraza,,,,225 Rue de l'Égalité,,,,11260
-225 Rue de l'Égalité 11260,,,,225 Rue de l'Égalité,,,Espéraza,
-225 Rue de l'Égalité,2.220285,42.936589,,225 Rue de l'Égalité,,,,11260
-19BIS Rue des Pétrels Fleury,,,,19BIS Rue des Pétrels,,,,11560
-19BIS Rue des Pétrels 11560,,,,19BIS Rue des Pétrels,,,Fleury,
-19BIS Rue des Pétrels,3.182476,43.177115,,19BIS Rue des Pétrels,,,,11560
-20 Chalets 10E Rangée Gruissan,,,,20 Chalets 10E Rangée,,,,11430
-20 Chalets 10E Rangée 11430,,,,20 Chalets 10E Rangée,,,Gruissan,
-20 Chalets 10E Rangée,3.117681,43.107258,,20 Chalets 10E Rangée,,,,11430
-4 Rue Émile Bertrand Leucate,,,,4 Rue Émile Bertrand,,,,11370
-4 Rue Émile Bertrand 11370,,,,4 Rue Émile Bertrand,,,Leucate,
-4 Rue Émile Bertrand,3.036168,42.931546,,4 Rue Émile Bertrand,,,,11370
-5 Rue Peyronnet Lézignan-Corbières,,,,5 Rue Peyronnet,,,,11200
-5 Rue Peyronnet 11200,,,,5 Rue Peyronnet,,,Lézignan-Corbières,
-5 Rue Peyronnet,2.759861,43.199386,,5 Rue Peyronnet,,,,11200
-7 Rue du Cers Luc-sur-Orbieu,,,,7 Rue du Cers,,,,11200
-7 Rue du Cers 11200,,,,7 Rue du Cers,,,Luc-sur-Orbieu,
-7 Rue du Cers,2.783382,43.175923,,7 Rue du Cers,,,,11200
-6 Place du Monument aux Morts Moussan,,,,6 Place du Monument aux Morts,,,,11120
-6 Place du Monument aux Morts 11120,,,,6 Place du Monument aux Morts,,,Moussan,
-6 Place du Monument aux Morts,2.949762,43.231694,,6 Place du Monument aux Morts,,,,11120
-59 Avenue de la Coupe Narbonne,,,,59 Avenue de la Coupe,,,,11100
-59 Avenue de la Coupe 11100,,,,59 Avenue de la Coupe,,,Narbonne,
-59 Avenue de la Coupe,2.975098,43.157952,,59 Avenue de la Coupe,,,,11100
-24 Rue du Maine Narbonne,,,,24 Rue du Maine,,,,11100
-24 Rue du Maine 11100,,,,24 Rue du Maine,,,Narbonne,
-24 Rue du Maine,3.017903,43.196987,,24 Rue du Maine,,,,11100
-80 Rue Turenne Narbonne,,,,80 Rue Turenne,,,,11100
-80 Rue Turenne 11100,,,,80 Rue Turenne,,,Narbonne,
-80 Rue Turenne,3.001646,43.176403,,80 Rue Turenne,,,,11100
-94 Avenue Saint-Marc Ornaisons,,,,94 Avenue Saint-Marc,,,,11200
-94 Avenue Saint-Marc 11200,,,,94 Avenue Saint-Marc,,,Ornaisons,
-94 Avenue Saint-Marc,2.831688,43.181145,,94 Avenue Saint-Marc,,,,11200
-1 Place de la Provence Pezens,,,,1 Place de la Provence,,,,11170
-1 Place de la Provence 11170,,,,1 Place de la Provence,,,Pezens,
-1 Place de la Provence,2.269912,43.256630,,1 Place de la Provence,,,,11170
-32 Rue Saint-Blaise Rieux-Minervois,,,,32 Rue Saint-Blaise,,,,11160
-32 Rue Saint-Blaise 11160,,,,32 Rue Saint-Blaise,,,Rieux-Minervois,
-32 Rue Saint-Blaise,2.588036,43.282774,,32 Rue Saint-Blaise,,,,11160
-18 Rue de l'Aubier Sallèles-d'Aude,,,,18 Rue de l'Aubier,,,,11590
-18 Rue de l'Aubier 11590,,,,18 Rue de l'Aubier,,,Sallèles-d'Aude,
-18 Rue de l'Aubier,2.946255,43.265117,,18 Rue de l'Aubier,,,,11590
-8 Rue Jules Michelet Sigean,,,,8 Rue Jules Michelet,,,,11130
-8 Rue Jules Michelet 11130,,,,8 Rue Jules Michelet,,,Sigean,
-8 Rue Jules Michelet,2.976562,43.020260,,8 Rue Jules Michelet,,,,11130
-31 Rue des Carriers Villegailhenc,,,,31 Rue des Carriers,,,,11600
-31 Rue des Carriers 11600,,,,31 Rue des Carriers,,,Villegailhenc,
-31 Rue des Carriers,2.354165,43.269483,,31 Rue des Carriers,,,,11600
-4 Rue du Pommier Aimargues,,,,4 Rue du Pommier,,,,30470
-4 Rue du Pommier 30470,,,,4 Rue du Pommier,,,Aimargues,
-4 Rue du Pommier,4.201634,43.699408,,4 Rue du Pommier,,,,30470
-12 Rue Jean Aicard Alès,,,,12 Rue Jean Aicard,,,,30100
-12 Rue Jean Aicard 30100,,,,12 Rue Jean Aicard,,,Alès,
-12 Rue Jean Aicard,4.094476,44.131753,,12 Rue Jean Aicard,,,,30100
-15 Rue Taisson Alès,,,,15 Rue Taisson,,,,30100
-15 Rue Taisson 30100,,,,15 Rue Taisson,,,Alès,
-15 Rue Taisson,4.078452,44.124384,,15 Rue Taisson,,,,30100
-28 Rue de la République Les Angles,,,,28 Rue de la République,,,,30133
-28 Rue de la République 30133,,,,28 Rue de la République,,,Les Angles,
-28 Rue de la République,4.766360,43.952370,,28 Rue de la République,,,,30133
-1031 Avenue Alphonse Daudet Bagnols-sur-Cèze,,,,1031 Avenue Alphonse Daudet,,,,30200
-1031 Avenue Alphonse Daudet 30200,,,,1031 Avenue Alphonse Daudet,,,Bagnols-sur-Cèze,
-1031 Avenue Alphonse Daudet,4.613304,44.152982,,1031 Avenue Alphonse Daudet,,,,30200
-40 Chemin de la Source Bagnols-sur-Cèze,,,,40 Chemin de la Source,,,,30200
-40 Chemin de la Source 30200,,,,40 Chemin de la Source,,,Bagnols-sur-Cèze,
-40 Chemin de la Source,4.607519,44.153717,,40 Chemin de la Source,,,,30200
-362 Chemin de l'Esquillon Beauvoisin,,,,362 Chemin de l'Esquillon,,,,30640
-362 Chemin de l'Esquillon 30640,,,,362 Chemin de l'Esquillon,,,Beauvoisin,
-362 Chemin de l'Esquillon,4.314159,43.714694,,362 Chemin de l'Esquillon,,,,30640
-360B Chemin de Marguerittes Bezouce,,,,360B Chemin de Marguerittes,,,,30320
-360B Chemin de Marguerittes 30320,,,,360B Chemin de Marguerittes,,,Bezouce,
-360B Chemin de Marguerittes,4.485703,43.879085,,360B Chemin de Marguerittes,,,,30320
-1 Chemin des Ayres Le Cailar,,,,1 Chemin des Ayres,,,,30740
-1 Chemin des Ayres 30740,,,,1 Chemin des Ayres,,,Le Cailar,
-1 Chemin des Ayres,4.234116,43.675602,,1 Chemin des Ayres,,,,30740
-1 Rue Turion Sabatier Castillon-du-Gard,,,,1 Rue Turion Sabatier,,,,30210
-1 Rue Turion Sabatier 30210,,,,1 Rue Turion Sabatier,,,Castillon-du-Gard,
-1 Rue Turion Sabatier,4.554719,43.970894,,1 Rue Turion Sabatier,,,,30210
-1 Rue du Moulin à Huile Combas,,,,1 Rue du Moulin à Huile,,,,30250
-1 Rue du Moulin à Huile 30250,,,,1 Rue du Moulin à Huile,,,Combas,
-1 Rue du Moulin à Huile,4.112049,43.853998,,1 Rue du Moulin à Huile,,,,30250
-26 Rue de la Costière Garons,,,,26 Rue de la Costière,,,,30128
-26 Rue de la Costière 30128,,,,26 Rue de la Costière,,,Garons,
-26 Rue de la Costière,4.431799,43.765668,,26 Rue de la Costière,,,,30128
-15 Impasse des Cigales Le Grau-du-Roi,,,,15 Impasse des Cigales,,,,30240
-15 Impasse des Cigales 30240,,,,15 Impasse des Cigales,,,Le Grau-du-Roi,
-15 Impasse des Cigales,4.143067,43.520524,,15 Impasse des Cigales,,,,30240
-505 Rue Emile Zola Laudun-l'Ardoise,,,,505 Rue Emile Zola,,,,30290
-505 Rue Emile Zola 30290,,,,505 Rue Emile Zola,,,Laudun-l'Ardoise,
-505 Rue Emile Zola,4.669990,44.106979,,505 Rue Emile Zola,,,,30290
-9 Rue des Anciens Combattants Marguerittes,,,,9 Rue des Anciens Combattants,,,,30320
-9 Rue des Anciens Combattants 30320,,,,9 Rue des Anciens Combattants,,,Marguerittes,
-9 Rue des Anciens Combattants,4.437148,43.854392,,9 Rue des Anciens Combattants,,,,30320
-10 Rue Alphonse Daudet Milhaud,,,,10 Rue Alphonse Daudet,,,,30540
-10 Rue Alphonse Daudet 30540,,,,10 Rue Alphonse Daudet,,,Milhaud,
-10 Rue Alphonse Daudet,4.317366,43.792677,,10 Rue Alphonse Daudet,,,,30540
-40 Rue du Temple Mus,,,,40 Rue du Temple,,,,30121
-40 Rue du Temple 30121,,,,40 Rue du Temple,,,Mus,
-40 Rue du Temple,4.200455,43.740178,,40 Rue du Temple,,,,30121
-212 Impasse Bonne Brise Nîmes,,,,212 Impasse Bonne Brise,,,,30000
-212 Impasse Bonne Brise 30000,,,,212 Impasse Bonne Brise,,,Nîmes,
-212 Impasse Bonne Brise,4.332683,43.837978,,212 Impasse Bonne Brise,,,,30000
-18 Rue Edmond Rostand Nîmes,,,,18 Rue Edmond Rostand,,,,30000
-18 Rue Edmond Rostand 30000,,,,18 Rue Edmond Rostand,,,Nîmes,
-18 Rue Edmond Rostand,4.369179,43.850030,,18 Rue Edmond Rostand,,,,30000
-29B Avenue Jean Jaurès Nîmes,,,,29B Avenue Jean Jaurès,,,,30000
-29B Avenue Jean Jaurès 30000,,,,29B Avenue Jean Jaurès,,,Nîmes,
-29B Avenue Jean Jaurès,4.351594,43.834145,,29B Avenue Jean Jaurès,,,,30000
-130 Impasse des Orchidées Nîmes,,,,130 Impasse des Orchidées,,,,30000
-130 Impasse des Orchidées 30000,,,,130 Impasse des Orchidées,,,Nîmes,
-130 Impasse des Orchidées,4.381477,43.810838,,130 Impasse des Orchidées,,,,30000
-58 Rue Sainte-Perpétue Nîmes,,,,58 Rue Sainte-Perpétue,,,,30000
-58 Rue Sainte-Perpétue 30000,,,,58 Rue Sainte-Perpétue,,,Nîmes,
-58 Rue Sainte-Perpétue,4.376036,43.836243,,58 Rue Sainte-Perpétue,,,,30000
-19 Avenue Gaston Doumergue Pont-Saint-Esprit,,,,19 Avenue Gaston Doumergue,,,,30130
-19 Avenue Gaston Doumergue 30130,,,,19 Avenue Gaston Doumergue,,,Pont-Saint-Esprit,
-19 Avenue Gaston Doumergue,4.646512,44.254628,,19 Avenue Gaston Doumergue,,,,30130
-177 Voie Romaine Quissac,,,,177 Voie Romaine,,,,30260
-177 Voie Romaine 30260,,,,177 Voie Romaine,,,Quissac,
-177 Voie Romaine,4.005736,43.905849,,177 Voie Romaine,,,,30260
-35 Rue du 19 Mars 1962 Roquemaure,,,,35 Rue du 19 Mars 1962,,,,30150
-35 Rue du 19 Mars 1962 30150,,,,35 Rue du 19 Mars 1962,,,Roquemaure,
-35 Rue du 19 Mars 1962,4.785823,44.046466,,35 Rue du 19 Mars 1962,,,,30150
-5 Chemin de la Rouvière Saint-Bauzély,,,,5 Chemin de la Rouvière,,,,30730
-5 Chemin de la Rouvière 30730,,,,5 Chemin de la Rouvière,,,Saint-Bauzély,
-5 Chemin de la Rouvière,4.200742,43.921346,,5 Chemin de la Rouvière,,,,30730
-4 Impasse de l'Aqueduc Saint-Gervasy,,,,4 Impasse de l'Aqueduc,,,,30320
-4 Impasse de l'Aqueduc 30320,,,,4 Impasse de l'Aqueduc,,,Saint-Gervasy,
-4 Impasse de l'Aqueduc,4.463123,43.877580,,4 Impasse de l'Aqueduc,,,,30320
-170 Chemin de Saint-Hilaire A Trouillas Saint-Hilaire-de-Brethmas,,,,170 Chemin de Saint-Hilaire A Trouillas,,,,30560
-170 Chemin de Saint-Hilaire A Trouillas 30560,,,,170 Chemin de Saint-Hilaire A Trouillas,,,Saint-Hilaire-de-Brethmas,
-170 Chemin de Saint-Hilaire A Trouillas,4.127880,44.081987,,170 Chemin de Saint-Hilaire A Trouillas,,,,30560
-59 Rue Pierre-Babinot Saint-Laurent-d'Aigouze,,,,59 Rue Pierre-Babinot,,,,30220
-59 Rue Pierre-Babinot 30220,,,,59 Rue Pierre-Babinot,,,Saint-Laurent-d'Aigouze,
-59 Rue Pierre-Babinot,4.194101,43.634416,,59 Rue Pierre-Babinot,,,,30220
-99 Chemin du Viget Saint-Privat-des-Vieux,,,,99 Chemin du Viget,,,,30340
-99 Chemin du Viget 30340,,,,99 Chemin du Viget,,,Saint-Privat-des-Vieux,
-99 Chemin du Viget,4.120706,44.149931,,99 Chemin du Viget,,,,30340
-18 Rue Frédéric Mistral Saze,,,,18 Rue Frédéric Mistral,,,,30650
-18 Rue Frédéric Mistral 30650,,,,18 Rue Frédéric Mistral,,,Saze,
-18 Rue Frédéric Mistral,4.681719,43.942595,,18 Rue Frédéric Mistral,,,,30650
-12 Rue des Tamaris Uchaud,,,,12 Rue des Tamaris,,,,30620
-12 Rue des Tamaris 30620,,,,12 Rue des Tamaris,,,Uchaud,
-12 Rue des Tamaris,4.272253,43.757794,,12 Rue des Tamaris,,,,30620
-6 Rue Posquière Vauvert,,,,6 Rue Posquière,,,,30640
-6 Rue Posquière 30640,,,,6 Rue Posquière,,,Vauvert,
-6 Rue Posquière,4.277792,43.692519,,6 Rue Posquière,,,,30640
-895 Route du Pont de la Croix Le Vigan,,,,895 Route du Pont de la Croix,,,,30120
-895 Route du Pont de la Croix 30120,,,,895 Route du Pont de la Croix,,,Le Vigan,
-895 Route du Pont de la Croix,3.624068,43.989618,,895 Route du Pont de la Croix,,,,30120
-1 Impasse Di Capellus Rodilhan,,,,1 Impasse Di Capellus,,,,30230
-1 Impasse Di Capellus 30230,,,,1 Impasse Di Capellus,,,Rodilhan,
-1 Impasse Di Capellus,4.431379,43.830745,,1 Impasse Di Capellus,,,,30230
-9 Rue Francois Le Courtier Agde,,,,9 Rue Francois Le Courtier,,,,34300
-9 Rue Francois Le Courtier 34300,,,,9 Rue Francois Le Courtier,,,Agde,
-9 Rue Francois Le Courtier,3.458278,43.292557,,9 Rue Francois Le Courtier,,,,34300
-12 Rue Saint-Cesaire Agde,,,,12 Rue Saint-Cesaire,,,,34300
-12 Rue Saint-Cesaire 34300,,,,12 Rue Saint-Cesaire,,,Agde,
-12 Rue Saint-Cesaire,3.470905,43.300621,,12 Rue Saint-Cesaire,,,,34300
-5 Rue du Maréchal Leclerc Aspiran,,,,5 Rue du Maréchal Leclerc,,,,34800
-5 Rue du Maréchal Leclerc 34800,,,,5 Rue du Maréchal Leclerc,,,Aspiran,
-5 Rue du Maréchal Leclerc,3.449806,43.565690,,5 Rue du Maréchal Leclerc,,,,34800
-8 Impasse des Primevères Balaruc-les-Bains,,,,8 Impasse des Primevères,,,,34540
-8 Impasse des Primevères 34540,,,,8 Impasse des Primevères,,,Balaruc-les-Bains,
-8 Impasse des Primevères,3.703653,43.445346,,8 Impasse des Primevères,,,,34540
-3 Rue de l'Abreuvoir Berlou,,,,3 Rue de l'Abreuvoir,,,,34360
-3 Rue de l'Abreuvoir 34360,,,,3 Rue de l'Abreuvoir,,,Berlou,
-3 Rue de l'Abreuvoir,2.963197,43.492135,,3 Rue de l'Abreuvoir,,,,34360
-1456 Avenue du Préfet Claude Érignac Béziers,,,,1456 Avenue du Préfet Claude Érignac,,,,34500
-1456 Avenue du Préfet Claude Érignac 34500,,,,1456 Avenue du Préfet Claude Érignac,,,Béziers,
-1456 Avenue du Préfet Claude Érignac,3.213129,43.365010,,1456 Avenue du Préfet Claude Érignac,,,,34500
-23 Rue Honoré Daumier Béziers,,,,23 Rue Honoré Daumier,,,,34500
-23 Rue Honoré Daumier 34500,,,,23 Rue Honoré Daumier,,,Béziers,
-23 Rue Honoré Daumier,3.225281,43.347295,,23 Rue Honoré Daumier,,,,34500
-69 Rue Louis Pasteur Béziers,,,,69 Rue Louis Pasteur,,,,34500
-69 Rue Louis Pasteur 34500,,,,69 Rue Louis Pasteur,,,Béziers,
-69 Rue Louis Pasteur,3.228097,43.337448,,69 Rue Louis Pasteur,,,,34500
-59 Avenue Vingt Deux Aout 1944 Béziers,,,,59 Avenue Vingt Deux Aout 1944,,,,34500
-59 Avenue Vingt Deux Aout 1944 34500,,,,59 Avenue Vingt Deux Aout 1944,,,Béziers,
-59 Avenue Vingt Deux Aout 1944,3.220144,43.344142,,59 Avenue Vingt Deux Aout 1944,,,,34500
-3BIS Place de l'Église Brignac,,,,3BIS Place de l'Église,,,,34800
-3BIS Place de l'Église 34800,,,,3BIS Place de l'Église,,,Brignac,
-3BIS Place de l'Église,3.474652,43.623487,,3BIS Place de l'Église,,,,34800
-4 Rue Bacchus Castelnau-le-Lez,,,,4 Rue Bacchus,,,,34170
-4 Rue Bacchus 34170,,,,4 Rue Bacchus,,,Castelnau-le-Lez,
-4 Rue Bacchus,3.925686,43.644586,,4 Rue Bacchus,,,,34170
-57 Rue de la Tramontane Castries,,,,57 Rue de la Tramontane,,,,34160
-57 Rue de la Tramontane 34160,,,,57 Rue de la Tramontane,,,Castries,
-57 Rue de la Tramontane,3.976670,43.680666,,57 Rue de la Tramontane,,,,34160
-6 Placette des Mûriers Cazouls-lès-Béziers,,,,6 Placette des Mûriers,,,,34370
-6 Placette des Mûriers 34370,,,,6 Placette des Mûriers,,,Cazouls-lès-Béziers,
-6 Placette des Mûriers,3.101653,43.385824,,6 Placette des Mûriers,,,,34370
-316 Chemin de Sauviac Claret,,,,316 Chemin de Sauviac,,,,34270
-316 Chemin de Sauviac 34270,,,,316 Chemin de Sauviac,,,Claret,
-316 Chemin de Sauviac,3.903328,43.853370,,316 Chemin de Sauviac,,,,34270
-3 Rue des Coronilles Cournonsec,,,,3 Rue des Coronilles,,,,34660
-3 Rue des Coronilles 34660,,,,3 Rue des Coronilles,,,Cournonsec,
-3 Rue des Coronilles,3.698226,43.543795,,3 Rue des Coronilles,,,,34660
-16 Rue de la Sauvagine Le Crès,,,,16 Rue de la Sauvagine,,,,34920
-16 Rue de la Sauvagine 34920,,,,16 Rue de la Sauvagine,,,Le Crès,
-16 Rue de la Sauvagine,3.935624,43.663918,,16 Rue de la Sauvagine,,,,34920
-1 Rue des Peupliers Florensac,,,,1 Rue des Peupliers,,,,34510
-1 Rue des Peupliers 34510,,,,1 Rue des Peupliers,,,Florensac,
-1 Rue des Peupliers,3.475458,43.383614,,1 Rue des Peupliers,,,,34510
-10 Impasse des Primevères Frontignan,,,,10 Impasse des Primevères,,,,34110
-10 Impasse des Primevères 34110,,,,10 Impasse des Primevères,,,Frontignan,
-10 Impasse des Primevères,3.732403,43.434947,,10 Impasse des Primevères,,,,34110
-11 Avenue des Treilles Gigean,,,,11 Avenue des Treilles,,,,34770
-11 Avenue des Treilles 34770,,,,11 Avenue des Treilles,,,Gigean,
-11 Avenue des Treilles,3.707620,43.498863,,11 Avenue des Treilles,,,,34770
-3 Rue du Languedoc Jacou,,,,3 Rue du Languedoc,,,,34830
-3 Rue du Languedoc 34830,,,,3 Rue du Languedoc,,,Jacou,
-3 Rue du Languedoc,3.909344,43.658735,,3 Rue du Languedoc,,,,34830
-7 Rue des Flamants Roses Lansargues,,,,7 Rue des Flamants Roses,,,,34130
-7 Rue des Flamants Roses 34130,,,,7 Rue des Flamants Roses,,,Lansargues,
-7 Rue des Flamants Roses,4.070892,43.652730,,7 Rue des Flamants Roses,,,,34130
-28 Rue Pasiphae Lattes,,,,28 Rue Pasiphae,,,,34970
-28 Rue Pasiphae 34970,,,,28 Rue Pasiphae,,,Lattes,
-28 Rue Pasiphae,3.902711,43.576892,,28 Rue Pasiphae,,,,34970
-20 Impasse Raimu Lignan-sur-Orb,,,,20 Impasse Raimu,,,,34490
-20 Impasse Raimu 34490,,,,20 Impasse Raimu,,,Lignan-sur-Orb,
-20 Impasse Raimu,3.175538,43.379525,,20 Impasse Raimu,,,,34490
-14 Impasse du Cordelier Lunel,,,,14 Impasse du Cordelier,,,,34400
-14 Impasse du Cordelier 34400,,,,14 Impasse du Cordelier,,,Lunel,
-14 Impasse du Cordelier,4.134210,43.670959,,14 Impasse du Cordelier,,,,34400
-604 Avenue du Vidourle Lunel,,,,604 Avenue du Vidourle,,,,34400
-604 Avenue du Vidourle 34400,,,,604 Avenue du Vidourle,,,Lunel,
-604 Avenue du Vidourle,4.150523,43.683924,,604 Avenue du Vidourle,,,,34400
-316 Rue de Poussan Maraussan,,,,316 Rue de Poussan,,,,34370
-316 Rue de Poussan 34370,,,,316 Rue de Poussan,,,Maraussan,
-316 Rue de Poussan,3.159766,43.362898,,316 Rue de Poussan,,,,34370
-33 Place du Théatre Marseillan,,,,33 Place du Théatre,,,,34340
-33 Place du Théatre 34340,,,,33 Place du Théatre,,,Marseillan,
-33 Place du Théatre,3.529230,43.353799,,33 Place du Théatre,,,,34340
-163 Avenue Grassion Cibrand Carnon Mauguio,,,,163 Avenue Grassion Cibrand Carnon,,,,34280
-163 Avenue Grassion Cibrand Carnon 34280,,,,163 Avenue Grassion Cibrand Carnon,,,Mauguio,
-163 Avenue Grassion Cibrand Carnon,3.984266,43.546303,,163 Avenue Grassion Cibrand Carnon,,,,34280
-4 Rue Gaffarot Mèze,,,,4 Rue Gaffarot,,,,34140
-4 Rue Gaffarot 34140,,,,4 Rue Gaffarot,,,Mèze,
-4 Rue Gaffarot,3.608495,43.425989,,4 Rue Gaffarot,,,,34140
-8 Rue du Commerce Montagnac,,,,8 Rue du Commerce,,,,34530
-8 Rue du Commerce 34530,,,,8 Rue du Commerce,,,Montagnac,
-8 Rue du Commerce,3.483892,43.478951,,8 Rue du Commerce,,,,34530
-276 Côte des Ecureuils Montferrier-sur-Lez,,,,276 Côte des Ecureuils,,,,34980
-276 Côte des Ecureuils 34980,,,,276 Côte des Ecureuils,,,Montferrier-sur-Lez,
-276 Côte des Ecureuils,3.844786,43.672044,,276 Côte des Ecureuils,,,,34980
-6B Boulevard Berthelot Montpellier,,,,6B Boulevard Berthelot,,,,34090
-6B Boulevard Berthelot 34090,,,,6B Boulevard Berthelot,,,Montpellier,
-6B Boulevard Berthelot,3.870413,43.600639,,6B Boulevard Berthelot,,,,34090
-435 Rue de la Croix Verte Montpellier,,,,435 Rue de la Croix Verte,,,,34090
-435 Rue de la Croix Verte 34090,,,,435 Rue de la Croix Verte,,,Montpellier,
-435 Rue de la Croix Verte,3.838657,43.646070,,435 Rue de la Croix Verte,,,,34090
-5 Rue Général Riu Montpellier,,,,5 Rue Général Riu,,,,34090
-5 Rue Général Riu 34090,,,,5 Rue Général Riu,,,Montpellier,
-5 Rue Général Riu,3.882132,43.604499,,5 Rue Général Riu,,,,34090
-166B Avenue de Lodève Montpellier,,,,166B Avenue de Lodève,,,,34090
-166B Avenue de Lodève 34090,,,,166B Avenue de Lodève,,,Montpellier,
-166B Avenue de Lodève,3.842268,43.613285,,166B Avenue de Lodève,,,,34090
-33 Avenue de Palavas Montpellier,,,,33 Avenue de Palavas,,,,34090
-33 Avenue de Palavas 34090,,,,33 Avenue de Palavas,,,Montpellier,
-33 Avenue de Palavas,3.885154,43.599471,,33 Avenue de Palavas,,,,34090
-265 Rue Romy Schneider Montpellier,,,,265 Rue Romy Schneider,,,,34090
-265 Rue Romy Schneider 34090,,,,265 Rue Romy Schneider,,,Montpellier,
-265 Rue Romy Schneider,3.860698,43.587038,,265 Rue Romy Schneider,,,,34090
-7 Place Jacques Mirouze Montpellier,,,,7 Place Jacques Mirouze,,,,34090
-7 Place Jacques Mirouze 34090,,,,7 Place Jacques Mirouze,,,Montpellier,
-7 Place Jacques Mirouze,3.869907,43.612749,,7 Place Jacques Mirouze,,,,34090
-6 Avenue Bonnafé Edouard Murviel-lès-Béziers,,,,6 Avenue Bonnafé Edouard,,,,34490
-6 Avenue Bonnafé Edouard 34490,,,,6 Avenue Bonnafé Edouard,,,Murviel-lès-Béziers,
-6 Avenue Bonnafé Edouard,3.145488,43.442514,,6 Avenue Bonnafé Edouard,,,,34490
-3 Rue du Garajou Octon,,,,3 Rue du Garajou,,,,34800
-3 Rue du Garajou 34800,,,,3 Rue du Garajou,,,Octon,
-3 Rue du Garajou,3.304937,43.655922,,3 Rue du Garajou,,,,34800
-12 Avenue des Adrets Pérols,,,,12 Avenue des Adrets,,,,34470
-12 Avenue des Adrets 34470,,,,12 Avenue des Adrets,,,Pérols,
-12 Avenue des Adrets,3.941266,43.565554,,12 Avenue des Adrets,,,,34470
-6 Avenue Yves Brayer Pézenas,,,,6 Avenue Yves Brayer,,,,34120
-6 Avenue Yves Brayer 34120,,,,6 Avenue Yves Brayer,,,Pézenas,
-6 Avenue Yves Brayer,3.412110,43.454349,,6 Avenue Yves Brayer,,,,34120
-11 Rue Peiro Signado Portiragnes,,,,11 Rue Peiro Signado,,,,34420
-11 Rue Peiro Signado 34420,,,,11 Rue Peiro Signado,,,Portiragnes,
-11 Rue Peiro Signado,3.328685,43.308784,,11 Rue Peiro Signado,,,,34420
-1161 Route de Vendargues Prades-le-Lez,,,,1161 Route de Vendargues,,,,34730
-1161 Route de Vendargues 34730,,,,1161 Route de Vendargues,,,Prades-le-Lez,
-1161 Route de Vendargues,3.874166,43.692918,,1161 Route de Vendargues,,,,34730
-7 Impasse Suzanne Valadon Roujan,,,,7 Impasse Suzanne Valadon,,,,34320
-7 Impasse Suzanne Valadon 34320,,,,7 Impasse Suzanne Valadon,,,Roujan,
-7 Impasse Suzanne Valadon,3.308522,43.502234,,7 Impasse Suzanne Valadon,,,,34320
-5 Place Constantine Saint-Chinian,,,,5 Place Constantine,,,,34360
-5 Place Constantine 34360,,,,5 Place Constantine,,,Saint-Chinian,
-5 Place Constantine,2.945469,43.421672,,5 Place Constantine,,,,34360
-358 Rue du Carignan Saint-Gély-du-Fesc,,,,358 Rue du Carignan,,,,34980
-358 Rue du Carignan 34980,,,,358 Rue du Carignan,,,Saint-Gély-du-Fesc,
-358 Rue du Carignan,3.800204,43.703765,,358 Rue du Carignan,,,,34980
-8 Allée des Chênes Verts Saint-Georges-d'Orques,,,,8 Allée des Chênes Verts,,,,34680
-8 Allée des Chênes Verts 34680,,,,8 Allée des Chênes Verts,,,Saint-Georges-d'Orques,
-8 Allée des Chênes Verts,3.772187,43.608772,,8 Allée des Chênes Verts,,,,34680
-162 Rue du Château d'Eau Saint-Just,,,,162 Rue du Château d'Eau,,,,34400
-162 Rue du Château d'Eau 34400,,,,162 Rue du Château d'Eau,,,Saint-Just,
-162 Rue du Château d'Eau,4.113536,43.659521,,162 Rue du Château d'Eau,,,,34400
-17 Avenue de la Gare Saint-Pons-de-Thomières,,,,17 Avenue de la Gare,,,,34220
-17 Avenue de la Gare 34220,,,,17 Avenue de la Gare,,,Saint-Pons-de-Thomières,
-17 Avenue de la Gare,2.764949,43.487970,,17 Avenue de la Gare,,,,34220
-24 Chemin de Mazeilles Sauvian,,,,24 Chemin de Mazeilles,,,,34410
-24 Chemin de Mazeilles 34410,,,,24 Chemin de Mazeilles,,,Sauvian,
-24 Chemin de Mazeilles,3.266183,43.288052,,24 Chemin de Mazeilles,,,,34410
-6 Rue des Cigales Servian,,,,6 Rue des Cigales,,,,34290
-6 Rue des Cigales 34290,,,,6 Rue des Cigales,,,Servian,
-6 Rue des Cigales,3.303321,43.431253,,6 Rue des Cigales,,,,34290
-43 Rue Garenne Prolongée Sète,,,,43 Rue Garenne Prolongée,,,,34200
-43 Rue Garenne Prolongée 34200,,,,43 Rue Garenne Prolongée,,,Sète,
-43 Rue Garenne Prolongée,3.693808,43.400036,,43 Rue Garenne Prolongée,,,,34200
-3 Rue Raspail Sète,,,,3 Rue Raspail,,,,34200
-3 Rue Raspail 34200,,,,3 Rue Raspail,,,Sète,
-3 Rue Raspail,3.696695,43.409426,,3 Rue Raspail,,,,34200
-18 Rue Docteur Philémon Rastoul Thézan-lès-Béziers,,,,18 Rue Docteur Philémon Rastoul,,,,34490
-18 Rue Docteur Philémon Rastoul 34490,,,,18 Rue Docteur Philémon Rastoul,,,Thézan-lès-Béziers,
-18 Rue Docteur Philémon Rastoul,3.169923,43.420932,,18 Rue Docteur Philémon Rastoul,,,,34490
-8 Cami Founjut Valras-Plage,,,,8 Cami Founjut,,,,34350
-8 Cami Founjut 34350,,,,8 Cami Founjut,,,Valras-Plage,
-8 Cami Founjut,3.281590,43.243623,,8 Cami Founjut,,,,34350
-9 Rue de l'Aqueduc Romain Vendres,,,,9 Rue de l'Aqueduc Romain,,,,34350
-9 Rue de l'Aqueduc Romain 34350,,,,9 Rue de l'Aqueduc Romain,,,Vendres,
-9 Rue de l'Aqueduc Romain,3.226602,43.267294,,9 Rue de l'Aqueduc Romain,,,,34350
-14 Avenue de la Gare Villeneuve-lès-Béziers,,,,14 Avenue de la Gare,,,,34500
-14 Avenue de la Gare 34500,,,,14 Avenue de la Gare,,,Villeneuve-lès-Béziers,
-14 Avenue de la Gare,3.282143,43.319310,,14 Avenue de la Gare,,,,34500
-11 Rue du Peyrou Villeveyrac,,,,11 Rue du Peyrou,,,,34560
-11 Rue du Peyrou 34560,,,,11 Rue du Peyrou,,,Villeveyrac,
-11 Rue du Peyrou,3.607753,43.502270,,11 Rue du Peyrou,,,,34560
-14TER Route Mazet Nationale 599 Marvejols,,,,14TER Route Mazet Nationale 599,,,,48100
-14TER Route Mazet Nationale 599 48100,,,,14TER Route Mazet Nationale 599,,,Marvejols,
-14TER Route Mazet Nationale 599,3.303988,44.554247,,14TER Route Mazet Nationale 599,,,,48100
-2 Rue du Clerc Saint-Alban-sur-Limagnole,,,,2 Rue du Clerc,,,,48120
-2 Rue du Clerc 48120,,,,2 Rue du Clerc,,,Saint-Alban-sur-Limagnole,
-2 Rue du Clerc,3.388011,44.780860,,2 Rue du Clerc,,,,48120
-11 Rue Leconte de l'Isle Argelès-sur-Mer,,,,11 Rue Leconte de l'Isle,,,,66700
-11 Rue Leconte de l'Isle 66700,,,,11 Rue Leconte de l'Isle,,,Argelès-sur-Mer,
-11 Rue Leconte de l'Isle,3.027548,42.546754,,11 Rue Leconte de l'Isle,,,,66700
-28 Rue des Eaux Vives Baho,,,,28 Rue des Eaux Vives,,,,66540
-28 Rue des Eaux Vives 66540,,,,28 Rue des Eaux Vives,,,Baho,
-28 Rue des Eaux Vives,2.819128,42.703493,,28 Rue des Eaux Vives,,,,66540
-23 Boulevard du Grau Saint-Ange Le Barcarès,,,,23 Boulevard du Grau Saint-Ange,,,,66420
-23 Boulevard du Grau Saint-Ange 66420,,,,23 Boulevard du Grau Saint-Ange,,,Le Barcarès,
-23 Boulevard du Grau Saint-Ange,3.036387,42.785588,,23 Boulevard du Grau Saint-Ange,,,,66420
-74 Avenue d'en Carbouner Le Boulou,,,,74 Avenue d'en Carbouner,,,,66160
-74 Avenue d'en Carbouner 66160,,,,74 Avenue d'en Carbouner,,,Le Boulou,
-74 Avenue d'en Carbouner,2.861910,42.510944,,74 Avenue d'en Carbouner,,,,66160
-2 Rue Josep Andreu Toront Cabestany,,,,2 Rue Josep Andreu Toront,,,,66330
-2 Rue Josep Andreu Toront 66330,,,,2 Rue Josep Andreu Toront,,,Cabestany,
-2 Rue Josep Andreu Toront,2.944853,42.683315,,2 Rue Josep Andreu Toront,,,,66330
-1 Avenue de la Méditerranée Canet-en-Roussillon,,,,1 Avenue de la Méditerranée,,,,66140
-1 Avenue de la Méditerranée 66140,,,,1 Avenue de la Méditerranée,,,Canet-en-Roussillon,
-1 Avenue de la Méditerranée,3.034686,42.693510,,1 Avenue de la Méditerranée,,,,66140
-1 Rue du Fenouilledes Caudiès-de-Fenouillèdes,,,,1 Rue du Fenouilledes,,,,66220
-1 Rue du Fenouilledes 66220,,,,1 Rue du Fenouilledes,,,Caudiès-de-Fenouillèdes,
-1 Rue du Fenouilledes,2.378770,42.810042,,1 Rue du Fenouilledes,,,,66220
-2 Rue des Fleurs Codalet,,,,2 Rue des Fleurs,,,,66500
-2 Rue des Fleurs 66500,,,,2 Rue des Fleurs,,,Codalet,
-2 Rue des Fleurs,2.416550,42.610137,,2 Rue des Fleurs,,,,66500
-7 Rue de la Paix Elne,,,,7 Rue de la Paix,,,,66200
-7 Rue de la Paix 66200,,,,7 Rue de la Paix,,,Elne,
-7 Rue de la Paix,2.971105,42.598901,,7 Rue de la Paix,,,,66200
-1 Rue Lafayette Ille-sur-Têt,,,,1 Rue Lafayette,,,,66130
-1 Rue Lafayette 66130,,,,1 Rue Lafayette,,,Ille-sur-Têt,
-1 Rue Lafayette,2.624681,42.670506,,1 Rue Lafayette,,,,66130
-23BIS Rue Gabriel Fauré Llupia,,,,23BIS Rue Gabriel Fauré,,,,66300
-23BIS Rue Gabriel Fauré 66300,,,,23BIS Rue Gabriel Fauré,,,Llupia,
-23BIS Rue Gabriel Fauré,2.769904,42.618383,,23BIS Rue Gabriel Fauré,,,,66300
-4 PLA DES MICOCOULIERS Montesquieu-des-Albères,,,,4 PLA DES MICOCOULIERS,,,,66740
-4 PLA DES MICOCOULIERS 66740,,,,4 PLA DES MICOCOULIERS,,,Montesquieu-des-Albères,
-4 PLA DES MICOCOULIERS,2.880025,42.541218,,4 PLA DES MICOCOULIERS,,,,66740
-6 Rue Alfred de Vigny Perpignan,,,,6 Rue Alfred de Vigny,,,,66000
-6 Rue Alfred de Vigny 66000,,,,6 Rue Alfred de Vigny,,,Perpignan,
-6 Rue Alfred de Vigny,2.886713,42.694318,,6 Rue Alfred de Vigny,,,,66000
-105 Avenue du Commandant Ernest Soubielle Perpignan,,,,105 Avenue du Commandant Ernest Soubielle,,,,66000
-105 Avenue du Commandant Ernest Soubielle 66000,,,,105 Avenue du Commandant Ernest Soubielle,,,Perpignan,
-105 Avenue du Commandant Ernest Soubielle,2.884283,42.703166,,105 Avenue du Commandant Ernest Soubielle,,,,66000
-11 Rue George Sand Perpignan,,,,11 Rue George Sand,,,,66000
-11 Rue George Sand 66000,,,,11 Rue George Sand,,,Perpignan,
-11 Rue George Sand,2.891835,42.689197,,11 Rue George Sand,,,,66000
-26 Rue René Laennec Perpignan,,,,26 Rue René Laennec,,,,66000
-26 Rue René Laennec 66000,,,,26 Rue René Laennec,,,Perpignan,
-26 Rue René Laennec,2.902351,42.692287,,26 Rue René Laennec,,,,66000
-32 Rue Paul Fort Perpignan,,,,32 Rue Paul Fort,,,,66000
-32 Rue Paul Fort 66000,,,,32 Rue Paul Fort,,,Perpignan,
-32 Rue Paul Fort,2.888390,42.707765,,32 Rue Paul Fort,,,,66000
-11 Rue Henri Stendhal Perpignan,,,,11 Rue Henri Stendhal,,,,66000
-11 Rue Henri Stendhal 66000,,,,11 Rue Henri Stendhal,,,Perpignan,
-11 Rue Henri Stendhal,2.876308,42.697946,,11 Rue Henri Stendhal,,,,66000
-2 Rue Beausejour Pia,,,,2 Rue Beausejour,,,,66380
-2 Rue Beausejour 66380,,,,2 Rue Beausejour,,,Pia,
-2 Rue Beausejour,2.919665,42.746028,,2 Rue Beausejour,,,,66380
-13 Rue des Oeillets Ponteilla,,,,13 Rue des Oeillets,,,,66300
-13 Rue des Oeillets 66300,,,,13 Rue des Oeillets,,,Ponteilla,
-13 Rue des Oeillets,2.815055,42.624872,,13 Rue des Oeillets,,,,66300
-45 Route Nationale Ria-Sirach,,,,45 Route Nationale,,,,66500
-45 Route Nationale 66500,,,,45 Route Nationale,,,Ria-Sirach,
-45 Route Nationale,2.396960,42.605818,,45 Route Nationale,,,,66500
-26 Rue Saint-Ferréol Saint-André,,,,26 Rue Saint-Ferréol,,,,66690
-26 Rue Saint-Ferréol 66690,,,,26 Rue Saint-Ferréol,,,Saint-André,
-26 Rue Saint-Ferréol,2.971316,42.554208,,26 Rue Saint-Ferréol,,,,66690
-44 Résidence Les Casellas Saint-Cyprien,,,,44 Résidence Les Casellas,,,,66750
-44 Résidence Les Casellas 66750,,,,44 Résidence Les Casellas,,,Saint-Cyprien,
-44 Résidence Les Casellas,3.029163,42.629779,,44 Résidence Les Casellas,,,,66750
-27 Avenue des Albères Saint-Génis-des-Fontaines,,,,27 Avenue des Albères,,,,66740
-27 Avenue des Albères 66740,,,,27 Avenue des Albères,,,Saint-Génis-des-Fontaines,
-27 Avenue des Albères,2.921021,42.542822,,27 Avenue des Albères,,,,66740
-11 Rue Jean Bart Saint-Laurent-de-la-Salanque,,,,11 Rue Jean Bart,,,,66250
-11 Rue Jean Bart 66250,,,,11 Rue Jean Bart,,,Saint-Laurent-de-la-Salanque,
-11 Rue Jean Bart,2.989447,42.771453,,11 Rue Jean Bart,,,,66250
-4 Rue des Pommiers Sainte-Marie,,,,4 Rue des Pommiers,,,,66470
-4 Rue des Pommiers 66470,,,,4 Rue des Pommiers,,,Sainte-Marie,
-4 Rue des Pommiers,3.027917,42.734895,,4 Rue des Pommiers,,,,66470
-26 Avenue du Roussillon Salses-le-Château,,,,26 Avenue du Roussillon,,,,66600
-26 Avenue du Roussillon 66600,,,,26 Avenue du Roussillon,,,Salses-le-Château,
-26 Avenue du Roussillon,2.915768,42.832438,,26 Avenue du Roussillon,,,,66600
-2 Place Louis Blanc Tautavel,,,,2 Place Louis Blanc,,,,66720
-2 Place Louis Blanc 66720,,,,2 Place Louis Blanc,,,Tautavel,
-2 Place Louis Blanc,2.745706,42.813517,,2 Place Louis Blanc,,,,66720
-8 Rue de la Concorde Torreilles,,,,8 Rue de la Concorde,,,,66440
-8 Rue de la Concorde 66440,,,,8 Rue de la Concorde,,,Torreilles,
-8 Rue de la Concorde,2.994477,42.754457,,8 Rue de la Concorde,,,,66440
-14 Boulevard du Cady Vernet-les-Bains,,,,14 Boulevard du Cady,,,,66820
-14 Boulevard du Cady 66820,,,,14 Boulevard du Cady,,,Vernet-les-Bains,
-14 Boulevard du Cady,2.387726,42.547151,,14 Boulevard du Cady,,,,66820
-166 Avenue du Général de Gaulle Vinça,,,,166 Avenue du Général de Gaulle,,,,66320
-166 Avenue du Général de Gaulle 66320,,,,166 Avenue du Général de Gaulle,,,Vinça,
-166 Avenue du Général de Gaulle,2.522040,42.644502,,166 Avenue du Général de Gaulle,,,,66320
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+11 Rue du Fort Barbaira,,,,11,Rue du Fort,,11800
+11 Rue du Fort 11800,,,,11,Rue du Fort,Barbaira,
+11 Rue du Fort,2.509534,43.183902,,11,Rue du Fort,,11800
+34 Avenue des Anciens Combattants Capendu,,,,34,Avenue des Anciens Combattants,,11700
+34 Avenue des Anciens Combattants 11700,,,,34,Avenue des Anciens Combattants,Capendu,
+34 Avenue des Anciens Combattants,2.555346,43.185447,,34,Avenue des Anciens Combattants,,11700
+9 Rue des Études Carcassonne,,,,9,Rue des Études,,11000
+9 Rue des Études 11000,,,,9,Rue des Études,Carcassonne,
+9 Rue des Études,2.348515,43.211265,,9,Rue des Études,,11000
+7 Place Marcou Carcassonne,,,,7,Place Marcou,,11000
+7 Place Marcou 11000,,,,7,Place Marcou,Carcassonne,
+7 Place Marcou,2.364929,43.206461,,7,Place Marcou,,11000
+102 Rue Trivalle Carcassonne,,,,102,Rue Trivalle,,11000
+102 Rue Trivalle 11000,,,,102,Rue Trivalle,Carcassonne,
+102 Rue Trivalle,2.364638,43.209361,,102,Rue Trivalle,,11000
+9 Avenue des Bosquets Caux-et-Sauzens,,,,9,Avenue des Bosquets,,11170
+9 Avenue des Bosquets 11170,,,,9,Avenue des Bosquets,Caux-et-Sauzens,
+9 Avenue des Bosquets,2.257166,43.220486,,9,Avenue des Bosquets,,11170
+13 Avenue Frédéric Mistral Coursan,,,,13,Avenue Frédéric Mistral,,11110
+13 Avenue Frédéric Mistral 11110,,,,13,Avenue Frédéric Mistral,Coursan,
+13 Avenue Frédéric Mistral,3.057388,43.234421,,13,Avenue Frédéric Mistral,,11110
+225 Rue de l'Égalité Espéraza,,,,225,Rue de l'Égalité,,11260
+225 Rue de l'Égalité 11260,,,,225,Rue de l'Égalité,Espéraza,
+225 Rue de l'Égalité,2.220285,42.936589,,225,Rue de l'Égalité,,11260
+19BIS Rue des Pétrels Fleury,,,,19BIS,Rue des Pétrels,,11560
+19BIS Rue des Pétrels 11560,,,,19BIS,Rue des Pétrels,Fleury,
+19BIS Rue des Pétrels,3.182476,43.177115,,19BIS,Rue des Pétrels,,11560
+20 Chalets 10E Rangée Gruissan,,,,20,Chalets 10E Rangée,,11430
+20 Chalets 10E Rangée 11430,,,,20,Chalets 10E Rangée,Gruissan,
+20 Chalets 10E Rangée,3.117681,43.107258,,20,Chalets 10E Rangée,,11430
+4 Rue Émile Bertrand Leucate,,,,4,Rue Émile Bertrand,,11370
+4 Rue Émile Bertrand 11370,,,,4,Rue Émile Bertrand,Leucate,
+4 Rue Émile Bertrand,3.036168,42.931546,,4,Rue Émile Bertrand,,11370
+5 Rue Peyronnet Lézignan-Corbières,,,,5,Rue Peyronnet,,11200
+5 Rue Peyronnet 11200,,,,5,Rue Peyronnet,Lézignan-Corbières,
+5 Rue Peyronnet,2.759861,43.199386,,5,Rue Peyronnet,,11200
+7 Rue du Cers Luc-sur-Orbieu,,,,7,Rue du Cers,,11200
+7 Rue du Cers 11200,,,,7,Rue du Cers,Luc-sur-Orbieu,
+7 Rue du Cers,2.783382,43.175923,,7,Rue du Cers,,11200
+6 Place du Monument aux Morts Moussan,,,,6,Place du Monument aux Morts,,11120
+6 Place du Monument aux Morts 11120,,,,6,Place du Monument aux Morts,Moussan,
+6 Place du Monument aux Morts,2.949762,43.231694,,6,Place du Monument aux Morts,,11120
+59 Avenue de la Coupe Narbonne,,,,59,Avenue de la Coupe,,11100
+59 Avenue de la Coupe 11100,,,,59,Avenue de la Coupe,Narbonne,
+59 Avenue de la Coupe,2.975098,43.157952,,59,Avenue de la Coupe,,11100
+24 Rue du Maine Narbonne,,,,24,Rue du Maine,,11100
+24 Rue du Maine 11100,,,,24,Rue du Maine,Narbonne,
+24 Rue du Maine,3.017903,43.196987,,24,Rue du Maine,,11100
+80 Rue Turenne Narbonne,,,,80,Rue Turenne,,11100
+80 Rue Turenne 11100,,,,80,Rue Turenne,Narbonne,
+80 Rue Turenne,3.001646,43.176403,,80,Rue Turenne,,11100
+94 Avenue Saint-Marc Ornaisons,,,,94,Avenue Saint-Marc,,11200
+94 Avenue Saint-Marc 11200,,,,94,Avenue Saint-Marc,Ornaisons,
+94 Avenue Saint-Marc,2.831688,43.181145,,94,Avenue Saint-Marc,,11200
+1 Place de la Provence Pezens,,,,1,Place de la Provence,,11170
+1 Place de la Provence 11170,,,,1,Place de la Provence,Pezens,
+1 Place de la Provence,2.269912,43.25663,,1,Place de la Provence,,11170
+32 Rue Saint-Blaise Rieux-Minervois,,,,32,Rue Saint-Blaise,,11160
+32 Rue Saint-Blaise 11160,,,,32,Rue Saint-Blaise,Rieux-Minervois,
+32 Rue Saint-Blaise,2.588036,43.282774,,32,Rue Saint-Blaise,,11160
+18 Rue de l'Aubier Sallèles-d'Aude,,,,18,Rue de l'Aubier,,11590
+18 Rue de l'Aubier 11590,,,,18,Rue de l'Aubier,Sallèles-d'Aude,
+18 Rue de l'Aubier,2.946255,43.265117,,18,Rue de l'Aubier,,11590
+8 Rue Jules Michelet Sigean,,,,8,Rue Jules Michelet,,11130
+8 Rue Jules Michelet 11130,,,,8,Rue Jules Michelet,Sigean,
+8 Rue Jules Michelet,2.976562,43.02026,,8,Rue Jules Michelet,,11130
+31 Rue des Carriers Villegailhenc,,,,31,Rue des Carriers,,11600
+31 Rue des Carriers 11600,,,,31,Rue des Carriers,Villegailhenc,
+31 Rue des Carriers,2.354165,43.269483,,31,Rue des Carriers,,11600
+4 Rue du Pommier Aimargues,,,,4,Rue du Pommier,,30470
+4 Rue du Pommier 30470,,,,4,Rue du Pommier,Aimargues,
+4 Rue du Pommier,4.201634,43.699408,,4,Rue du Pommier,,30470
+12 Rue Jean Aicard Alès,,,,12,Rue Jean Aicard,,30100
+12 Rue Jean Aicard 30100,,,,12,Rue Jean Aicard,Alès,
+12 Rue Jean Aicard,4.094476,44.131753,,12,Rue Jean Aicard,,30100
+15 Rue Taisson Alès,,,,15,Rue Taisson,,30100
+15 Rue Taisson 30100,,,,15,Rue Taisson,Alès,
+15 Rue Taisson,4.078452,44.124384,,15,Rue Taisson,,30100
+28 Rue de la République Les Angles,,,,28,Rue de la République,,30133
+28 Rue de la République 30133,,,,28,Rue de la République,Les Angles,
+28 Rue de la République,4.76636,43.95237,,28,Rue de la République,,30133
+1031 Avenue Alphonse Daudet Bagnols-sur-Cèze,,,,1031,Avenue Alphonse Daudet,,30200
+1031 Avenue Alphonse Daudet 30200,,,,1031,Avenue Alphonse Daudet,Bagnols-sur-Cèze,
+1031 Avenue Alphonse Daudet,4.613304,44.152982,,1031,Avenue Alphonse Daudet,,30200
+40 Chemin de la Source Bagnols-sur-Cèze,,,,40,Chemin de la Source,,30200
+40 Chemin de la Source 30200,,,,40,Chemin de la Source,Bagnols-sur-Cèze,
+40 Chemin de la Source,4.607519,44.153717,,40,Chemin de la Source,,30200
+362 Chemin de l'Esquillon Beauvoisin,,,,362,Chemin de l'Esquillon,,30640
+362 Chemin de l'Esquillon 30640,,,,362,Chemin de l'Esquillon,Beauvoisin,
+362 Chemin de l'Esquillon,4.314159,43.714694,,362,Chemin de l'Esquillon,,30640
+360B Chemin de Marguerittes Bezouce,,,,360B,Chemin de Marguerittes,,30320
+360B Chemin de Marguerittes 30320,,,,360B,Chemin de Marguerittes,Bezouce,
+360B Chemin de Marguerittes,4.485703,43.879085,,360B,Chemin de Marguerittes,,30320
+1 Chemin des Ayres Le Cailar,,,,1,Chemin des Ayres,,30740
+1 Chemin des Ayres 30740,,,,1,Chemin des Ayres,Le Cailar,
+1 Chemin des Ayres,4.234116,43.675602,,1,Chemin des Ayres,,30740
+1 Rue Turion Sabatier Castillon-du-Gard,,,,1,Rue Turion Sabatier,,30210
+1 Rue Turion Sabatier 30210,,,,1,Rue Turion Sabatier,Castillon-du-Gard,
+1 Rue Turion Sabatier,4.554719,43.970894,,1,Rue Turion Sabatier,,30210
+1 Rue du Moulin à Huile Combas,,,,1,Rue du Moulin à Huile,,30250
+1 Rue du Moulin à Huile 30250,,,,1,Rue du Moulin à Huile,Combas,
+1 Rue du Moulin à Huile,4.112049,43.853998,,1,Rue du Moulin à Huile,,30250
+26 Rue de la Costière Garons,,,,26,Rue de la Costière,,30128
+26 Rue de la Costière 30128,,,,26,Rue de la Costière,Garons,
+26 Rue de la Costière,4.431799,43.765668,,26,Rue de la Costière,,30128
+15 Impasse des Cigales Le Grau-du-Roi,,,,15,Impasse des Cigales,,30240
+15 Impasse des Cigales 30240,,,,15,Impasse des Cigales,Le Grau-du-Roi,
+15 Impasse des Cigales,4.143067,43.520524,,15,Impasse des Cigales,,30240
+505 Rue Emile Zola Laudun-l'Ardoise,,,,505,Rue Emile Zola,,30290
+505 Rue Emile Zola 30290,,,,505,Rue Emile Zola,Laudun-l'Ardoise,
+505 Rue Emile Zola,4.66999,44.106979,,505,Rue Emile Zola,,30290
+9 Rue des Anciens Combattants Marguerittes,,,,9,Rue des Anciens Combattants,,30320
+9 Rue des Anciens Combattants 30320,,,,9,Rue des Anciens Combattants,Marguerittes,
+9 Rue des Anciens Combattants,4.437148,43.854392,,9,Rue des Anciens Combattants,,30320
+10 Rue Alphonse Daudet Milhaud,,,,10,Rue Alphonse Daudet,,30540
+10 Rue Alphonse Daudet 30540,,,,10,Rue Alphonse Daudet,Milhaud,
+10 Rue Alphonse Daudet,4.317366,43.792677,,10,Rue Alphonse Daudet,,30540
+40 Rue du Temple Mus,,,,40,Rue du Temple,,30121
+40 Rue du Temple 30121,,,,40,Rue du Temple,Mus,
+40 Rue du Temple,4.200455,43.740178,,40,Rue du Temple,,30121
+212 Impasse Bonne Brise Nîmes,,,,212,Impasse Bonne Brise,,30000
+212 Impasse Bonne Brise 30000,,,,212,Impasse Bonne Brise,Nîmes,
+212 Impasse Bonne Brise,4.332683,43.837978,,212,Impasse Bonne Brise,,30000
+18 Rue Edmond Rostand Nîmes,,,,18,Rue Edmond Rostand,,30000
+18 Rue Edmond Rostand 30000,,,,18,Rue Edmond Rostand,Nîmes,
+18 Rue Edmond Rostand,4.369179,43.85003,,18,Rue Edmond Rostand,,30000
+29B Avenue Jean Jaurès Nîmes,,,,29B,Avenue Jean Jaurès,,30000
+29B Avenue Jean Jaurès 30000,,,,29B,Avenue Jean Jaurès,Nîmes,
+29B Avenue Jean Jaurès,4.351594,43.834145,,29B,Avenue Jean Jaurès,,30000
+130 Impasse des Orchidées Nîmes,,,,130,Impasse des Orchidées,,30000
+130 Impasse des Orchidées 30000,,,,130,Impasse des Orchidées,Nîmes,
+130 Impasse des Orchidées,4.381477,43.810838,,130,Impasse des Orchidées,,30000
+58 Rue Sainte-Perpétue Nîmes,,,,58,Rue Sainte-Perpétue,,30000
+58 Rue Sainte-Perpétue 30000,,,,58,Rue Sainte-Perpétue,Nîmes,
+58 Rue Sainte-Perpétue,4.376036,43.836243,,58,Rue Sainte-Perpétue,,30000
+19 Avenue Gaston Doumergue Pont-Saint-Esprit,,,,19,Avenue Gaston Doumergue,,30130
+19 Avenue Gaston Doumergue 30130,,,,19,Avenue Gaston Doumergue,Pont-Saint-Esprit,
+19 Avenue Gaston Doumergue,4.646512,44.254628,,19,Avenue Gaston Doumergue,,30130
+177 Voie Romaine Quissac,,,,177,Voie Romaine,,30260
+177 Voie Romaine 30260,,,,177,Voie Romaine,Quissac,
+177 Voie Romaine,4.005736,43.905849,,177,Voie Romaine,,30260
+35 Rue du 19 Mars 1962 Roquemaure,,,,35,Rue du 19 Mars 1962,,30150
+35 Rue du 19 Mars 1962 30150,,,,35,Rue du 19 Mars 1962,Roquemaure,
+35 Rue du 19 Mars 1962,4.785823,44.046466,,35,Rue du 19 Mars 1962,,30150
+5 Chemin de la Rouvière Saint-Bauzély,,,,5,Chemin de la Rouvière,,30730
+5 Chemin de la Rouvière 30730,,,,5,Chemin de la Rouvière,Saint-Bauzély,
+5 Chemin de la Rouvière,4.200742,43.921346,,5,Chemin de la Rouvière,,30730
+4 Impasse de l'Aqueduc Saint-Gervasy,,,,4,Impasse de l'Aqueduc,,30320
+4 Impasse de l'Aqueduc 30320,,,,4,Impasse de l'Aqueduc,Saint-Gervasy,
+4 Impasse de l'Aqueduc,4.463123,43.87758,,4,Impasse de l'Aqueduc,,30320
+170 Chemin de Saint-Hilaire A Trouillas Saint-Hilaire-de-Brethmas,,,,170,Chemin de Saint-Hilaire A Trouillas,,30560
+170 Chemin de Saint-Hilaire A Trouillas 30560,,,,170,Chemin de Saint-Hilaire A Trouillas,Saint-Hilaire-de-Brethmas,
+170 Chemin de Saint-Hilaire A Trouillas,4.12788,44.081987,,170,Chemin de Saint-Hilaire A Trouillas,,30560
+59 Rue Pierre-Babinot Saint-Laurent-d'Aigouze,,,,59,Rue Pierre-Babinot,,30220
+59 Rue Pierre-Babinot 30220,,,,59,Rue Pierre-Babinot,Saint-Laurent-d'Aigouze,
+59 Rue Pierre-Babinot,4.194101,43.634416,,59,Rue Pierre-Babinot,,30220
+99 Chemin du Viget Saint-Privat-des-Vieux,,,,99,Chemin du Viget,,30340
+99 Chemin du Viget 30340,,,,99,Chemin du Viget,Saint-Privat-des-Vieux,
+99 Chemin du Viget,4.120706,44.149931,,99,Chemin du Viget,,30340
+18 Rue Frédéric Mistral Saze,,,,18,Rue Frédéric Mistral,,30650
+18 Rue Frédéric Mistral 30650,,,,18,Rue Frédéric Mistral,Saze,
+18 Rue Frédéric Mistral,4.681719,43.942595,,18,Rue Frédéric Mistral,,30650
+12 Rue des Tamaris Uchaud,,,,12,Rue des Tamaris,,30620
+12 Rue des Tamaris 30620,,,,12,Rue des Tamaris,Uchaud,
+12 Rue des Tamaris,4.272253,43.757794,,12,Rue des Tamaris,,30620
+6 Rue Posquière Vauvert,,,,6,Rue Posquière,,30640
+6 Rue Posquière 30640,,,,6,Rue Posquière,Vauvert,
+6 Rue Posquière,4.277792,43.692519,,6,Rue Posquière,,30640
+895 Route du Pont de la Croix Le Vigan,,,,895,Route du Pont de la Croix,,30120
+895 Route du Pont de la Croix 30120,,,,895,Route du Pont de la Croix,Le Vigan,
+895 Route du Pont de la Croix,3.624068,43.989618,,895,Route du Pont de la Croix,,30120
+1 Impasse Di Capellus Rodilhan,,,,1,Impasse Di Capellus,,30230
+1 Impasse Di Capellus 30230,,,,1,Impasse Di Capellus,Rodilhan,
+1 Impasse Di Capellus,4.431379,43.830745,,1,Impasse Di Capellus,,30230
+9 Rue Francois Le Courtier Agde,,,,9,Rue Francois Le Courtier,,34300
+9 Rue Francois Le Courtier 34300,,,,9,Rue Francois Le Courtier,Agde,
+9 Rue Francois Le Courtier,3.458278,43.292557,,9,Rue Francois Le Courtier,,34300
+12 Rue Saint-Cesaire Agde,,,,12,Rue Saint-Cesaire,,34300
+12 Rue Saint-Cesaire 34300,,,,12,Rue Saint-Cesaire,Agde,
+12 Rue Saint-Cesaire,3.470905,43.300621,,12,Rue Saint-Cesaire,,34300
+5 Rue du Maréchal Leclerc Aspiran,,,,5,Rue du Maréchal Leclerc,,34800
+5 Rue du Maréchal Leclerc 34800,,,,5,Rue du Maréchal Leclerc,Aspiran,
+5 Rue du Maréchal Leclerc,3.449806,43.56569,,5,Rue du Maréchal Leclerc,,34800
+8 Impasse des Primevères Balaruc-les-Bains,,,,8,Impasse des Primevères,,34540
+8 Impasse des Primevères 34540,,,,8,Impasse des Primevères,Balaruc-les-Bains,
+8 Impasse des Primevères,3.703653,43.445346,,8,Impasse des Primevères,,34540
+3 Rue de l'Abreuvoir Berlou,,,,3,Rue de l'Abreuvoir,,34360
+3 Rue de l'Abreuvoir 34360,,,,3,Rue de l'Abreuvoir,Berlou,
+3 Rue de l'Abreuvoir,2.963197,43.492135,,3,Rue de l'Abreuvoir,,34360
+1456 Avenue du Préfet Claude Érignac Béziers,,,,1456,Avenue du Préfet Claude Érignac,,34500
+1456 Avenue du Préfet Claude Érignac 34500,,,,1456,Avenue du Préfet Claude Érignac,Béziers,
+1456 Avenue du Préfet Claude Érignac,3.213129,43.36501,,1456,Avenue du Préfet Claude Érignac,,34500
+23 Rue Honoré Daumier Béziers,,,,23,Rue Honoré Daumier,,34500
+23 Rue Honoré Daumier 34500,,,,23,Rue Honoré Daumier,Béziers,
+23 Rue Honoré Daumier,3.225281,43.347295,,23,Rue Honoré Daumier,,34500
+69 Rue Louis Pasteur Béziers,,,,69,Rue Louis Pasteur,,34500
+69 Rue Louis Pasteur 34500,,,,69,Rue Louis Pasteur,Béziers,
+69 Rue Louis Pasteur,3.228097,43.337448,,69,Rue Louis Pasteur,,34500
+59 Avenue Vingt Deux Aout 1944 Béziers,,,,59,Avenue Vingt Deux Aout 1944,,34500
+59 Avenue Vingt Deux Aout 1944 34500,,,,59,Avenue Vingt Deux Aout 1944,Béziers,
+59 Avenue Vingt Deux Aout 1944,3.220144,43.344142,,59,Avenue Vingt Deux Aout 1944,,34500
+3BIS Place de l'Église Brignac,,,,3BIS,Place de l'Église,,34800
+3BIS Place de l'Église 34800,,,,3BIS,Place de l'Église,Brignac,
+3BIS Place de l'Église,3.474652,43.623487,,3BIS,Place de l'Église,,34800
+4 Rue Bacchus Castelnau-le-Lez,,,,4,Rue Bacchus,,34170
+4 Rue Bacchus 34170,,,,4,Rue Bacchus,Castelnau-le-Lez,
+4 Rue Bacchus,3.925686,43.644586,,4,Rue Bacchus,,34170
+57 Rue de la Tramontane Castries,,,,57,Rue de la Tramontane,,34160
+57 Rue de la Tramontane 34160,,,,57,Rue de la Tramontane,Castries,
+57 Rue de la Tramontane,3.97667,43.680666,,57,Rue de la Tramontane,,34160
+6 Placette des Mûriers Cazouls-lès-Béziers,,,,6,Placette des Mûriers,,34370
+6 Placette des Mûriers 34370,,,,6,Placette des Mûriers,Cazouls-lès-Béziers,
+6 Placette des Mûriers,3.101653,43.385824,,6,Placette des Mûriers,,34370
+316 Chemin de Sauviac Claret,,,,316,Chemin de Sauviac,,34270
+316 Chemin de Sauviac 34270,,,,316,Chemin de Sauviac,Claret,
+316 Chemin de Sauviac,3.903328,43.85337,,316,Chemin de Sauviac,,34270
+3 Rue des Coronilles Cournonsec,,,,3,Rue des Coronilles,,34660
+3 Rue des Coronilles 34660,,,,3,Rue des Coronilles,Cournonsec,
+3 Rue des Coronilles,3.698226,43.543795,,3,Rue des Coronilles,,34660
+16 Rue de la Sauvagine Le Crès,,,,16,Rue de la Sauvagine,,34920
+16 Rue de la Sauvagine 34920,,,,16,Rue de la Sauvagine,Le Crès,
+16 Rue de la Sauvagine,3.935624,43.663918,,16,Rue de la Sauvagine,,34920
+1 Rue des Peupliers Florensac,,,,1,Rue des Peupliers,,34510
+1 Rue des Peupliers 34510,,,,1,Rue des Peupliers,Florensac,
+1 Rue des Peupliers,3.475458,43.383614,,1,Rue des Peupliers,,34510
+10 Impasse des Primevères Frontignan,,,,10,Impasse des Primevères,,34110
+10 Impasse des Primevères 34110,,,,10,Impasse des Primevères,Frontignan,
+10 Impasse des Primevères,3.732403,43.434947,,10,Impasse des Primevères,,34110
+11 Avenue des Treilles Gigean,,,,11,Avenue des Treilles,,34770
+11 Avenue des Treilles 34770,,,,11,Avenue des Treilles,Gigean,
+11 Avenue des Treilles,3.70762,43.498863,,11,Avenue des Treilles,,34770
+3 Rue du Languedoc Jacou,,,,3,Rue du Languedoc,,34830
+3 Rue du Languedoc 34830,,,,3,Rue du Languedoc,Jacou,
+3 Rue du Languedoc,3.909344,43.658735,,3,Rue du Languedoc,,34830
+7 Rue des Flamants Roses Lansargues,,,,7,Rue des Flamants Roses,,34130
+7 Rue des Flamants Roses 34130,,,,7,Rue des Flamants Roses,Lansargues,
+7 Rue des Flamants Roses,4.070892,43.65273,,7,Rue des Flamants Roses,,34130
+28 Rue Pasiphae Lattes,,,,28,Rue Pasiphae,,34970
+28 Rue Pasiphae 34970,,,,28,Rue Pasiphae,Lattes,
+28 Rue Pasiphae,3.902711,43.576892,,28,Rue Pasiphae,,34970
+20 Impasse Raimu Lignan-sur-Orb,,,,20,Impasse Raimu,,34490
+20 Impasse Raimu 34490,,,,20,Impasse Raimu,Lignan-sur-Orb,
+20 Impasse Raimu,3.175538,43.379525,,20,Impasse Raimu,,34490
+14 Impasse du Cordelier Lunel,,,,14,Impasse du Cordelier,,34400
+14 Impasse du Cordelier 34400,,,,14,Impasse du Cordelier,Lunel,
+14 Impasse du Cordelier,4.13421,43.670959,,14,Impasse du Cordelier,,34400
+604 Avenue du Vidourle Lunel,,,,604,Avenue du Vidourle,,34400
+604 Avenue du Vidourle 34400,,,,604,Avenue du Vidourle,Lunel,
+604 Avenue du Vidourle,4.150523,43.683924,,604,Avenue du Vidourle,,34400
+316 Rue de Poussan Maraussan,,,,316,Rue de Poussan,,34370
+316 Rue de Poussan 34370,,,,316,Rue de Poussan,Maraussan,
+316 Rue de Poussan,3.159766,43.362898,,316,Rue de Poussan,,34370
+33 Place du Théatre Marseillan,,,,33,Place du Théatre,,34340
+33 Place du Théatre 34340,,,,33,Place du Théatre,Marseillan,
+33 Place du Théatre,3.52923,43.353799,,33,Place du Théatre,,34340
+163 Avenue Grassion Cibrand Carnon Mauguio,,,,163,Avenue Grassion Cibrand Carnon,,34280
+163 Avenue Grassion Cibrand Carnon 34280,,,,163,Avenue Grassion Cibrand Carnon,Mauguio,
+163 Avenue Grassion Cibrand Carnon,3.984266,43.546303,,163,Avenue Grassion Cibrand Carnon,,34280
+4 Rue Gaffarot Mèze,,,,4,Rue Gaffarot,,34140
+4 Rue Gaffarot 34140,,,,4,Rue Gaffarot,Mèze,
+4 Rue Gaffarot,3.608495,43.425989,,4,Rue Gaffarot,,34140
+8 Rue du Commerce Montagnac,,,,8,Rue du Commerce,,34530
+8 Rue du Commerce 34530,,,,8,Rue du Commerce,Montagnac,
+8 Rue du Commerce,3.483892,43.478951,,8,Rue du Commerce,,34530
+276 Côte des Ecureuils Montferrier-sur-Lez,,,,276,Côte des Ecureuils,,34980
+276 Côte des Ecureuils 34980,,,,276,Côte des Ecureuils,Montferrier-sur-Lez,
+276 Côte des Ecureuils,3.844786,43.672044,,276,Côte des Ecureuils,,34980
+6B Boulevard Berthelot Montpellier,,,,6B,Boulevard Berthelot,,34090
+6B Boulevard Berthelot 34090,,,,6B,Boulevard Berthelot,Montpellier,
+6B Boulevard Berthelot,3.870413,43.600639,,6B,Boulevard Berthelot,,34090
+435 Rue de la Croix Verte Montpellier,,,,435,Rue de la Croix Verte,,34090
+435 Rue de la Croix Verte 34090,,,,435,Rue de la Croix Verte,Montpellier,
+435 Rue de la Croix Verte,3.838657,43.64607,,435,Rue de la Croix Verte,,34090
+5 Rue Général Riu Montpellier,,,,5,Rue Général Riu,,34090
+5 Rue Général Riu 34090,,,,5,Rue Général Riu,Montpellier,
+5 Rue Général Riu,3.882132,43.604499,,5,Rue Général Riu,,34090
+166B Avenue de Lodève Montpellier,,,,166B,Avenue de Lodève,,34090
+166B Avenue de Lodève 34090,,,,166B,Avenue de Lodève,Montpellier,
+166B Avenue de Lodève,3.842268,43.613285,,166B,Avenue de Lodève,,34090
+33 Avenue de Palavas Montpellier,,,,33,Avenue de Palavas,,34090
+33 Avenue de Palavas 34090,,,,33,Avenue de Palavas,Montpellier,
+33 Avenue de Palavas,3.885154,43.599471,,33,Avenue de Palavas,,34090
+265 Rue Romy Schneider Montpellier,,,,265,Rue Romy Schneider,,34090
+265 Rue Romy Schneider 34090,,,,265,Rue Romy Schneider,Montpellier,
+265 Rue Romy Schneider,3.860698,43.587038,,265,Rue Romy Schneider,,34090
+7 Place Jacques Mirouze Montpellier,,,,7,Place Jacques Mirouze,,34090
+7 Place Jacques Mirouze 34090,,,,7,Place Jacques Mirouze,Montpellier,
+7 Place Jacques Mirouze,3.869907,43.612749,,7,Place Jacques Mirouze,,34090
+6 Avenue Bonnafé Edouard Murviel-lès-Béziers,,,,6,Avenue Bonnafé Edouard,,34490
+6 Avenue Bonnafé Edouard 34490,,,,6,Avenue Bonnafé Edouard,Murviel-lès-Béziers,
+6 Avenue Bonnafé Edouard,3.145488,43.442514,,6,Avenue Bonnafé Edouard,,34490
+3 Rue du Garajou Octon,,,,3,Rue du Garajou,,34800
+3 Rue du Garajou 34800,,,,3,Rue du Garajou,Octon,
+3 Rue du Garajou,3.304937,43.655922,,3,Rue du Garajou,,34800
+12 Avenue des Adrets Pérols,,,,12,Avenue des Adrets,,34470
+12 Avenue des Adrets 34470,,,,12,Avenue des Adrets,Pérols,
+12 Avenue des Adrets,3.941266,43.565554,,12,Avenue des Adrets,,34470
+6 Avenue Yves Brayer Pézenas,,,,6,Avenue Yves Brayer,,34120
+6 Avenue Yves Brayer 34120,,,,6,Avenue Yves Brayer,Pézenas,
+6 Avenue Yves Brayer,3.41211,43.454349,,6,Avenue Yves Brayer,,34120
+11 Rue Peiro Signado Portiragnes,,,,11,Rue Peiro Signado,,34420
+11 Rue Peiro Signado 34420,,,,11,Rue Peiro Signado,Portiragnes,
+11 Rue Peiro Signado,3.328685,43.308784,,11,Rue Peiro Signado,,34420
+1161 Route de Vendargues Prades-le-Lez,,,,1161,Route de Vendargues,,34730
+1161 Route de Vendargues 34730,,,,1161,Route de Vendargues,Prades-le-Lez,
+1161 Route de Vendargues,3.874166,43.692918,,1161,Route de Vendargues,,34730
+7 Impasse Suzanne Valadon Roujan,,,,7,Impasse Suzanne Valadon,,34320
+7 Impasse Suzanne Valadon 34320,,,,7,Impasse Suzanne Valadon,Roujan,
+7 Impasse Suzanne Valadon,3.308522,43.502234,,7,Impasse Suzanne Valadon,,34320
+5 Place Constantine Saint-Chinian,,,,5,Place Constantine,,34360
+5 Place Constantine 34360,,,,5,Place Constantine,Saint-Chinian,
+5 Place Constantine,2.945469,43.421672,,5,Place Constantine,,34360
+358 Rue du Carignan Saint-Gély-du-Fesc,,,,358,Rue du Carignan,,34980
+358 Rue du Carignan 34980,,,,358,Rue du Carignan,Saint-Gély-du-Fesc,
+358 Rue du Carignan,3.800204,43.703765,,358,Rue du Carignan,,34980
+8 Allée des Chênes Verts Saint-Georges-d'Orques,,,,8,Allée des Chênes Verts,,34680
+8 Allée des Chênes Verts 34680,,,,8,Allée des Chênes Verts,Saint-Georges-d'Orques,
+8 Allée des Chênes Verts,3.772187,43.608772,,8,Allée des Chênes Verts,,34680
+162 Rue du Château d'Eau Saint-Just,,,,162,Rue du Château d'Eau,,34400
+162 Rue du Château d'Eau 34400,,,,162,Rue du Château d'Eau,Saint-Just,
+162 Rue du Château d'Eau,4.113536,43.659521,,162,Rue du Château d'Eau,,34400
+17 Avenue de la Gare Saint-Pons-de-Thomières,,,,17,Avenue de la Gare,,34220
+17 Avenue de la Gare 34220,,,,17,Avenue de la Gare,Saint-Pons-de-Thomières,
+17 Avenue de la Gare,2.764949,43.48797,,17,Avenue de la Gare,,34220
+24 Chemin de Mazeilles Sauvian,,,,24,Chemin de Mazeilles,,34410
+24 Chemin de Mazeilles 34410,,,,24,Chemin de Mazeilles,Sauvian,
+24 Chemin de Mazeilles,3.266183,43.288052,,24,Chemin de Mazeilles,,34410
+6 Rue des Cigales Servian,,,,6,Rue des Cigales,,34290
+6 Rue des Cigales 34290,,,,6,Rue des Cigales,Servian,
+6 Rue des Cigales,3.303321,43.431253,,6,Rue des Cigales,,34290
+43 Rue Garenne Prolongée Sète,,,,43,Rue Garenne Prolongée,,34200
+43 Rue Garenne Prolongée 34200,,,,43,Rue Garenne Prolongée,Sète,
+43 Rue Garenne Prolongée,3.693808,43.400036,,43,Rue Garenne Prolongée,,34200
+3 Rue Raspail Sète,,,,3,Rue Raspail,,34200
+3 Rue Raspail 34200,,,,3,Rue Raspail,Sète,
+3 Rue Raspail,3.696695,43.409426,,3,Rue Raspail,,34200
+18 Rue Docteur Philémon Rastoul Thézan-lès-Béziers,,,,18,Rue Docteur Philémon Rastoul,,34490
+18 Rue Docteur Philémon Rastoul 34490,,,,18,Rue Docteur Philémon Rastoul,Thézan-lès-Béziers,
+18 Rue Docteur Philémon Rastoul,3.169923,43.420932,,18,Rue Docteur Philémon Rastoul,,34490
+8 Cami Founjut Valras-Plage,,,,8,Cami Founjut,,34350
+8 Cami Founjut 34350,,,,8,Cami Founjut,Valras-Plage,
+8 Cami Founjut,3.28159,43.243623,,8,Cami Founjut,,34350
+9 Rue de l'Aqueduc Romain Vendres,,,,9,Rue de l'Aqueduc Romain,,34350
+9 Rue de l'Aqueduc Romain 34350,,,,9,Rue de l'Aqueduc Romain,Vendres,
+9 Rue de l'Aqueduc Romain,3.226602,43.267294,,9,Rue de l'Aqueduc Romain,,34350
+14 Avenue de la Gare Villeneuve-lès-Béziers,,,,14,Avenue de la Gare,,34500
+14 Avenue de la Gare 34500,,,,14,Avenue de la Gare,Villeneuve-lès-Béziers,
+14 Avenue de la Gare,3.282143,43.31931,,14,Avenue de la Gare,,34500
+11 Rue du Peyrou Villeveyrac,,,,11,Rue du Peyrou,,34560
+11 Rue du Peyrou 34560,,,,11,Rue du Peyrou,Villeveyrac,
+11 Rue du Peyrou,3.607753,43.50227,,11,Rue du Peyrou,,34560
+14TER Route Mazet Nationale 599 Marvejols,,,,14TER,Route Mazet Nationale 599,,48100
+14TER Route Mazet Nationale 599 48100,,,,14TER,Route Mazet Nationale 599,Marvejols,
+14TER Route Mazet Nationale 599,3.303988,44.554247,,14TER,Route Mazet Nationale 599,,48100
+2 Rue du Clerc Saint-Alban-sur-Limagnole,,,,2,Rue du Clerc,,48120
+2 Rue du Clerc 48120,,,,2,Rue du Clerc,Saint-Alban-sur-Limagnole,
+2 Rue du Clerc,3.388011,44.78086,,2,Rue du Clerc,,48120
+11 Rue Leconte de l'Isle Argelès-sur-Mer,,,,11,Rue Leconte de l'Isle,,66700
+11 Rue Leconte de l'Isle 66700,,,,11,Rue Leconte de l'Isle,Argelès-sur-Mer,
+11 Rue Leconte de l'Isle,3.027548,42.546754,,11,Rue Leconte de l'Isle,,66700
+28 Rue des Eaux Vives Baho,,,,28,Rue des Eaux Vives,,66540
+28 Rue des Eaux Vives 66540,,,,28,Rue des Eaux Vives,Baho,
+28 Rue des Eaux Vives,2.819128,42.703493,,28,Rue des Eaux Vives,,66540
+23 Boulevard du Grau Saint-Ange Le Barcarès,,,,23,Boulevard du Grau Saint-Ange,,66420
+23 Boulevard du Grau Saint-Ange 66420,,,,23,Boulevard du Grau Saint-Ange,Le Barcarès,
+23 Boulevard du Grau Saint-Ange,3.036387,42.785588,,23,Boulevard du Grau Saint-Ange,,66420
+74 Avenue d'en Carbouner Le Boulou,,,,74,Avenue d'en Carbouner,,66160
+74 Avenue d'en Carbouner 66160,,,,74,Avenue d'en Carbouner,Le Boulou,
+74 Avenue d'en Carbouner,2.86191,42.510944,,74,Avenue d'en Carbouner,,66160
+2 Rue Josep Andreu Toront Cabestany,,,,2,Rue Josep Andreu Toront,,66330
+2 Rue Josep Andreu Toront 66330,,,,2,Rue Josep Andreu Toront,Cabestany,
+2 Rue Josep Andreu Toront,2.944853,42.683315,,2,Rue Josep Andreu Toront,,66330
+1 Avenue de la Méditerranée Canet-en-Roussillon,,,,1,Avenue de la Méditerranée,,66140
+1 Avenue de la Méditerranée 66140,,,,1,Avenue de la Méditerranée,Canet-en-Roussillon,
+1 Avenue de la Méditerranée,3.034686,42.69351,,1,Avenue de la Méditerranée,,66140
+1 Rue du Fenouilledes Caudiès-de-Fenouillèdes,,,,1,Rue du Fenouilledes,,66220
+1 Rue du Fenouilledes 66220,,,,1,Rue du Fenouilledes,Caudiès-de-Fenouillèdes,
+1 Rue du Fenouilledes,2.37877,42.810042,,1,Rue du Fenouilledes,,66220
+2 Rue des Fleurs Codalet,,,,2,Rue des Fleurs,,66500
+2 Rue des Fleurs 66500,,,,2,Rue des Fleurs,Codalet,
+2 Rue des Fleurs,2.41655,42.610137,,2,Rue des Fleurs,,66500
+7 Rue de la Paix Elne,,,,7,Rue de la Paix,,66200
+7 Rue de la Paix 66200,,,,7,Rue de la Paix,Elne,
+7 Rue de la Paix,2.971105,42.598901,,7,Rue de la Paix,,66200
+1 Rue Lafayette Ille-sur-Têt,,,,1,Rue Lafayette,,66130
+1 Rue Lafayette 66130,,,,1,Rue Lafayette,Ille-sur-Têt,
+1 Rue Lafayette,2.624681,42.670506,,1,Rue Lafayette,,66130
+23BIS Rue Gabriel Fauré Llupia,,,,23BIS,Rue Gabriel Fauré,,66300
+23BIS Rue Gabriel Fauré 66300,,,,23BIS,Rue Gabriel Fauré,Llupia,
+23BIS Rue Gabriel Fauré,2.769904,42.618383,,23BIS,Rue Gabriel Fauré,,66300
+4 PLA DES MICOCOULIERS Montesquieu-des-Albères,,,,4,MICOCOULIERS,,66740
+4 PLA DES MICOCOULIERS 66740,,,,4,MICOCOULIERS,Montesquieu-des-Albères,
+4 PLA DES MICOCOULIERS,2.880025,42.541218,,4,MICOCOULIERS,,66740
+6 Rue Alfred de Vigny Perpignan,,,,6,Rue Alfred de Vigny,,66000
+6 Rue Alfred de Vigny 66000,,,,6,Rue Alfred de Vigny,Perpignan,
+6 Rue Alfred de Vigny,2.886713,42.694318,,6,Rue Alfred de Vigny,,66000
+105 Avenue du Commandant Ernest Soubielle Perpignan,,,,105,Avenue du Commandant Ernest Soubielle,,66000
+105 Avenue du Commandant Ernest Soubielle 66000,,,,105,Avenue du Commandant Ernest Soubielle,Perpignan,
+105 Avenue du Commandant Ernest Soubielle,2.884283,42.703166,,105,Avenue du Commandant Ernest Soubielle,,66000
+11 Rue George Sand Perpignan,,,,11,Rue George Sand,,66000
+11 Rue George Sand 66000,,,,11,Rue George Sand,Perpignan,
+11 Rue George Sand,2.891835,42.689197,,11,Rue George Sand,,66000
+26 Rue René Laennec Perpignan,,,,26,Rue René Laennec,,66000
+26 Rue René Laennec 66000,,,,26,Rue René Laennec,Perpignan,
+26 Rue René Laennec,2.902351,42.692287,,26,Rue René Laennec,,66000
+32 Rue Paul Fort Perpignan,,,,32,Rue Paul Fort,,66000
+32 Rue Paul Fort 66000,,,,32,Rue Paul Fort,Perpignan,
+32 Rue Paul Fort,2.88839,42.707765,,32,Rue Paul Fort,,66000
+11 Rue Henri Stendhal Perpignan,,,,11,Rue Henri Stendhal,,66000
+11 Rue Henri Stendhal 66000,,,,11,Rue Henri Stendhal,Perpignan,
+11 Rue Henri Stendhal,2.876308,42.697946,,11,Rue Henri Stendhal,,66000
+2 Rue Beausejour Pia,,,,2,Rue Beausejour,,66380
+2 Rue Beausejour 66380,,,,2,Rue Beausejour,Pia,
+2 Rue Beausejour,2.919665,42.746028,,2,Rue Beausejour,,66380
+13 Rue des Oeillets Ponteilla,,,,13,Rue des Oeillets,,66300
+13 Rue des Oeillets 66300,,,,13,Rue des Oeillets,Ponteilla,
+13 Rue des Oeillets,2.815055,42.624872,,13,Rue des Oeillets,,66300
+45 Route Nationale Ria-Sirach,,,,45,Route Nationale,,66500
+45 Route Nationale 66500,,,,45,Route Nationale,Ria-Sirach,
+45 Route Nationale,2.39696,42.605818,,45,Route Nationale,,66500
+26 Rue Saint-Ferréol Saint-André,,,,26,Rue Saint-Ferréol,,66690
+26 Rue Saint-Ferréol 66690,,,,26,Rue Saint-Ferréol,Saint-André,
+26 Rue Saint-Ferréol,2.971316,42.554208,,26,Rue Saint-Ferréol,,66690
+44 Résidence Les Casellas Saint-Cyprien,,,,44,Résidence Les Casellas,,66750
+44 Résidence Les Casellas 66750,,,,44,Résidence Les Casellas,Saint-Cyprien,
+44 Résidence Les Casellas,3.029163,42.629779,,44,Résidence Les Casellas,,66750
+27 Avenue des Albères Saint-Génis-des-Fontaines,,,,27,Avenue des Albères,,66740
+27 Avenue des Albères 66740,,,,27,Avenue des Albères,Saint-Génis-des-Fontaines,
+27 Avenue des Albères,2.921021,42.542822,,27,Avenue des Albères,,66740
+11 Rue Jean Bart Saint-Laurent-de-la-Salanque,,,,11,Rue Jean Bart,,66250
+11 Rue Jean Bart 66250,,,,11,Rue Jean Bart,Saint-Laurent-de-la-Salanque,
+11 Rue Jean Bart,2.989447,42.771453,,11,Rue Jean Bart,,66250
+4 Rue des Pommiers Sainte-Marie,,,,4,Rue des Pommiers,,66470
+4 Rue des Pommiers 66470,,,,4,Rue des Pommiers,Sainte-Marie,
+4 Rue des Pommiers,3.027917,42.734895,,4,Rue des Pommiers,,66470
+26 Avenue du Roussillon Salses-le-Château,,,,26,Avenue du Roussillon,,66600
+26 Avenue du Roussillon 66600,,,,26,Avenue du Roussillon,Salses-le-Château,
+26 Avenue du Roussillon,2.915768,42.832438,,26,Avenue du Roussillon,,66600
+2 Place Louis Blanc Tautavel,,,,2,Place Louis Blanc,,66720
+2 Place Louis Blanc 66720,,,,2,Place Louis Blanc,Tautavel,
+2 Place Louis Blanc,2.745706,42.813517,,2,Place Louis Blanc,,66720
+8 Rue de la Concorde Torreilles,,,,8,Rue de la Concorde,,66440
+8 Rue de la Concorde 66440,,,,8,Rue de la Concorde,Torreilles,
+8 Rue de la Concorde,2.994477,42.754457,,8,Rue de la Concorde,,66440
+14 Boulevard du Cady Vernet-les-Bains,,,,14,Boulevard du Cady,,66820
+14 Boulevard du Cady 66820,,,,14,Boulevard du Cady,Vernet-les-Bains,
+14 Boulevard du Cady,2.387726,42.547151,,14,Boulevard du Cady,,66820
+166 Avenue du Général de Gaulle Vinça,,,,166,Avenue du Général de Gaulle,,66320
+166 Avenue du Général de Gaulle 66320,,,,166,Avenue du Général de Gaulle,Vinça,
+166 Avenue du Général de Gaulle,2.52204,42.644502,,166,Avenue du Général de Gaulle,,66320

--- a/geocoder_tester/world/france/limousin/test_addresses.csv
+++ b/geocoder_tester/world/france/limousin/test_addresses.csv
@@ -1,106 +1,106 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-16 Rue Blaise Raynal Brive-la-Gaillarde,,,,16 Rue Blaise Raynal,,,,19100
-16 Rue Blaise Raynal 19100,,,,16 Rue Blaise Raynal,,,Brive-la-Gaillarde,
-16 Rue Blaise Raynal,1.535265,45.157895,,16 Rue Blaise Raynal,,,,19100
-1 Avenue Guynemer Brive-la-Gaillarde,,,,1 Avenue Guynemer,,,,19100
-1 Avenue Guynemer 19100,,,,1 Avenue Guynemer,,,Brive-la-Gaillarde,
-1 Avenue Guynemer,1.505766,45.151186,,1 Avenue Guynemer,,,,19100
-3 Rue Paul Bordier Brive-la-Gaillarde,,,,3 Rue Paul Bordier,,,,19100
-3 Rue Paul Bordier 19100,,,,3 Rue Paul Bordier,,,Brive-la-Gaillarde,
-3 Rue Paul Bordier,1.530909,45.167170,,3 Rue Paul Bordier,,,,19100
-4 Rue du Tisserand Corrèze,,,,4 Rue du Tisserand,,,,19800
-4 Rue du Tisserand 19800,,,,4 Rue du Tisserand,,,Corrèze,
-4 Rue du Tisserand,1.873542,45.372870,,4 Rue du Tisserand,,,,19800
-27 Rue Aliénor d'Aquitaine Malemort-sur-Corrèze,,,,27 Rue Aliénor d'Aquitaine,,,,19360
-27 Rue Aliénor d'Aquitaine 19360,,,,27 Rue Aliénor d'Aquitaine,,,,19360
-27 Rue Aliénor d'Aquitaine,1.555503,45.173976,,27 Rue Aliénor d'Aquitaine,,,,19360
-32 Impasse de Saint-Jean Objat,,,,32 Impasse de Saint-Jean,,,,19130
-32 Impasse de Saint-Jean 19130,,,,32 Impasse de Saint-Jean,,,Objat,
-32 Impasse de Saint-Jean,1.402727,45.280168,,32 Impasse de Saint-Jean,,,,19130
-5 Allée de la Rechèze Troche,,,,5 Allée de la Rechèze,,,,19230
-5 Allée de la Rechèze 19230,,,,5 Allée de la Rechèze,,,Troche,
-5 Allée de la Rechèze,1.448137,45.383012,,5 Allée de la Rechèze,,,,19230
-14 Impasse des Bouleaux Ussel,,,,14 Impasse des Bouleaux,,,,19200
-14 Impasse des Bouleaux 19200,,,,14 Impasse des Bouleaux,,,Ussel,
-14 Impasse des Bouleaux,2.321441,45.548217,,14 Impasse des Bouleaux,,,,19200
-2 Rue Claude Monet Boussac,,,,2 Rue Claude Monet,,,,23600
-2 Rue Claude Monet 23600,,,,2 Rue Claude Monet,,,Boussac,
-2 Rue Claude Monet,2.228363,46.346141,,2 Rue Claude Monet,,,,23600
-53 Faubourg Monneix Évaux-les-Bains,,,,53 Faubourg Monneix,,,,23110
-53 Faubourg Monneix 23110,,,,53 Faubourg Monneix,,,Évaux-les-Bains,
-53 Faubourg Monneix,2.492872,46.174087,,53 Faubourg Monneix,,,,23110
-9 Rue du Marché Guéret,,,,9 Rue du Marché,,,,23000
-9 Rue du Marché 23000,,,,9 Rue du Marché,,,Guéret,
-9 Rue du Marché,1.868474,46.170670,,9 Rue du Marché,,,,23000
-18 Rue du Cheix Rougnat,,,,18 Rue du Cheix,,,,23700
-18 Rue du Cheix 23700,,,,18 Rue du Cheix,,,Rougnat,
-18 Rue du Cheix,2.500174,46.052893,,18 Rue du Cheix,,,,23700
-25 Route de la Croix-Pierre Saint-Moreil,,,,25 Route de la Croix-Pierre,,,,23400
-25 Route de la Croix-Pierre 23400,,,,25 Route de la Croix-Pierre,,,Saint-Moreil,
-25 Route de la Croix-Pierre,1.691059,45.854509,,25 Route de la Croix-Pierre,,,,23400
-18 Rue des Roses Bellac,,,,18 Rue des Roses,,,,87300
-18 Rue des Roses 87300,,,,18 Rue des Roses,,,Bellac,
-18 Rue des Roses,1.056114,46.124870,,18 Rue des Roses,,,,87300
-20 Rue du Clos Bussière-Poitevine,,,,20 Rue du Clos,,,,87320
-20 Rue du Clos 87320,,,,20 Rue du Clos,,,Bussière-Poitevine,
-20 Rue du Clos,0.904117,46.234280,,20 Rue du Clos,,,,87320
-2 Espace Camille Samy Châteauneuf-la-Forêt,,,,2 Espace Camille Samy,,,,87130
-2 Espace Camille Samy 87130,,,,2 Espace Camille Samy,,,Châteauneuf-la-Forêt,
-2 Espace Camille Samy,1.603867,45.713566,,2 Espace Camille Samy,,,,87130
-28BIS Route du Landou Couzeix,,,,28BIS Route du Landou,,,,87270
-28BIS Route du Landou 87270,,,,28BIS Route du Landou,,,Couzeix,
-28BIS Route du Landou,1.208714,45.863047,,28BIS Route du Landou,,,,87270
-6 Rue Saint-Michel Le Dorat,,,,6 Rue Saint-Michel,,,,87210
-6 Rue Saint-Michel 87210,,,,6 Rue Saint-Michel,,,Le Dorat,
-6 Rue Saint-Michel,1.080443,46.214103,,6 Rue Saint-Michel,,,,87210
-1 Place du 8 Mai 1945 Feytiat,,,,1 Place du 8 Mai 1945,,,,87220
-1 Place du 8 Mai 1945 87220,,,,1 Place du 8 Mai 1945,,,Feytiat,
-1 Place du 8 Mai 1945,1.333052,45.811397,,1 Place du 8 Mai 1945,,,,87220
-450 Rue Edith Piaf Jourgnac,,,,450 Rue Edith Piaf,,,,87800
-450 Rue Edith Piaf 87800,,,,450 Rue Edith Piaf,,,Jourgnac,
-450 Rue Edith Piaf,1.194919,45.725790,,450 Rue Edith Piaf,,,,87800
-19 Rue Alphonse Daudet Limoges,,,,19 Rue Alphonse Daudet,,,,87000
-19 Rue Alphonse Daudet 87000,,,,19 Rue Alphonse Daudet,,,Limoges,
-19 Rue Alphonse Daudet,1.236357,45.845385,,19 Rue Alphonse Daudet,,,,87000
-3 Impasse Charles Bichet Limoges,,,,3 Impasse Charles Bichet,,,,87000
-3 Impasse Charles Bichet 87000,,,,3 Impasse Charles Bichet,,,Limoges,
-3 Impasse Charles Bichet,1.263414,45.818336,,3 Impasse Charles Bichet,,,,87000
-10 Rue François Chénieux Limoges,,,,10 Rue François Chénieux,,,,87000
-10 Rue François Chénieux 87000,,,,10 Rue François Chénieux,,,Limoges,
-10 Rue François Chénieux,1.255877,45.833836,,10 Rue François Chénieux,,,,87000
-13 Cours Jourdan Limoges,,,,13 Cours Jourdan,,,,87000
-13 Cours Jourdan 87000,,,,13 Cours Jourdan,,,Limoges,
-13 Cours Jourdan,1.264267,45.833205,,13 Cours Jourdan,,,,87000
-16 Rue Mozart Limoges,,,,16 Rue Mozart,,,,87000
-16 Rue Mozart 87000,,,,16 Rue Mozart,,,Limoges,
-16 Rue Mozart,1.252692,45.822628,,16 Rue Mozart,,,,87000
-5 Rue Saint-Aurélien Limoges,,,,5 Rue Saint-Aurélien,,,,87000
-5 Rue Saint-Aurélien 87000,,,,5 Rue Saint-Aurélien,,,Limoges,
-5 Rue Saint-Aurélien,1.257774,45.828111,,5 Rue Saint-Aurélien,,,,87000
-10 Route de Saint-Martial Mézières-sur-Issoire,,,,10 Route de Saint-Martial,,,,87330
-10 Route de Saint-Martial 87330,,,,10 Route de Saint-Martial,,,,87330
-10 Route de Saint-Martial,0.907516,46.108916,,10 Route de Saint-Martial,,,,87330
-4 Allée Molière Le Palais-sur-Vienne,,,,4 Allée Molière,,,,87410
-4 Allée Molière 87410,,,,4 Allée Molière,,,Le Palais-sur-Vienne,
-4 Allée Molière,1.322074,45.862695,,4 Allée Molière,,,,87410
-6 Chemin de la Vie Creuse Peyrat-de-Bellac,,,,6 Chemin de la Vie Creuse,,,,87300
-6 Chemin de la Vie Creuse 87300,,,,6 Chemin de la Vie Creuse,,,Peyrat-de-Bellac,
-6 Chemin de la Vie Creuse,1.031307,46.139247,,6 Chemin de la Vie Creuse,,,,87300
-3 Chemin des Marguerites Rochechouart,,,,3 Chemin des Marguerites,,,,87600
-3 Chemin des Marguerites 87600,,,,3 Chemin des Marguerites,,,Rochechouart,
-3 Chemin des Marguerites,0.841283,45.836296,,3 Chemin des Marguerites,,,,87600
-14 Rue du Poète Saint-Georges-les-Landes,,,,14 Rue du Poète,,,,87160
-14 Rue du Poète 87160,,,,14 Rue du Poète,,,Saint-Georges-les-Landes,
-14 Rue du Poète,1.336370,46.341664,,14 Rue du Poète,,,,87160
-34 Rue du Relais Saint-Junien,,,,34 Rue du Relais,,,,87200
-34 Rue du Relais 87200,,,,34 Rue du Relais,,,Saint-Junien,
-34 Rue du Relais,0.885007,45.879445,,34 Rue du Relais,,,,87200
-15 Domaine de Rochefaye Saint-Laurent-sur-Gorre,,,,15 Domaine de Rochefaye,,,,87310
-15 Domaine de Rochefaye 87310,,,,15 Domaine de Rochefaye,,,Saint-Laurent-sur-Gorre,
-15 Domaine de Rochefaye,1.004355,45.768738,,15 Domaine de Rochefaye,,,,87310
-2 Impasse du Rieu Saint-Sulpice-Laurière,,,,2 Impasse du Rieu,,,,87370
-2 Impasse du Rieu 87370,,,,2 Impasse du Rieu,,,Saint-Sulpice-Laurière,
-2 Impasse du Rieu,1.484240,46.047127,,2 Impasse du Rieu,,,,87370
-4 Rue du Gué de Luchapt Thiat,,,,4 Rue du Gué de Luchapt,,,,87320
-4 Rue du Gué de Luchapt 87320,,,,4 Rue du Gué de Luchapt,,,Thiat,
-4 Rue du Gué de Luchapt,0.973287,46.264691,,4 Rue du Gué de Luchapt,,,,87320
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+16 Rue Blaise Raynal Brive-la-Gaillarde,,,,16,Rue Blaise Raynal,,19100
+16 Rue Blaise Raynal 19100,,,,16,Rue Blaise Raynal,Brive-la-Gaillarde,
+16 Rue Blaise Raynal,1.535265,45.157895,,16,Rue Blaise Raynal,,19100
+1 Avenue Guynemer Brive-la-Gaillarde,,,,1,Avenue Guynemer,,19100
+1 Avenue Guynemer 19100,,,,1,Avenue Guynemer,Brive-la-Gaillarde,
+1 Avenue Guynemer,1.505766,45.151186,,1,Avenue Guynemer,,19100
+3 Rue Paul Bordier Brive-la-Gaillarde,,,,3,Rue Paul Bordier,,19100
+3 Rue Paul Bordier 19100,,,,3,Rue Paul Bordier,Brive-la-Gaillarde,
+3 Rue Paul Bordier,1.530909,45.16717,,3,Rue Paul Bordier,,19100
+4 Rue du Tisserand Corrèze,,,,4,Rue du Tisserand,,19800
+4 Rue du Tisserand 19800,,,,4,Rue du Tisserand,Corrèze,
+4 Rue du Tisserand,1.873542,45.37287,,4,Rue du Tisserand,,19800
+27 Rue Aliénor d'Aquitaine Malemort-sur-Corrèze,,,,27,Rue Aliénor d'Aquitaine,,19360
+27 Rue Aliénor d'Aquitaine 19360,,,,27,Rue Aliénor d'Aquitaine,,19360
+27 Rue Aliénor d'Aquitaine,1.555503,45.173976,,27,Rue Aliénor d'Aquitaine,,19360
+32 Impasse de Saint-Jean Objat,,,,32,Impasse de Saint-Jean,,19130
+32 Impasse de Saint-Jean 19130,,,,32,Impasse de Saint-Jean,Objat,
+32 Impasse de Saint-Jean,1.402727,45.280168,,32,Impasse de Saint-Jean,,19130
+5 Allée de la Rechèze Troche,,,,5,Allée de la Rechèze,,19230
+5 Allée de la Rechèze 19230,,,,5,Allée de la Rechèze,Troche,
+5 Allée de la Rechèze,1.448137,45.383012,,5,Allée de la Rechèze,,19230
+14 Impasse des Bouleaux Ussel,,,,14,Impasse des Bouleaux,,19200
+14 Impasse des Bouleaux 19200,,,,14,Impasse des Bouleaux,Ussel,
+14 Impasse des Bouleaux,2.321441,45.548217,,14,Impasse des Bouleaux,,19200
+2 Rue Claude Monet Boussac,,,,2,Rue Claude Monet,,23600
+2 Rue Claude Monet 23600,,,,2,Rue Claude Monet,Boussac,
+2 Rue Claude Monet,2.228363,46.346141,,2,Rue Claude Monet,,23600
+53 Faubourg Monneix Évaux-les-Bains,,,,53,Faubourg Monneix,,23110
+53 Faubourg Monneix 23110,,,,53,Faubourg Monneix,Évaux-les-Bains,
+53 Faubourg Monneix,2.492872,46.174087,,53,Faubourg Monneix,,23110
+9 Rue du Marché Guéret,,,,9,Rue du Marché,,23000
+9 Rue du Marché 23000,,,,9,Rue du Marché,Guéret,
+9 Rue du Marché,1.868474,46.17067,,9,Rue du Marché,,23000
+18 Rue du Cheix Rougnat,,,,18,Rue du Cheix,,23700
+18 Rue du Cheix 23700,,,,18,Rue du Cheix,Rougnat,
+18 Rue du Cheix,2.500174,46.052893,,18,Rue du Cheix,,23700
+25 Route de la Croix-Pierre Saint-Moreil,,,,25,Route de la Croix-Pierre,,23400
+25 Route de la Croix-Pierre 23400,,,,25,Route de la Croix-Pierre,Saint-Moreil,
+25 Route de la Croix-Pierre,1.691059,45.854509,,25,Route de la Croix-Pierre,,23400
+18 Rue des Roses Bellac,,,,18,Rue des Roses,,87300
+18 Rue des Roses 87300,,,,18,Rue des Roses,Bellac,
+18 Rue des Roses,1.056114,46.12487,,18,Rue des Roses,,87300
+20 Rue du Clos Bussière-Poitevine,,,,20,Rue du Clos,,87320
+20 Rue du Clos 87320,,,,20,Rue du Clos,Bussière-Poitevine,
+20 Rue du Clos,0.904117,46.23428,,20,Rue du Clos,,87320
+2 Espace Camille Samy Châteauneuf-la-Forêt,,,,2,Espace Camille Samy,,87130
+2 Espace Camille Samy 87130,,,,2,Espace Camille Samy,Châteauneuf-la-Forêt,
+2 Espace Camille Samy,1.603867,45.713566,,2,Espace Camille Samy,,87130
+28BIS Route du Landou Couzeix,,,,28BIS,Route du Landou,,87270
+28BIS Route du Landou 87270,,,,28BIS,Route du Landou,Couzeix,
+28BIS Route du Landou,1.208714,45.863047,,28BIS,Route du Landou,,87270
+6 Rue Saint-Michel Le Dorat,,,,6,Rue Saint-Michel,,87210
+6 Rue Saint-Michel 87210,,,,6,Rue Saint-Michel,Le Dorat,
+6 Rue Saint-Michel,1.080443,46.214103,,6,Rue Saint-Michel,,87210
+1 Place du 8 Mai 1945 Feytiat,,,,1,Place du 8 Mai 1945,,87220
+1 Place du 8 Mai 1945 87220,,,,1,Place du 8 Mai 1945,Feytiat,
+1 Place du 8 Mai 1945,1.333052,45.811397,,1,Place du 8 Mai 1945,,87220
+450 Rue Edith Piaf Jourgnac,,,,450,Rue Edith Piaf,,87800
+450 Rue Edith Piaf 87800,,,,450,Rue Edith Piaf,Jourgnac,
+450 Rue Edith Piaf,1.194919,45.72579,,450,Rue Edith Piaf,,87800
+19 Rue Alphonse Daudet Limoges,,,,19,Rue Alphonse Daudet,,87000
+19 Rue Alphonse Daudet 87000,,,,19,Rue Alphonse Daudet,Limoges,
+19 Rue Alphonse Daudet,1.236357,45.845385,,19,Rue Alphonse Daudet,,87000
+3 Impasse Charles Bichet Limoges,,,,3,Impasse Charles Bichet,,87000
+3 Impasse Charles Bichet 87000,,,,3,Impasse Charles Bichet,Limoges,
+3 Impasse Charles Bichet,1.263414,45.818336,,3,Impasse Charles Bichet,,87000
+10 Rue François Chénieux Limoges,,,,10,Rue François Chénieux,,87000
+10 Rue François Chénieux 87000,,,,10,Rue François Chénieux,Limoges,
+10 Rue François Chénieux,1.255877,45.833836,,10,Rue François Chénieux,,87000
+13 Cours Jourdan Limoges,,,,13,Cours Jourdan,,87000
+13 Cours Jourdan 87000,,,,13,Cours Jourdan,Limoges,
+13 Cours Jourdan,1.264267,45.833205,,13,Cours Jourdan,,87000
+16 Rue Mozart Limoges,,,,16,Rue Mozart,,87000
+16 Rue Mozart 87000,,,,16,Rue Mozart,Limoges,
+16 Rue Mozart,1.252692,45.822628,,16,Rue Mozart,,87000
+5 Rue Saint-Aurélien Limoges,,,,5,Rue Saint-Aurélien,,87000
+5 Rue Saint-Aurélien 87000,,,,5,Rue Saint-Aurélien,Limoges,
+5 Rue Saint-Aurélien,1.257774,45.828111,,5,Rue Saint-Aurélien,,87000
+10 Route de Saint-Martial Mézières-sur-Issoire,,,,10,Route de Saint-Martial,,87330
+10 Route de Saint-Martial 87330,,,,10,Route de Saint-Martial,,87330
+10 Route de Saint-Martial,0.907516,46.108916,,10,Route de Saint-Martial,,87330
+4 Allée Molière Le Palais-sur-Vienne,,,,4,Allée Molière,,87410
+4 Allée Molière 87410,,,,4,Allée Molière,Le Palais-sur-Vienne,
+4 Allée Molière,1.322074,45.862695,,4,Allée Molière,,87410
+6 Chemin de la Vie Creuse Peyrat-de-Bellac,,,,6,Chemin de la Vie Creuse,,87300
+6 Chemin de la Vie Creuse 87300,,,,6,Chemin de la Vie Creuse,Peyrat-de-Bellac,
+6 Chemin de la Vie Creuse,1.031307,46.139247,,6,Chemin de la Vie Creuse,,87300
+3 Chemin des Marguerites Rochechouart,,,,3,Chemin des Marguerites,,87600
+3 Chemin des Marguerites 87600,,,,3,Chemin des Marguerites,Rochechouart,
+3 Chemin des Marguerites,0.841283,45.836296,,3,Chemin des Marguerites,,87600
+14 Rue du Poète Saint-Georges-les-Landes,,,,14,Rue du Poète,,87160
+14 Rue du Poète 87160,,,,14,Rue du Poète,Saint-Georges-les-Landes,
+14 Rue du Poète,1.33637,46.341664,,14,Rue du Poète,,87160
+34 Rue du Relais Saint-Junien,,,,34,Rue du Relais,,87200
+34 Rue du Relais 87200,,,,34,Rue du Relais,Saint-Junien,
+34 Rue du Relais,0.885007,45.879445,,34,Rue du Relais,,87200
+15 Domaine de Rochefaye Saint-Laurent-sur-Gorre,,,,15,Domaine de Rochefaye,,87310
+15 Domaine de Rochefaye 87310,,,,15,Domaine de Rochefaye,Saint-Laurent-sur-Gorre,
+15 Domaine de Rochefaye,1.004355,45.768738,,15,Domaine de Rochefaye,,87310
+2 Impasse du Rieu Saint-Sulpice-Laurière,,,,2,Impasse du Rieu,,87370
+2 Impasse du Rieu 87370,,,,2,Impasse du Rieu,Saint-Sulpice-Laurière,
+2 Impasse du Rieu,1.48424,46.047127,,2,Impasse du Rieu,,87370
+4 Rue du Gué de Luchapt Thiat,,,,4,Rue du Gué de Luchapt,,87320
+4 Rue du Gué de Luchapt 87320,,,,4,Rue du Gué de Luchapt,Thiat,
+4 Rue du Gué de Luchapt,0.973287,46.264691,,4,Rue du Gué de Luchapt,,87320

--- a/geocoder_tester/world/france/lorraine/test_addresses.csv
+++ b/geocoder_tester/world/france/lorraine/test_addresses.csv
@@ -1,385 +1,385 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-2 Rue Rodicq Audun-le-Roman,,,,2 Rue Rodicq,,,,54560
-2 Rue Rodicq 54560,,,,2 Rue Rodicq,,,Audun-le-Roman,
-2 Rue Rodicq,5.892380,49.369621,,2 Rue Rodicq,,,,54560
-2 Route de Grand Champ Baslieux,,,,2 Route de Grand Champ,,,,54620
-2 Route de Grand Champ 54620,,,,2 Route de Grand Champ,,,Baslieux,
-2 Route de Grand Champ,5.755811,49.435419,,2 Route de Grand Champ,,,,54620
-3 Rue Croix Pierson Blainville-sur-l'Eau,,,,3 Rue Croix Pierson,,,,54360
-3 Rue Croix Pierson 54360,,,,3 Rue Croix Pierson,,,Blainville-sur-l'Eau,
-3 Rue Croix Pierson,6.393294,48.551391,,3 Rue Croix Pierson,,,,54360
-4 Rue des Corvées Bouxières-aux-Dames,,,,4 Rue des Corvées,,,,54136
-4 Rue des Corvées 54136,,,,4 Rue des Corvées,,,Bouxières-aux-Dames,
-4 Rue des Corvées,6.166931,48.750386,,4 Rue des Corvées,,,,54136
-8B Rue des Prayés Cerville,,,,8B Rue des Prayés,,,,54420
-8B Rue des Prayés 54420,,,,8B Rue des Prayés,,,Cerville,
-8B Rue des Prayés,6.313293,48.695141,,8B Rue des Prayés,,,,54420
-107 Rue Capitaine Paturaud Chaudeney-sur-Moselle,,,,107 Rue Capitaine Paturaud,,,,54200
-107 Rue Capitaine Paturaud 54200,,,,107 Rue Capitaine Paturaud,,,Chaudeney-sur-Moselle,
-107 Rue Capitaine Paturaud,5.904495,48.651795,,107 Rue Capitaine Paturaud,,,,54200
-8 Rue de Guyenne Cosnes-et-Romain,,,,8 Rue de Guyenne,,,,54400
-8 Rue de Guyenne 54400,,,,8 Rue de Guyenne,,,Cosnes-et-Romain,
-8 Rue de Guyenne,5.712454,49.518355,,8 Rue de Guyenne,,,,54400
-26 Rue de l'Aître Deneuvre,,,,26 Rue de l'Aître,,,,54120
-26 Rue de l'Aître 54120,,,,26 Rue de l'Aître,,,Deneuvre,
-26 Rue de l'Aître,6.739213,48.438624,,26 Rue de l'Aître,,,,54120
-7 Rue René II Dombasle-sur-Meurthe,,,,7 Rue René II,,,,54110
-7 Rue René II 54110,,,,7 Rue René II,,,Dombasle-sur-Meurthe,
-7 Rue René II,6.353086,48.616015,,7 Rue René II,,,,54110
-26 Rue Grande Rue Emberménil,,,,26 Rue Grande Rue,,,,54370
-26 Rue Grande Rue 54370,,,,26 Rue Grande Rue,,,Emberménil,
-26 Rue Grande Rue,6.696898,48.629866,,26 Rue Grande Rue,,,,54370
-8 Rue des Bouvreuils Fléville-devant-Nancy,,,,8 Rue des Bouvreuils,,,,54710
-8 Rue des Bouvreuils 54710,,,,8 Rue des Bouvreuils,,,Fléville-devant-Nancy,
-8 Rue des Bouvreuils,6.196211,48.623269,,8 Rue des Bouvreuils,,,,54710
-150 Rue de Nancy Frouard,,,,150 Rue de Nancy,,,,54390
-150 Rue de Nancy 54390,,,,150 Rue de Nancy,,,Frouard,
-150 Rue de Nancy,6.149027,48.747467,,150 Rue de Nancy,,,,54390
-16 Rue de la Prairie Hagéville,,,,16 Rue de la Prairie,,,,54470
-16 Rue de la Prairie 54470,,,,16 Rue de la Prairie,,,Hagéville,
-16 Rue de la Prairie,5.857967,49.031059,,16 Rue de la Prairie,,,,54470
-20 Avenue de la Concorde Herserange,,,,20 Avenue de la Concorde,,,,54440
-20 Avenue de la Concorde 54440,,,,20 Avenue de la Concorde,,,Herserange,
-20 Avenue de la Concorde,5.802451,49.523951,,20 Avenue de la Concorde,,,,54440
-3 Rue Ambroise Croizat Hussigny-Godbrange,,,,3 Rue Ambroise Croizat,,,,54590
-3 Rue Ambroise Croizat 54590,,,,3 Rue Ambroise Croizat,,,Hussigny-Godbrange,
-3 Rue Ambroise Croizat,5.879281,49.491592,,3 Rue Ambroise Croizat,,,,54590
-29 Rue du Général Leclerc Jarville-la-Malgrange,,,,29 Rue du Général Leclerc,,,,54140
-29 Rue du Général Leclerc 54140,,,,29 Rue du Général Leclerc,,,Jarville-la-Malgrange,
-29 Rue du Général Leclerc,6.198028,48.669645,,29 Rue du Général Leclerc,,,,54140
-26 Rue du Pré Joudreville,,,,26 Rue du Pré,,,,54490
-26 Rue du Pré 54490,,,,26 Rue du Pré,,,Joudreville,
-26 Rue du Pré,5.782937,49.298076,,26 Rue du Pré,,,,54490
-7 Rue Aristide Briand Laxou,,,,7 Rue Aristide Briand,,,,54520
-7 Rue Aristide Briand 54520,,,,7 Rue Aristide Briand,,,Laxou,
-7 Rue Aristide Briand,6.156813,48.684706,,7 Rue Aristide Briand,,,,54520
-6 Rue Romain Fontaine Lexy,,,,6 Rue Romain Fontaine,,,,54720
-6 Rue Romain Fontaine 54720,,,,6 Rue Romain Fontaine,,,Lexy,
-6 Rue Romain Fontaine,5.721460,49.502525,,6 Rue Romain Fontaine,,,,54720
-44 Rue Val Fleuri Longuyon,,,,44 Rue Val Fleuri,,,,54260
-44 Rue Val Fleuri 54260,,,,44 Rue Val Fleuri,,,Longuyon,
-44 Rue Val Fleuri,5.597922,49.441250,,44 Rue Val Fleuri,,,,54260
-116 Impasse Camille Corot Ludres,,,,116 Impasse Camille Corot,,,,54710
-116 Impasse Camille Corot 54710,,,,116 Impasse Camille Corot,,,Ludres,
-116 Impasse Camille Corot,6.175372,48.614483,,116 Impasse Camille Corot,,,,54710
-8 Rue du 8e Régiment de Dragons Lunéville,,,,8 Rue du 8e Régiment de Dragons,,,,54300
-8 Rue du 8e Régiment de Dragons 54300,,,,8 Rue du 8e Régiment de Dragons,,,Lunéville,
-8 Rue du 8e Régiment de Dragons,6.480252,48.598314,,8 Rue du 8e Régiment de Dragons,,,,54300
-66A Rue du Colonel Driant Malzéville,,,,66A Rue du Colonel Driant,,,,54220
-66A Rue du Colonel Driant 54220,,,,66A Rue du Colonel Driant,,,Malzéville,
-66A Rue du Colonel Driant,6.192648,48.704086,,66A Rue du Colonel Driant,,,,54220
-4 Allée David Maxéville,,,,4 Allée David,,,,54320
-4 Allée David 54320,,,,4 Allée David,,,Maxéville,
-4 Allée David,6.164980,48.711377,,4 Allée David,,,,54320
-18 Lotissement Le Clos du Moulin Moineville,,,,18 Lotissement Le Clos du Moulin,,,,54580
-18 Lotissement Le Clos du Moulin 54580,,,,18 Lotissement Le Clos du Moulin,,,Moineville,
-18 Lotissement Le Clos du Moulin,5.937011,49.201362,,18 Lotissement Le Clos du Moulin,,,,54580
-1 Grande Rue Moriviller,,,,1 Grande Rue,,,,54830
-1 Grande Rue 54830,,,,1 Grande Rue,,,Moriviller,
-1 Grande Rue,6.441924,48.477836,,1 Grande Rue,,,,54830
-12 Rue Col Courtot de Cissey Nancy,,,,12 Rue Col Courtot de Cissey,,,,54100
-12 Rue Col Courtot de Cissey 54100,,,,12 Rue Col Courtot de Cissey,,,Nancy,
-12 Rue Col Courtot de Cissey,6.166971,48.674640,,12 Rue Col Courtot de Cissey,,,,54100
-17 Rue Jacquard Nancy,,,,17 Rue Jacquard,,,,54100
-17 Rue Jacquard 54100,,,,17 Rue Jacquard,,,Nancy,
-17 Rue Jacquard,6.178094,48.694502,,17 Rue Jacquard,,,,54100
-14 Impasse Pierre Crevisier Nancy,,,,14 Impasse Pierre Crevisier,,,,54100
-14 Impasse Pierre Crevisier 54100,,,,14 Impasse Pierre Crevisier,,,Nancy,
-14 Impasse Pierre Crevisier,6.172921,48.682482,,14 Impasse Pierre Crevisier,,,,54100
-23 Allée des Bégonias Neuves-Maisons,,,,23 Allée des Bégonias,,,,54230
-23 Allée des Bégonias 54230,,,,23 Allée des Bégonias,,,Neuves-Maisons,
-23 Allée des Bégonias,6.107208,48.626714,,23 Allée des Bégonias,,,,54230
-15 Rue Joly Pagny-sur-Moselle,,,,15 Rue Joly,,,,54530
-15 Rue Joly 54530,,,,15 Rue Joly,,,Pagny-sur-Moselle,
-15 Rue Joly,6.018681,48.984346,,15 Rue Joly,,,,54530
-625 Avenue de Champagne Pont-à-Mousson,,,,625 Avenue de Champagne,,,,54700
-625 Avenue de Champagne 54700,,,,625 Avenue de Champagne,,,Pont-à-Mousson,
-625 Avenue de Champagne,6.056007,48.915788,,625 Avenue de Champagne,,,,54700
-34 Les Blés d'Or Pulnoy,,,,34 Les Blés d'Or,,,,54425
-34 Les Blés d'Or 54425,,,,34 Les Blés d'Or,,,Pulnoy,
-34 Les Blés d'Or,6.259623,48.705402,,34 Les Blés d'Or,,,,54425
-16 Rue du Capitaine Clochette Rosières-aux-Salines,,,,16 Rue du Capitaine Clochette,,,,54110
-16 Rue du Capitaine Clochette 54110,,,,16 Rue du Capitaine Clochette,,,Rosières-aux-Salines,
-16 Rue du Capitaine Clochette,6.331426,48.594490,,16 Rue du Capitaine Clochette,,,,54110
-2B Chemin des Aulnois Saint-Nicolas-de-Port,,,,2B Chemin des Aulnois,,,,54210
-2B Chemin des Aulnois 54210,,,,2B Chemin des Aulnois,,,Saint-Nicolas-de-Port,
-2B Chemin des Aulnois,6.299142,48.622458,,2B Chemin des Aulnois,,,,54210
-22 Rue de Provence Saulxures-lès-Nancy,,,,22 Rue de Provence,,,,54420
-22 Rue de Provence 54420,,,,22 Rue de Provence,,,Saulxures-lès-Nancy,
-22 Rue de Provence,6.237845,48.679343,,22 Rue de Provence,,,,54420
-27 Rue de Fagnoux Thiaville-sur-Meurthe,,,,27 Rue de Fagnoux,,,,54120
-27 Rue de Fagnoux 54120,,,,27 Rue de Fagnoux,,,Thiaville-sur-Meurthe,
-27 Rue de Fagnoux,6.794692,48.409750,,27 Rue de Fagnoux,,,,54120
-39 Rue Drouas Toul,,,,39 Rue Drouas,,,,54200
-39 Rue Drouas 54200,,,,39 Rue Drouas,,,Toul,
-39 Rue Drouas,5.895344,48.675347,,39 Rue Drouas,,,,54200
-1BIS Place de la République Tucquegnieux,,,,1BIS Place de la République,,,,54640
-1BIS Place de la République 54640,,,,1BIS Place de la République,,,Tucquegnieux,
-1BIS Place de la République,5.882822,49.298468,,1BIS Place de la République,,,,54640
-16 Rue Jean Mermoz Vandœuvre-lès-Nancy,,,,16 Rue Jean Mermoz,,,,54500
-16 Rue Jean Mermoz 54500,,,,16 Rue Jean Mermoz,,,Vandœuvre-lès-Nancy,
-16 Rue Jean Mermoz,6.186954,48.655240,,16 Rue Jean Mermoz,,,,54500
-24 Rue du Maréchal Foch Vézelise,,,,24 Rue du Maréchal Foch,,,,54330
-24 Rue du Maréchal Foch 54330,,,,24 Rue du Maréchal Foch,,,Vézelise,
-24 Rue du Maréchal Foch,6.092112,48.487799,,24 Rue du Maréchal Foch,,,,54330
-12 Square des Noisetiers Villers-lès-Nancy,,,,12 Square des Noisetiers,,,,54600
-12 Square des Noisetiers 54600,,,,12 Square des Noisetiers,,,Villers-lès-Nancy,
-12 Square des Noisetiers,6.105362,48.658591,,12 Square des Noisetiers,,,,54600
-4BIS Rue Yvonne Baratte Villette,,,,4BIS Rue Yvonne Baratte,,,,54260
-4BIS Rue Yvonne Baratte 54260,,,,4BIS Rue Yvonne Baratte,,,Villette,
-4BIS Rue Yvonne Baratte,5.547660,49.474362,,4BIS Rue Yvonne Baratte,,,,54260
-1 Rue de la Porte Espagnole Damvillers,,,,1 Rue de la Porte Espagnole,,,,55150
-1 Rue de la Porte Espagnole 55150,,,,1 Rue de la Porte Espagnole,,,Damvillers,
-1 Rue de la Porte Espagnole,5.402175,49.343775,,1 Rue de la Porte Espagnole,,,,55150
-87 Rue Leroux Ligny-en-Barrois,,,,87 Rue Leroux,,,,55500
-87 Rue Leroux 55500,,,,87 Rue Leroux,,,Ligny-en-Barrois,
-87 Rue Leroux,5.319590,48.690459,,87 Rue Leroux,,,,55500
-48 Rue Raymond Poincaré Revigny-sur-Ornain,,,,48 Rue Raymond Poincaré,,,,55800
-48 Rue Raymond Poincaré 55800,,,,48 Rue Raymond Poincaré,,,Revigny-sur-Ornain,
-48 Rue Raymond Poincaré,4.983539,48.829802,,48 Rue Raymond Poincaré,,,,55800
-5 Rue de Bezonvaux Verdun,,,,5 Rue de Bezonvaux,,,,55100
-5 Rue de Bezonvaux 55100,,,,5 Rue de Bezonvaux,,,Verdun,
-5 Rue de Bezonvaux,5.395082,49.162609,,5 Rue de Bezonvaux,,,,55100
-57 Avenue Trentieme Corps Verdun,,,,57 Avenue Trentieme Corps,,,,55100
-57 Avenue Trentieme Corps 55100,,,,57 Avenue Trentieme Corps,,,Verdun,
-57 Avenue Trentieme Corps,5.407287,49.165509,,57 Avenue Trentieme Corps,,,,55100
-80  Amanvillers,,,,80 ,,,,57865
-80  57865,,,,80 ,,,Amanvillers,
-80 ,6.040720,49.166561,,80 ,,,,57865
-23  Ars-sur-Moselle,,,,23 ,,,,57130
-23  57130,,,,23 ,,,Ars-sur-Moselle,
-23 ,6.059680,49.079122,,23 ,,,,57130
-1A Rue Saint-Gorgon Aumetz,,,,1A Rue Saint-Gorgon,,,,57710
-1A Rue Saint-Gorgon 57710,,,,1A Rue Saint-Gorgon,,,Aumetz,
-1A Rue Saint-Gorgon,5.942295,49.415786,,1A Rue Saint-Gorgon,,,,57710
-129 Rue de l'Église Berthelming,,,,129 Rue de l'Église,,,,57930
-129 Rue de l'Église 57930,,,,129 Rue de l'Église,,,Berthelming,
-129 Rue de l'Église,7.006118,48.817773,,129 Rue de l'Église,,,,57930
-17 Rue du Val de Blies Blies-Ébersing,,,,17 Rue du Val de Blies,,,,57200
-17 Rue du Val de Blies 57200,,,,17 Rue du Val de Blies,,,Blies-Ébersing,
-17 Rue du Val de Blies,7.136689,49.126028,,17 Rue du Val de Blies,,,,57200
-15 Rue de l'Église Breistroff-la-Grande,,,,15 Rue de l'Église,,,,57570
-15 Rue de l'Église 57570,,,,15 Rue de l'Église,,,Breistroff-la-Grande,
-15 Rue de l'Église,6.214418,49.457274,,15 Rue de l'Église,,,,57570
-21  Châtel-Saint-Germain,,,,21 ,,,,57160
-21  57160,,,,21 ,,,Châtel-Saint-Germain,
-21 ,6.079211,49.120764,,21 ,,,,57160
-17 Allée des Glycines Courcelles-Chaussy,,,,17 Allée des Glycines,,,,57530
-17 Allée des Glycines 57530,,,,17 Allée des Glycines,,,Courcelles-Chaussy,
-17 Allée des Glycines,6.398452,49.103600,,17 Allée des Glycines,,,,57530
-32 Boulevard Rabelais Creutzwald,,,,32 Boulevard Rabelais,,,,57150
-32 Boulevard Rabelais 57150,,,,32 Boulevard Rabelais,,,Creutzwald,
-32 Boulevard Rabelais,6.702144,49.205289,,32 Boulevard Rabelais,,,,57150
-12 Rue des Anciens Fours à Chaux Distroff,,,,12 Rue des Anciens Fours à Chaux,,,,57925
-12 Rue des Anciens Fours à Chaux 57925,,,,12 Rue des Anciens Fours à Chaux,,,Distroff,
-12 Rue des Anciens Fours à Chaux,6.270634,49.336111,,12 Rue des Anciens Fours à Chaux,,,,57925
-37 Chaussee Robert Schuman Évrange,,,,37 Chaussee Robert Schuman,,,,57570
-37 Chaussee Robert Schuman 57570,,,,37 Chaussee Robert Schuman,,,Évrange,
-37 Chaussee Robert Schuman,6.193377,49.505147,,37 Chaussee Robert Schuman,,,,57570
-16 Allée des Hêtres Farébersviller,,,,16 Allée des Hêtres,,,,57450
-16 Allée des Hêtres 57450,,,,16 Allée des Hêtres,,,Farébersviller,
-16 Allée des Hêtres,6.886268,49.114054,,16 Allée des Hêtres,,,,57450
-48 Rue de la Centrale Florange,,,,48 Rue de la Centrale,,,,57190
-48 Rue de la Centrale 57190,,,,48 Rue de la Centrale,,,Florange,
-48 Rue de la Centrale,6.114303,49.320592,,48 Rue de la Centrale,,,,57190
-19 LES CAPUCINES Forbach,,,,19 LES CAPUCINES,,,,57600
-19 LES CAPUCINES 57600,,,,19 LES CAPUCINES,,,Forbach,
-19 LES CAPUCINES,6.886604,49.178708,,19 LES CAPUCINES,,,,57600
-17 Rue du Caveau Freyming-Merlebach,,,,17 Rue du Caveau,,,,57800
-17 Rue du Caveau 57800,,,,17 Rue du Caveau,,,Freyming-Merlebach,
-17 Rue du Caveau,6.782246,49.142567,,17 Rue du Caveau,,,,57800
-4BIS Rue de Civaux Gomelange,,,,4BIS Rue de Civaux,,,,57220
-4BIS Rue de Civaux 57220,,,,4BIS Rue de Civaux,,,Gomelange,
-4BIS Rue de Civaux,6.469572,49.241981,,4BIS Rue de Civaux,,,,57220
-6 Lotissement Les Tilleuls Guessling-Hémering,,,,6 Lotissement Les Tilleuls,,,,57380
-6 Lotissement Les Tilleuls 57380,,,,6 Lotissement Les Tilleuls,,,Guessling-Hémering,
-6 Lotissement Les Tilleuls,6.656295,49.017853,,6 Lotissement Les Tilleuls,,,,57380
-15 Rue de Siltzheim Hambach,,,,15 Rue de Siltzheim,,,,57910
-15 Rue de Siltzheim 57910,,,,15 Rue de Siltzheim,,,Hambach,
-15 Rue de Siltzheim,7.044724,49.064107,,15 Rue de Siltzheim,,,,57910
-21 Rue Pierre Mendès-France Hayange,,,,21 Rue Pierre Mendès-France,,,,57700
-21 Rue Pierre Mendès-France 57700,,,,21 Rue Pierre Mendès-France,,,Hayange,
-21 Rue Pierre Mendès-France,6.074455,49.331884,,21 Rue Pierre Mendès-France,,,,57700
-29 Rue de la Gendarmerie Hettange-Grande,,,,29 Rue de la Gendarmerie,,,,57330
-29 Rue de la Gendarmerie 57330,,,,29 Rue de la Gendarmerie,,,Hettange-Grande,
-29 Rue de la Gendarmerie,6.158461,49.400168,,29 Rue de la Gendarmerie,,,,57330
-70 Rue de Carling L'Hôpital,,,,70 Rue de Carling,,,,57490
-70 Rue de Carling 57490,,,,70 Rue de Carling,,,L'Hôpital,
-70 Rue de Carling,6.721758,49.161782,,70 Rue de Carling,,,,57490
-20 Rue de Cantevanne Kanfen,,,,20 Rue de Cantevanne,,,,57330
-20 Rue de Cantevanne 57330,,,,20 Rue de Cantevanne,,,Kanfen,
-20 Rue de Cantevanne,6.114941,49.436686,,20 Rue de Cantevanne,,,,57330
-13 Rue des Cyclamens Langatte,,,,13 Rue des Cyclamens,,,,57400
-13 Rue des Cyclamens 57400,,,,13 Rue des Cyclamens,,,Langatte,
-13 Rue des Cyclamens,6.952854,48.764246,,13 Rue des Cyclamens,,,,57400
-89  Longeville-lès-Metz,,,,89 ,,,,57050
-89  57050,,,,89 ,,,Longeville-lès-Metz,
-89 ,6.152375,49.115174,,89 ,,,,57050
-19 Rue Jacqueline Auriol Maizières-lès-Metz,,,,19 Rue Jacqueline Auriol,,,,57280
-19 Rue Jacqueline Auriol 57280,,,,19 Rue Jacqueline Auriol,,,Maizières-lès-Metz,
-19 Rue Jacqueline Auriol,6.154913,49.216282,,19 Rue Jacqueline Auriol,,,,57280
-99 Rue de la République Marange-Silvange,,,,99 Rue de la République,,,,57535
-99 Rue de la République 57535,,,,99 Rue de la République,,,Marange-Silvange,
-99 Rue de la République,6.102787,49.210191,,99 Rue de la République,,,,57535
-29  Marly,,,,29 ,,,,57155
-29  57155,,,,29 ,,,Marly,
-29 ,6.149609,49.077384,,29 ,,,,57155
-31  Metz,,,,31 ,,,,57000
-31  57000,,,,31 ,,,Metz,
-31 ,6.181387,49.118684,,31 ,,,,57000
-17B  Metz,,,,17B ,,,,57000
-17B  57000,,,,17B ,,,Metz,
-17B ,6.207192,49.121177,,17B ,,,,57000
-6 Place Saint-Roch Metz,,,,6 Place Saint-Roch,,,,57000
-6 Place Saint-Roch 57000,,,,6 Place Saint-Roch,,,Metz,
-6 Place Saint-Roch,6.184833,49.078058,,6 Place Saint-Roch,,,,57000
-39 Rue de l'Église Monneren,,,,39 Rue de l'Église,,,,57920
-39 Rue de l'Église 57920,,,,39 Rue de l'Église,,,Monneren,
-39 Rue de l'Église,6.414402,49.345336,,39 Rue de l'Église,,,,57920
-57  Montigny-lès-Metz,,,,57 ,,,,57950
-57  57950,,,,57 ,,,Montigny-lès-Metz,
-57 ,6.155775,49.086756,,57 ,,,,57950
-56 Rue du Bois Moyeuvre-Grande,,,,56 Rue du Bois,,,,57250
-56 Rue du Bois 57250,,,,56 Rue du Bois,,,Moyeuvre-Grande,
-56 Rue du Bois,6.049844,49.261298,,56 Rue du Bois,,,,57250
-36 Rue des Vosges Niderviller,,,,36 Rue des Vosges,,,,57565
-36 Rue des Vosges 57565,,,,36 Rue des Vosges,,,Niderviller,
-36 Rue des Vosges,7.110308,48.709410,,36 Rue des Vosges,,,,57565
-9 Rue du Maraicher Ogy,,,,9 Rue du Maraicher,,,,57530
-9 Rue du Maraicher 57530,,,,9 Rue du Maraicher,,,Ogy,
-9 Rue du Maraicher,6.313492,49.105433,,9 Rue du Maraicher,,,,57530
-28 Rue Roger Cadel Petite-Rosselle,,,,28 Rue Roger Cadel,,,,57540
-28 Rue Roger Cadel 57540,,,,28 Rue Roger Cadel,,,Petite-Rosselle,
-28 Rue Roger Cadel,6.867734,49.215023,,28 Rue Roger Cadel,,,,57540
-2 Impasse Prairial Porcelette,,,,2 Impasse Prairial,,,,57890
-2 Impasse Prairial 57890,,,,2 Impasse Prairial,,,Porcelette,
-2 Impasse Prairial,6.652172,49.160997,,2 Impasse Prairial,,,,57890
-12 Rue des Saules Réding,,,,12 Rue des Saules,,,,57445
-12 Rue des Saules 57445,,,,12 Rue des Saules,,,Réding,
-12 Rue des Saules,7.110521,48.750958,,12 Rue des Saules,,,,57445
-13 Rue de la Paix Rohrbach-lès-Bitche,,,,13 Rue de la Paix,,,,57410
-13 Rue de la Paix 57410,,,,13 Rue de la Paix,,,Rohrbach-lès-Bitche,
-13 Rue de la Paix,7.268006,49.043447,,13 Rue de la Paix,,,,57410
-3 Rue Sainte-Anne Roussy-le-Village,,,,3 Rue Sainte-Anne,,,,57330
-3 Rue Sainte-Anne 57330,,,,3 Rue Sainte-Anne,,,Roussy-le-Village,
-3 Rue Sainte-Anne,6.172500,49.457716,,3 Rue Sainte-Anne,,,,57330
-2 Rue des Roitelets Saint-Avold,,,,2 Rue des Roitelets,,,,57500
-2 Rue des Roitelets 57500,,,,2 Rue des Roitelets,,,Saint-Avold,
-2 Rue des Roitelets,6.706979,49.132441,,2 Rue des Roitelets,,,,57500
-2  Saint-Privat-la-Montagne,,,,2 ,,,,57855
-2  57855,,,,2 ,,,Saint-Privat-la-Montagne,
-2 ,6.032949,49.186655,,2 ,,,,57855
-11 Rue du Stade Sarrebourg,,,,11 Rue du Stade,,,,57400
-11 Rue du Stade 57400,,,,11 Rue du Stade,,,Sarrebourg,
-11 Rue du Stade,7.048087,48.727653,,11 Rue du Stade,,,,57400
-6 Rue Saint-Jean Neunkirch Sarreguemines,,,,6 Rue Saint-Jean Neunkirch,,,,57200
-6 Rue Saint-Jean Neunkirch 57200,,,,6 Rue Saint-Jean Neunkirch,,,Sarreguemines,
-6 Rue Saint-Jean Neunkirch,7.083101,49.123785,,6 Rue Saint-Jean Neunkirch,,,,57200
-39 Rue de Verdun Semécourt,,,,39 Rue de Verdun,,,,57280
-39 Rue de Verdun 57280,,,,39 Rue de Verdun,,,Semécourt,
-39 Rue de Verdun,6.131372,49.194569,,39 Rue de Verdun,,,,57280
-22 Rue Auguste Delaune Talange,,,,22 Rue Auguste Delaune,,,,57525
-22 Rue Auguste Delaune 57525,,,,22 Rue Auguste Delaune,,,Talange,
-22 Rue Auguste Delaune,6.178087,49.237491,,22 Rue Auguste Delaune,,,,57525
-22 Rue de l'Agriculture Thionville,,,,22 Rue de l'Agriculture,,,,57100
-22 Rue de l'Agriculture 57100,,,,22 Rue de l'Agriculture,,,Thionville,
-22 Rue de l'Agriculture,6.152628,49.367933,,22 Rue de l'Agriculture,,,,57100
-13 Rue de Nancy Thionville,,,,13 Rue de Nancy,,,,57100
-13 Rue de Nancy 57100,,,,13 Rue de Nancy,,,Thionville,
-13 Rue de Nancy,6.156236,49.355361,,13 Rue de Nancy,,,,57100
-7BIS Rue des Jardins Uckange,,,,7BIS Rue des Jardins,,,,57270
-7BIS Rue des Jardins 57270,,,,7BIS Rue des Jardins,,,Uckange,
-7BIS Rue des Jardins,6.149693,49.304631,,7BIS Rue des Jardins,,,,57270
-9  Vernéville,,,,9 ,,,,57130
-9  57130,,,,9 ,,,Vernéville,
-9 ,6.001320,49.146568,,9 ,,,,57130
-5 Rue du Rebberg Volmunster,,,,5 Rue du Rebberg,,,,57720
-5 Rue du Rebberg 57720,,,,5 Rue du Rebberg,,,Volmunster,
-5 Rue du Rebberg,7.350800,49.123287,,5 Rue du Rebberg,,,,57720
-17 Rue Hubert Colinet Woippy,,,,17 Rue Hubert Colinet,,,,57140
-17 Rue Hubert Colinet 57140,,,,17 Rue Hubert Colinet,,,Woippy,
-17 Rue Hubert Colinet,6.162780,49.145480,,17 Rue Hubert Colinet,,,,57140
-72 Route de Thionville Yutz,,,,72 Route de Thionville,,,,57970
-72 Route de Thionville 57970,,,,72 Route de Thionville,,,Yutz,
-72 Route de Thionville,6.177599,49.348295,,72 Route de Thionville,,,,57970
-338 Rue de la Passée La Baffe,,,,338 Rue de la Passée,,,,88460
-338 Rue de la Passée 88460,,,,338 Rue de la Passée,,,La Baffe,
-338 Rue de la Passée,6.573556,48.163578,,338 Rue de la Passée,,,,88460
-16 Chemin des Champis La Bresse,,,,16 Chemin des Champis,,,,88250
-16 Chemin des Champis 88250,,,,16 Chemin des Champis,,,La Bresse,
-16 Chemin des Champis,6.914273,48.024788,,16 Chemin des Champis,,,,88250
-1 Rue Abbé Bertrand Certilleux,,,,1 Rue Abbé Bertrand,,,,88300
-1 Rue Abbé Bertrand 88300,,,,1 Rue Abbé Bertrand,,,Certilleux,
-1 Rue Abbé Bertrand,5.727775,48.312059,,1 Rue Abbé Bertrand,,,,88300
-6 Za La Moise Châtenois,,,,6 Za La Moise,,,,88170
-6 Za La Moise 88170,,,,6 Za La Moise,,,Châtenois,
-6 Za La Moise,5.838397,48.307565,,6 Za La Moise,,,,88170
-17 Route du Droit Cornimont,,,,17 Route du Droit,,,,88310
-17 Route du Droit 88310,,,,17 Route du Droit,,,Cornimont,
-17 Route du Droit,6.828505,47.968317,,17 Route du Droit,,,,88310
-79 Rue de Jeuxey Dogneville,,,,79 Rue de Jeuxey,,,,88000
-79 Rue de Jeuxey 88000,,,,79 Rue de Jeuxey,,,Dogneville,
-79 Rue de Jeuxey,6.460782,48.221337,,79 Rue de Jeuxey,,,,88000
-25 Rue Antoine Réveillé Épinal,,,,25 Rue Antoine Réveillé,,,,88000
-25 Rue Antoine Réveillé 88000,,,,25 Rue Antoine Réveillé,,,Épinal,
-25 Rue Antoine Réveillé,6.452649,48.184187,,25 Rue Antoine Réveillé,,,,88000
-40 Rue de Nancy Épinal,,,,40 Rue de Nancy,,,,88000
-40 Rue de Nancy 88000,,,,40 Rue de Nancy,,,Épinal,
-40 Rue de Nancy,6.441918,48.183545,,40 Rue de Nancy,,,,88000
-13 Route de la Sure Ferdrupt,,,,13 Route de la Sure,,,,88360
-13 Route de la Sure 88360,,,,13 Route de la Sure,,,Ferdrupt,
-13 Route de la Sure,6.731762,47.903679,,13 Route de la Sure,,,,88360
-341 Allée des Marronniers Frizon,,,,341 Allée des Marronniers,,,,88440
-341 Allée des Marronniers 88440,,,,341 Allée des Marronniers,,,Frizon,
-341 Allée des Marronniers,6.364601,48.288761,,341 Allée des Marronniers,,,,88440
-1253 Rue de Xertigny Girancourt,,,,1253 Rue de Xertigny,,,,88390
-1253 Rue de Xertigny 88390,,,,1253 Rue de Xertigny,,,Girancourt,
-1253 Rue de Xertigny,6.316916,48.154983,,1253 Rue de Xertigny,,,,88390
-22 Rue du Pré Genêt Granges-sur-Vologne,,,,22 Rue du Pré Genêt,,,,88640
-22 Rue du Pré Genêt 88640,,,,22 Rue du Pré Genêt,,,,88640
-22 Rue du Pré Genêt,6.796522,48.148165,,22 Rue du Pré Genêt,,,,88640
-2 Rue du Château Jeanménil,,,,2 Rue du Château,,,,88700
-2 Rue du Château 88700,,,,2 Rue du Château,,,Jeanménil,
-2 Rue du Château,6.691300,48.335693,,2 Rue du Château,,,,88700
-395 Route de Bénifosse Mandray,,,,395 Route de Bénifosse,,,,88650
-395 Route de Bénifosse 88650,,,,395 Route de Bénifosse,,,Mandray,
-395 Route de Bénifosse,6.990715,48.218958,,395 Route de Bénifosse,,,,88650
-730 Rue du Mervaux Monthureux-sur-Saône,,,,730 Rue du Mervaux,,,,88410
-730 Rue du Mervaux 88410,,,,730 Rue du Mervaux,,,Monthureux-sur-Saône,
-730 Rue du Mervaux,5.941710,48.014821,,730 Rue du Mervaux,,,,88410
-18 Rue de Bouillemont La Neuveville-devant-Lépanges,,,,18 Rue de Bouillemont,,,,88600
-18 Rue de Bouillemont 88600,,,,18 Rue de Bouillemont,,,La Neuveville-devant-Lépanges,
-18 Rue de Bouillemont,6.668623,48.161122,,18 Rue de Bouillemont,,,,88600
-57 Rue de la Mairie Les Poulières,,,,57 Rue de la Mairie,,,,88600
-57 Rue de la Mairie 88600,,,,57 Rue de la Mairie,,,Les Poulières,
-57 Rue de la Mairie,6.797999,48.202256,,57 Rue de la Mairie,,,,88600
-13 Rue de Belle Vue Raon-l'Étape,,,,13 Rue de Belle Vue,,,,88110
-13 Rue de Belle Vue 88110,,,,13 Rue de Belle Vue,,,Raon-l'Étape,
-13 Rue de Belle Vue,6.853030,48.405012,,13 Rue de Belle Vue,,,,88110
-8BIS Rue Suchet Remiremont,,,,8BIS Rue Suchet,,,,88200
-8BIS Rue Suchet 88200,,,,8BIS Rue Suchet,,,Remiremont,
-8BIS Rue Suchet,6.587520,48.018065,,8BIS Rue Suchet,,,,88200
-6 Chemin de la Ruelle Saint-Benoît-la-Chipotte,,,,6 Chemin de la Ruelle,,,,88700
-6 Chemin de la Ruelle 88700,,,,6 Chemin de la Ruelle,,,Saint-Benoît-la-Chipotte,
-6 Chemin de la Ruelle,6.734459,48.355270,,6 Chemin de la Ruelle,,,,88700
-26 Rue Rovel Saint-Dié-des-Vosges,,,,26 Rue Rovel,,,,88100
-26 Rue Rovel 88100,,,,26 Rue Rovel,,,Saint-Dié-des-Vosges,
-26 Rue Rovel,6.944663,48.292217,,26 Rue Rovel,,,,88100
-212 Rue du Bousson Saint-Michel-sur-Meurthe,,,,212 Rue du Bousson,,,,88470
-212 Rue du Bousson 88470,,,,212 Rue du Bousson,,,Saint-Michel-sur-Meurthe,
-212 Rue du Bousson,6.884638,48.309582,,212 Rue du Bousson,,,,88470
-26BIS Rue Grande Rue Saulxures-lès-Bulgnéville,,,,26BIS Rue Grande Rue,,,,88140
-26BIS Rue Grande Rue 88140,,,,26BIS Rue Grande Rue,,,Saulxures-lès-Bulgnéville,
-26BIS Rue Grande Rue,5.807235,48.199855,,26BIS Rue Grande Rue,,,,88140
-7 Chemin des Épines Tendon,,,,7 Chemin des Épines,,,,88460
-7 Chemin des Épines 88460,,,,7 Chemin des Épines,,,Tendon,
-7 Chemin des Épines,6.676193,48.119403,,7 Chemin des Épines,,,,88460
-153 Rue du Docteur Guegniot Tignécourt,,,,153 Rue du Docteur Guegniot,,,,88320
-153 Rue du Docteur Guegniot 88320,,,,153 Rue du Docteur Guegniot,,,Tignécourt,
-153 Rue du Docteur Guegniot,5.892333,48.042130,,153 Rue du Docteur Guegniot,,,,88320
-4 Rue du Stade Le Val-d'Ajol,,,,4 Rue du Stade,,,,88340
-4 Rue du Stade 88340,,,,4 Rue du Stade,,,Le Val-d'Ajol,
-4 Rue du Stade,6.480783,47.926149,,4 Rue du Stade,,,,88340
-68 Rue de Nancy Vittel,,,,68 Rue de Nancy,,,,88800
-68 Rue de Nancy 88800,,,,68 Rue de Nancy,,,Vittel,
-68 Rue de Nancy,5.943299,48.198982,,68 Rue de Nancy,,,,88800
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+2 Rue Rodicq Audun-le-Roman,,,,2,Rue Rodicq,,54560
+2 Rue Rodicq 54560,,,,2,Rue Rodicq,Audun-le-Roman,
+2 Rue Rodicq,5.89238,49.369621,,2,Rue Rodicq,,54560
+2 Route de Grand Champ Baslieux,,,,2,Route de Grand Champ,,54620
+2 Route de Grand Champ 54620,,,,2,Route de Grand Champ,Baslieux,
+2 Route de Grand Champ,5.755811,49.435419,,2,Route de Grand Champ,,54620
+3 Rue Croix Pierson Blainville-sur-l'Eau,,,,3,Rue Croix Pierson,,54360
+3 Rue Croix Pierson 54360,,,,3,Rue Croix Pierson,Blainville-sur-l'Eau,
+3 Rue Croix Pierson,6.393294,48.551391,,3,Rue Croix Pierson,,54360
+4 Rue des Corvées Bouxières-aux-Dames,,,,4,Rue des Corvées,,54136
+4 Rue des Corvées 54136,,,,4,Rue des Corvées,Bouxières-aux-Dames,
+4 Rue des Corvées,6.166931,48.750386,,4,Rue des Corvées,,54136
+8B Rue des Prayés Cerville,,,,8B,Rue des Prayés,,54420
+8B Rue des Prayés 54420,,,,8B,Rue des Prayés,Cerville,
+8B Rue des Prayés,6.313293,48.695141,,8B,Rue des Prayés,,54420
+107 Rue Capitaine Paturaud Chaudeney-sur-Moselle,,,,107,Rue Capitaine Paturaud,,54200
+107 Rue Capitaine Paturaud 54200,,,,107,Rue Capitaine Paturaud,Chaudeney-sur-Moselle,
+107 Rue Capitaine Paturaud,5.904495,48.651795,,107,Rue Capitaine Paturaud,,54200
+8 Rue de Guyenne Cosnes-et-Romain,,,,8,Rue de Guyenne,,54400
+8 Rue de Guyenne 54400,,,,8,Rue de Guyenne,Cosnes-et-Romain,
+8 Rue de Guyenne,5.712454,49.518355,,8,Rue de Guyenne,,54400
+26 Rue de l'Aître Deneuvre,,,,26,Rue de l'Aître,,54120
+26 Rue de l'Aître 54120,,,,26,Rue de l'Aître,Deneuvre,
+26 Rue de l'Aître,6.739213,48.438624,,26,Rue de l'Aître,,54120
+7 Rue René II Dombasle-sur-Meurthe,,,,7,Rue René II,,54110
+7 Rue René II 54110,,,,7,Rue René II,Dombasle-sur-Meurthe,
+7 Rue René II,6.353086,48.616015,,7,Rue René II,,54110
+26 Rue Grande Rue Emberménil,,,,26,Rue Grande Rue,,54370
+26 Rue Grande Rue 54370,,,,26,Rue Grande Rue,Emberménil,
+26 Rue Grande Rue,6.696898,48.629866,,26,Rue Grande Rue,,54370
+8 Rue des Bouvreuils Fléville-devant-Nancy,,,,8,Rue des Bouvreuils,,54710
+8 Rue des Bouvreuils 54710,,,,8,Rue des Bouvreuils,Fléville-devant-Nancy,
+8 Rue des Bouvreuils,6.196211,48.623269,,8,Rue des Bouvreuils,,54710
+150 Rue de Nancy Frouard,,,,150,Rue de Nancy,,54390
+150 Rue de Nancy 54390,,,,150,Rue de Nancy,Frouard,
+150 Rue de Nancy,6.149027,48.747467,,150,Rue de Nancy,,54390
+16 Rue de la Prairie Hagéville,,,,16,Rue de la Prairie,,54470
+16 Rue de la Prairie 54470,,,,16,Rue de la Prairie,Hagéville,
+16 Rue de la Prairie,5.857967,49.031059,,16,Rue de la Prairie,,54470
+20 Avenue de la Concorde Herserange,,,,20,Avenue de la Concorde,,54440
+20 Avenue de la Concorde 54440,,,,20,Avenue de la Concorde,Herserange,
+20 Avenue de la Concorde,5.802451,49.523951,,20,Avenue de la Concorde,,54440
+3 Rue Ambroise Croizat Hussigny-Godbrange,,,,3,Rue Ambroise Croizat,,54590
+3 Rue Ambroise Croizat 54590,,,,3,Rue Ambroise Croizat,Hussigny-Godbrange,
+3 Rue Ambroise Croizat,5.879281,49.491592,,3,Rue Ambroise Croizat,,54590
+29 Rue du Général Leclerc Jarville-la-Malgrange,,,,29,Rue du Général Leclerc,,54140
+29 Rue du Général Leclerc 54140,,,,29,Rue du Général Leclerc,Jarville-la-Malgrange,
+29 Rue du Général Leclerc,6.198028,48.669645,,29,Rue du Général Leclerc,,54140
+26 Rue du Pré Joudreville,,,,26,Rue du Pré,,54490
+26 Rue du Pré 54490,,,,26,Rue du Pré,Joudreville,
+26 Rue du Pré,5.782937,49.298076,,26,Rue du Pré,,54490
+7 Rue Aristide Briand Laxou,,,,7,Rue Aristide Briand,,54520
+7 Rue Aristide Briand 54520,,,,7,Rue Aristide Briand,Laxou,
+7 Rue Aristide Briand,6.156813,48.684706,,7,Rue Aristide Briand,,54520
+6 Rue Romain Fontaine Lexy,,,,6,Rue Romain Fontaine,,54720
+6 Rue Romain Fontaine 54720,,,,6,Rue Romain Fontaine,Lexy,
+6 Rue Romain Fontaine,5.72146,49.502525,,6,Rue Romain Fontaine,,54720
+44 Rue Val Fleuri Longuyon,,,,44,Rue Val Fleuri,,54260
+44 Rue Val Fleuri 54260,,,,44,Rue Val Fleuri,Longuyon,
+44 Rue Val Fleuri,5.597922,49.44125,,44,Rue Val Fleuri,,54260
+116 Impasse Camille Corot Ludres,,,,116,Impasse Camille Corot,,54710
+116 Impasse Camille Corot 54710,,,,116,Impasse Camille Corot,Ludres,
+116 Impasse Camille Corot,6.175372,48.614483,,116,Impasse Camille Corot,,54710
+8 Rue du 8e Régiment de Dragons Lunéville,,,,8,Rue du 8e Régiment de Dragons,,54300
+8 Rue du 8e Régiment de Dragons 54300,,,,8,Rue du 8e Régiment de Dragons,Lunéville,
+8 Rue du 8e Régiment de Dragons,6.480252,48.598314,,8,Rue du 8e Régiment de Dragons,,54300
+66A Rue du Colonel Driant Malzéville,,,,66A,Rue du Colonel Driant,,54220
+66A Rue du Colonel Driant 54220,,,,66A,Rue du Colonel Driant,Malzéville,
+66A Rue du Colonel Driant,6.192648,48.704086,,66A,Rue du Colonel Driant,,54220
+4 Allée David Maxéville,,,,4,Allée David,,54320
+4 Allée David 54320,,,,4,Allée David,Maxéville,
+4 Allée David,6.16498,48.711377,,4,Allée David,,54320
+18 Lotissement Le Clos du Moulin Moineville,,,,18,Lotissement Le Clos du Moulin,,54580
+18 Lotissement Le Clos du Moulin 54580,,,,18,Lotissement Le Clos du Moulin,Moineville,
+18 Lotissement Le Clos du Moulin,5.937011,49.201362,,18,Lotissement Le Clos du Moulin,,54580
+1 Grande Rue Moriviller,,,,1,Grande Rue,,54830
+1 Grande Rue 54830,,,,1,Grande Rue,Moriviller,
+1 Grande Rue,6.441924,48.477836,,1,Grande Rue,,54830
+12 Rue Col Courtot de Cissey Nancy,,,,12,Rue Col Courtot de Cissey,,54100
+12 Rue Col Courtot de Cissey 54100,,,,12,Rue Col Courtot de Cissey,Nancy,
+12 Rue Col Courtot de Cissey,6.166971,48.67464,,12,Rue Col Courtot de Cissey,,54100
+17 Rue Jacquard Nancy,,,,17,Rue Jacquard,,54100
+17 Rue Jacquard 54100,,,,17,Rue Jacquard,Nancy,
+17 Rue Jacquard,6.178094,48.694502,,17,Rue Jacquard,,54100
+14 Impasse Pierre Crevisier Nancy,,,,14,Impasse Pierre Crevisier,,54100
+14 Impasse Pierre Crevisier 54100,,,,14,Impasse Pierre Crevisier,Nancy,
+14 Impasse Pierre Crevisier,6.172921,48.682482,,14,Impasse Pierre Crevisier,,54100
+23 Allée des Bégonias Neuves-Maisons,,,,23,Allée des Bégonias,,54230
+23 Allée des Bégonias 54230,,,,23,Allée des Bégonias,Neuves-Maisons,
+23 Allée des Bégonias,6.107208,48.626714,,23,Allée des Bégonias,,54230
+15 Rue Joly Pagny-sur-Moselle,,,,15,Rue Joly,,54530
+15 Rue Joly 54530,,,,15,Rue Joly,Pagny-sur-Moselle,
+15 Rue Joly,6.018681,48.984346,,15,Rue Joly,,54530
+625 Avenue de Champagne Pont-à-Mousson,,,,625,Avenue de Champagne,,54700
+625 Avenue de Champagne 54700,,,,625,Avenue de Champagne,Pont-à-Mousson,
+625 Avenue de Champagne,6.056007,48.915788,,625,Avenue de Champagne,,54700
+34 Les Blés d'Or Pulnoy,,,,34,Les Blés d'Or,,54425
+34 Les Blés d'Or 54425,,,,34,Les Blés d'Or,Pulnoy,
+34 Les Blés d'Or,6.259623,48.705402,,34,Les Blés d'Or,,54425
+16 Rue du Capitaine Clochette Rosières-aux-Salines,,,,16,Rue du Capitaine Clochette,,54110
+16 Rue du Capitaine Clochette 54110,,,,16,Rue du Capitaine Clochette,Rosières-aux-Salines,
+16 Rue du Capitaine Clochette,6.331426,48.59449,,16,Rue du Capitaine Clochette,,54110
+2B Chemin des Aulnois Saint-Nicolas-de-Port,,,,2B,Chemin des Aulnois,,54210
+2B Chemin des Aulnois 54210,,,,2B,Chemin des Aulnois,Saint-Nicolas-de-Port,
+2B Chemin des Aulnois,6.299142,48.622458,,2B,Chemin des Aulnois,,54210
+22 Rue de Provence Saulxures-lès-Nancy,,,,22,Rue de Provence,,54420
+22 Rue de Provence 54420,,,,22,Rue de Provence,Saulxures-lès-Nancy,
+22 Rue de Provence,6.237845,48.679343,,22,Rue de Provence,,54420
+27 Rue de Fagnoux Thiaville-sur-Meurthe,,,,27,Rue de Fagnoux,,54120
+27 Rue de Fagnoux 54120,,,,27,Rue de Fagnoux,Thiaville-sur-Meurthe,
+27 Rue de Fagnoux,6.794692,48.40975,,27,Rue de Fagnoux,,54120
+39 Rue Drouas Toul,,,,39,Rue Drouas,,54200
+39 Rue Drouas 54200,,,,39,Rue Drouas,Toul,
+39 Rue Drouas,5.895344,48.675347,,39,Rue Drouas,,54200
+1BIS Place de la République Tucquegnieux,,,,1BIS,Place de la République,,54640
+1BIS Place de la République 54640,,,,1BIS,Place de la République,Tucquegnieux,
+1BIS Place de la République,5.882822,49.298468,,1BIS,Place de la République,,54640
+16 Rue Jean Mermoz Vandœuvre-lès-Nancy,,,,16,Rue Jean Mermoz,,54500
+16 Rue Jean Mermoz 54500,,,,16,Rue Jean Mermoz,Vandœuvre-lès-Nancy,
+16 Rue Jean Mermoz,6.186954,48.65524,,16,Rue Jean Mermoz,,54500
+24 Rue du Maréchal Foch Vézelise,,,,24,Rue du Maréchal Foch,,54330
+24 Rue du Maréchal Foch 54330,,,,24,Rue du Maréchal Foch,Vézelise,
+24 Rue du Maréchal Foch,6.092112,48.487799,,24,Rue du Maréchal Foch,,54330
+12 Square des Noisetiers Villers-lès-Nancy,,,,12,Square des Noisetiers,,54600
+12 Square des Noisetiers 54600,,,,12,Square des Noisetiers,Villers-lès-Nancy,
+12 Square des Noisetiers,6.105362,48.658591,,12,Square des Noisetiers,,54600
+4BIS Rue Yvonne Baratte Villette,,,,4BIS,Rue Yvonne Baratte,,54260
+4BIS Rue Yvonne Baratte 54260,,,,4BIS,Rue Yvonne Baratte,Villette,
+4BIS Rue Yvonne Baratte,5.54766,49.474362,,4BIS,Rue Yvonne Baratte,,54260
+1 Rue de la Porte Espagnole Damvillers,,,,1,Rue de la Porte Espagnole,,55150
+1 Rue de la Porte Espagnole 55150,,,,1,Rue de la Porte Espagnole,Damvillers,
+1 Rue de la Porte Espagnole,5.402175,49.343775,,1,Rue de la Porte Espagnole,,55150
+87 Rue Leroux Ligny-en-Barrois,,,,87,Rue Leroux,,55500
+87 Rue Leroux 55500,,,,87,Rue Leroux,Ligny-en-Barrois,
+87 Rue Leroux,5.31959,48.690459,,87,Rue Leroux,,55500
+48 Rue Raymond Poincaré Revigny-sur-Ornain,,,,48,Rue Raymond Poincaré,,55800
+48 Rue Raymond Poincaré 55800,,,,48,Rue Raymond Poincaré,Revigny-sur-Ornain,
+48 Rue Raymond Poincaré,4.983539,48.829802,,48,Rue Raymond Poincaré,,55800
+5 Rue de Bezonvaux Verdun,,,,5,Rue de Bezonvaux,,55100
+5 Rue de Bezonvaux 55100,,,,5,Rue de Bezonvaux,Verdun,
+5 Rue de Bezonvaux,5.395082,49.162609,,5,Rue de Bezonvaux,,55100
+57 Avenue Trentieme Corps Verdun,,,,57,Avenue Trentieme Corps,,55100
+57 Avenue Trentieme Corps 55100,,,,57,Avenue Trentieme Corps,Verdun,
+57 Avenue Trentieme Corps,5.407287,49.165509,,57,Avenue Trentieme Corps,,55100
+80  Amanvillers,,,,80,,,57865
+80  57865,,,,80,,Amanvillers,
+80,6.04072,49.166561,,80,,,57865
+23  Ars-sur-Moselle,,,,23,,,57130
+23  57130,,,,23,,Ars-sur-Moselle,
+23,6.05968,49.079122,,23,,,57130
+1A Rue Saint-Gorgon Aumetz,,,,1A,Rue Saint-Gorgon,,57710
+1A Rue Saint-Gorgon 57710,,,,1A,Rue Saint-Gorgon,Aumetz,
+1A Rue Saint-Gorgon,5.942295,49.415786,,1A,Rue Saint-Gorgon,,57710
+129 Rue de l'Église Berthelming,,,,129,Rue de l'Église,,57930
+129 Rue de l'Église 57930,,,,129,Rue de l'Église,Berthelming,
+129 Rue de l'Église,7.006118,48.817773,,129,Rue de l'Église,,57930
+17 Rue du Val de Blies Blies-Ébersing,,,,17,Rue du Val de Blies,,57200
+17 Rue du Val de Blies 57200,,,,17,Rue du Val de Blies,Blies-Ébersing,
+17 Rue du Val de Blies,7.136689,49.126028,,17,Rue du Val de Blies,,57200
+15 Rue de l'Église Breistroff-la-Grande,,,,15,Rue de l'Église,,57570
+15 Rue de l'Église 57570,,,,15,Rue de l'Église,Breistroff-la-Grande,
+15 Rue de l'Église,6.214418,49.457274,,15,Rue de l'Église,,57570
+21  Châtel-Saint-Germain,,,,21,,,57160
+21  57160,,,,21,,Châtel-Saint-Germain,
+21,6.079211,49.120764,,21,,,57160
+17 Allée des Glycines Courcelles-Chaussy,,,,17,Allée des Glycines,,57530
+17 Allée des Glycines 57530,,,,17,Allée des Glycines,Courcelles-Chaussy,
+17 Allée des Glycines,6.398452,49.1036,,17,Allée des Glycines,,57530
+32 Boulevard Rabelais Creutzwald,,,,32,Boulevard Rabelais,,57150
+32 Boulevard Rabelais 57150,,,,32,Boulevard Rabelais,Creutzwald,
+32 Boulevard Rabelais,6.702144,49.205289,,32,Boulevard Rabelais,,57150
+12 Rue des Anciens Fours à Chaux Distroff,,,,12,Rue des Anciens Fours à Chaux,,57925
+12 Rue des Anciens Fours à Chaux 57925,,,,12,Rue des Anciens Fours à Chaux,Distroff,
+12 Rue des Anciens Fours à Chaux,6.270634,49.336111,,12,Rue des Anciens Fours à Chaux,,57925
+37 Chaussee Robert Schuman Évrange,,,,37,Chaussee Robert Schuman,,57570
+37 Chaussee Robert Schuman 57570,,,,37,Chaussee Robert Schuman,Évrange,
+37 Chaussee Robert Schuman,6.193377,49.505147,,37,Chaussee Robert Schuman,,57570
+16 Allée des Hêtres Farébersviller,,,,16,Allée des Hêtres,,57450
+16 Allée des Hêtres 57450,,,,16,Allée des Hêtres,Farébersviller,
+16 Allée des Hêtres,6.886268,49.114054,,16,Allée des Hêtres,,57450
+48 Rue de la Centrale Florange,,,,48,Rue de la Centrale,,57190
+48 Rue de la Centrale 57190,,,,48,Rue de la Centrale,Florange,
+48 Rue de la Centrale,6.114303,49.320592,,48,Rue de la Centrale,,57190
+19 LES CAPUCINES Forbach,,,,19,CAPUCINES,,57600
+19 LES CAPUCINES 57600,,,,19,CAPUCINES,Forbach,
+19 LES CAPUCINES,6.886604,49.178708,,19,CAPUCINES,,57600
+17 Rue du Caveau Freyming-Merlebach,,,,17,Rue du Caveau,,57800
+17 Rue du Caveau 57800,,,,17,Rue du Caveau,Freyming-Merlebach,
+17 Rue du Caveau,6.782246,49.142567,,17,Rue du Caveau,,57800
+4BIS Rue de Civaux Gomelange,,,,4BIS,Rue de Civaux,,57220
+4BIS Rue de Civaux 57220,,,,4BIS,Rue de Civaux,Gomelange,
+4BIS Rue de Civaux,6.469572,49.241981,,4BIS,Rue de Civaux,,57220
+6 Lotissement Les Tilleuls Guessling-Hémering,,,,6,Lotissement Les Tilleuls,,57380
+6 Lotissement Les Tilleuls 57380,,,,6,Lotissement Les Tilleuls,Guessling-Hémering,
+6 Lotissement Les Tilleuls,6.656295,49.017853,,6,Lotissement Les Tilleuls,,57380
+15 Rue de Siltzheim Hambach,,,,15,Rue de Siltzheim,,57910
+15 Rue de Siltzheim 57910,,,,15,Rue de Siltzheim,Hambach,
+15 Rue de Siltzheim,7.044724,49.064107,,15,Rue de Siltzheim,,57910
+21 Rue Pierre Mendès-France Hayange,,,,21,Rue Pierre Mendès-France,,57700
+21 Rue Pierre Mendès-France 57700,,,,21,Rue Pierre Mendès-France,Hayange,
+21 Rue Pierre Mendès-France,6.074455,49.331884,,21,Rue Pierre Mendès-France,,57700
+29 Rue de la Gendarmerie Hettange-Grande,,,,29,Rue de la Gendarmerie,,57330
+29 Rue de la Gendarmerie 57330,,,,29,Rue de la Gendarmerie,Hettange-Grande,
+29 Rue de la Gendarmerie,6.158461,49.400168,,29,Rue de la Gendarmerie,,57330
+70 Rue de Carling L'Hôpital,,,,70,Rue de Carling,,57490
+70 Rue de Carling 57490,,,,70,Rue de Carling,L'Hôpital,
+70 Rue de Carling,6.721758,49.161782,,70,Rue de Carling,,57490
+20 Rue de Cantevanne Kanfen,,,,20,Rue de Cantevanne,,57330
+20 Rue de Cantevanne 57330,,,,20,Rue de Cantevanne,Kanfen,
+20 Rue de Cantevanne,6.114941,49.436686,,20,Rue de Cantevanne,,57330
+13 Rue des Cyclamens Langatte,,,,13,Rue des Cyclamens,,57400
+13 Rue des Cyclamens 57400,,,,13,Rue des Cyclamens,Langatte,
+13 Rue des Cyclamens,6.952854,48.764246,,13,Rue des Cyclamens,,57400
+89  Longeville-lès-Metz,,,,89,,,57050
+89  57050,,,,89,,Longeville-lès-Metz,
+89,6.152375,49.115174,,89,,,57050
+19 Rue Jacqueline Auriol Maizières-lès-Metz,,,,19,Rue Jacqueline Auriol,,57280
+19 Rue Jacqueline Auriol 57280,,,,19,Rue Jacqueline Auriol,Maizières-lès-Metz,
+19 Rue Jacqueline Auriol,6.154913,49.216282,,19,Rue Jacqueline Auriol,,57280
+99 Rue de la République Marange-Silvange,,,,99,Rue de la République,,57535
+99 Rue de la République 57535,,,,99,Rue de la République,Marange-Silvange,
+99 Rue de la République,6.102787,49.210191,,99,Rue de la République,,57535
+29  Marly,,,,29,,,57155
+29  57155,,,,29,,Marly,
+29,6.149609,49.077384,,29,,,57155
+31  Metz,,,,31,,,57000
+31  57000,,,,31,,Metz,
+31,6.181387,49.118684,,31,,,57000
+17B  Metz,,,,17B,,,57000
+17B  57000,,,,17B,,Metz,
+17B,6.207192,49.121177,,17B,,,57000
+6 Place Saint-Roch Metz,,,,6,Place Saint-Roch,,57000
+6 Place Saint-Roch 57000,,,,6,Place Saint-Roch,Metz,
+6 Place Saint-Roch,6.184833,49.078058,,6,Place Saint-Roch,,57000
+39 Rue de l'Église Monneren,,,,39,Rue de l'Église,,57920
+39 Rue de l'Église 57920,,,,39,Rue de l'Église,Monneren,
+39 Rue de l'Église,6.414402,49.345336,,39,Rue de l'Église,,57920
+57  Montigny-lès-Metz,,,,57,,,57950
+57  57950,,,,57,,Montigny-lès-Metz,
+57,6.155775,49.086756,,57,,,57950
+56 Rue du Bois Moyeuvre-Grande,,,,56,Rue du Bois,,57250
+56 Rue du Bois 57250,,,,56,Rue du Bois,Moyeuvre-Grande,
+56 Rue du Bois,6.049844,49.261298,,56,Rue du Bois,,57250
+36 Rue des Vosges Niderviller,,,,36,Rue des Vosges,,57565
+36 Rue des Vosges 57565,,,,36,Rue des Vosges,Niderviller,
+36 Rue des Vosges,7.110308,48.70941,,36,Rue des Vosges,,57565
+9 Rue du Maraicher Ogy,,,,9,Rue du Maraicher,,57530
+9 Rue du Maraicher 57530,,,,9,Rue du Maraicher,Ogy,
+9 Rue du Maraicher,6.313492,49.105433,,9,Rue du Maraicher,,57530
+28 Rue Roger Cadel Petite-Rosselle,,,,28,Rue Roger Cadel,,57540
+28 Rue Roger Cadel 57540,,,,28,Rue Roger Cadel,Petite-Rosselle,
+28 Rue Roger Cadel,6.867734,49.215023,,28,Rue Roger Cadel,,57540
+2 Impasse Prairial Porcelette,,,,2,Impasse Prairial,,57890
+2 Impasse Prairial 57890,,,,2,Impasse Prairial,Porcelette,
+2 Impasse Prairial,6.652172,49.160997,,2,Impasse Prairial,,57890
+12 Rue des Saules Réding,,,,12,Rue des Saules,,57445
+12 Rue des Saules 57445,,,,12,Rue des Saules,Réding,
+12 Rue des Saules,7.110521,48.750958,,12,Rue des Saules,,57445
+13 Rue de la Paix Rohrbach-lès-Bitche,,,,13,Rue de la Paix,,57410
+13 Rue de la Paix 57410,,,,13,Rue de la Paix,Rohrbach-lès-Bitche,
+13 Rue de la Paix,7.268006,49.043447,,13,Rue de la Paix,,57410
+3 Rue Sainte-Anne Roussy-le-Village,,,,3,Rue Sainte-Anne,,57330
+3 Rue Sainte-Anne 57330,,,,3,Rue Sainte-Anne,Roussy-le-Village,
+3 Rue Sainte-Anne,6.1725,49.457716,,3,Rue Sainte-Anne,,57330
+2 Rue des Roitelets Saint-Avold,,,,2,Rue des Roitelets,,57500
+2 Rue des Roitelets 57500,,,,2,Rue des Roitelets,Saint-Avold,
+2 Rue des Roitelets,6.706979,49.132441,,2,Rue des Roitelets,,57500
+2  Saint-Privat-la-Montagne,,,,2,,,57855
+2  57855,,,,2,,Saint-Privat-la-Montagne,
+2,6.032949,49.186655,,2,,,57855
+11 Rue du Stade Sarrebourg,,,,11,Rue du Stade,,57400
+11 Rue du Stade 57400,,,,11,Rue du Stade,Sarrebourg,
+11 Rue du Stade,7.048087,48.727653,,11,Rue du Stade,,57400
+6 Rue Saint-Jean Neunkirch Sarreguemines,,,,6,Rue Saint-Jean Neunkirch,,57200
+6 Rue Saint-Jean Neunkirch 57200,,,,6,Rue Saint-Jean Neunkirch,Sarreguemines,
+6 Rue Saint-Jean Neunkirch,7.083101,49.123785,,6,Rue Saint-Jean Neunkirch,,57200
+39 Rue de Verdun Semécourt,,,,39,Rue de Verdun,,57280
+39 Rue de Verdun 57280,,,,39,Rue de Verdun,Semécourt,
+39 Rue de Verdun,6.131372,49.194569,,39,Rue de Verdun,,57280
+22 Rue Auguste Delaune Talange,,,,22,Rue Auguste Delaune,,57525
+22 Rue Auguste Delaune 57525,,,,22,Rue Auguste Delaune,Talange,
+22 Rue Auguste Delaune,6.178087,49.237491,,22,Rue Auguste Delaune,,57525
+22 Rue de l'Agriculture Thionville,,,,22,Rue de l'Agriculture,,57100
+22 Rue de l'Agriculture 57100,,,,22,Rue de l'Agriculture,Thionville,
+22 Rue de l'Agriculture,6.152628,49.367933,,22,Rue de l'Agriculture,,57100
+13 Rue de Nancy Thionville,,,,13,Rue de Nancy,,57100
+13 Rue de Nancy 57100,,,,13,Rue de Nancy,Thionville,
+13 Rue de Nancy,6.156236,49.355361,,13,Rue de Nancy,,57100
+7BIS Rue des Jardins Uckange,,,,7BIS,Rue des Jardins,,57270
+7BIS Rue des Jardins 57270,,,,7BIS,Rue des Jardins,Uckange,
+7BIS Rue des Jardins,6.149693,49.304631,,7BIS,Rue des Jardins,,57270
+9  Vernéville,,,,9,,,57130
+9  57130,,,,9,,Vernéville,
+9,6.00132,49.146568,,9,,,57130
+5 Rue du Rebberg Volmunster,,,,5,Rue du Rebberg,,57720
+5 Rue du Rebberg 57720,,,,5,Rue du Rebberg,Volmunster,
+5 Rue du Rebberg,7.3508,49.123287,,5,Rue du Rebberg,,57720
+17 Rue Hubert Colinet Woippy,,,,17,Rue Hubert Colinet,,57140
+17 Rue Hubert Colinet 57140,,,,17,Rue Hubert Colinet,Woippy,
+17 Rue Hubert Colinet,6.16278,49.14548,,17,Rue Hubert Colinet,,57140
+72 Route de Thionville Yutz,,,,72,Route de Thionville,,57970
+72 Route de Thionville 57970,,,,72,Route de Thionville,Yutz,
+72 Route de Thionville,6.177599,49.348295,,72,Route de Thionville,,57970
+338 Rue de la Passée La Baffe,,,,338,Rue de la Passée,,88460
+338 Rue de la Passée 88460,,,,338,Rue de la Passée,La Baffe,
+338 Rue de la Passée,6.573556,48.163578,,338,Rue de la Passée,,88460
+16 Chemin des Champis La Bresse,,,,16,Chemin des Champis,,88250
+16 Chemin des Champis 88250,,,,16,Chemin des Champis,La Bresse,
+16 Chemin des Champis,6.914273,48.024788,,16,Chemin des Champis,,88250
+1 Rue Abbé Bertrand Certilleux,,,,1,Rue Abbé Bertrand,,88300
+1 Rue Abbé Bertrand 88300,,,,1,Rue Abbé Bertrand,Certilleux,
+1 Rue Abbé Bertrand,5.727775,48.312059,,1,Rue Abbé Bertrand,,88300
+6 Za La Moise Châtenois,,,,6,Za La Moise,,88170
+6 Za La Moise 88170,,,,6,Za La Moise,Châtenois,
+6 Za La Moise,5.838397,48.307565,,6,Za La Moise,,88170
+17 Route du Droit Cornimont,,,,17,Route du Droit,,88310
+17 Route du Droit 88310,,,,17,Route du Droit,Cornimont,
+17 Route du Droit,6.828505,47.968317,,17,Route du Droit,,88310
+79 Rue de Jeuxey Dogneville,,,,79,Rue de Jeuxey,,88000
+79 Rue de Jeuxey 88000,,,,79,Rue de Jeuxey,Dogneville,
+79 Rue de Jeuxey,6.460782,48.221337,,79,Rue de Jeuxey,,88000
+25 Rue Antoine Réveillé Épinal,,,,25,Rue Antoine Réveillé,,88000
+25 Rue Antoine Réveillé 88000,,,,25,Rue Antoine Réveillé,Épinal,
+25 Rue Antoine Réveillé,6.452649,48.184187,,25,Rue Antoine Réveillé,,88000
+40 Rue de Nancy Épinal,,,,40,Rue de Nancy,,88000
+40 Rue de Nancy 88000,,,,40,Rue de Nancy,Épinal,
+40 Rue de Nancy,6.441918,48.183545,,40,Rue de Nancy,,88000
+13 Route de la Sure Ferdrupt,,,,13,Route de la Sure,,88360
+13 Route de la Sure 88360,,,,13,Route de la Sure,Ferdrupt,
+13 Route de la Sure,6.731762,47.903679,,13,Route de la Sure,,88360
+341 Allée des Marronniers Frizon,,,,341,Allée des Marronniers,,88440
+341 Allée des Marronniers 88440,,,,341,Allée des Marronniers,Frizon,
+341 Allée des Marronniers,6.364601,48.288761,,341,Allée des Marronniers,,88440
+1253 Rue de Xertigny Girancourt,,,,1253,Rue de Xertigny,,88390
+1253 Rue de Xertigny 88390,,,,1253,Rue de Xertigny,Girancourt,
+1253 Rue de Xertigny,6.316916,48.154983,,1253,Rue de Xertigny,,88390
+22 Rue du Pré Genêt Granges-sur-Vologne,,,,22,Rue du Pré Genêt,,88640
+22 Rue du Pré Genêt 88640,,,,22,Rue du Pré Genêt,,88640
+22 Rue du Pré Genêt,6.796522,48.148165,,22,Rue du Pré Genêt,,88640
+2 Rue du Château Jeanménil,,,,2,Rue du Château,,88700
+2 Rue du Château 88700,,,,2,Rue du Château,Jeanménil,
+2 Rue du Château,6.6913,48.335693,,2,Rue du Château,,88700
+395 Route de Bénifosse Mandray,,,,395,Route de Bénifosse,,88650
+395 Route de Bénifosse 88650,,,,395,Route de Bénifosse,Mandray,
+395 Route de Bénifosse,6.990715,48.218958,,395,Route de Bénifosse,,88650
+730 Rue du Mervaux Monthureux-sur-Saône,,,,730,Rue du Mervaux,,88410
+730 Rue du Mervaux 88410,,,,730,Rue du Mervaux,Monthureux-sur-Saône,
+730 Rue du Mervaux,5.94171,48.014821,,730,Rue du Mervaux,,88410
+18 Rue de Bouillemont La Neuveville-devant-Lépanges,,,,18,Rue de Bouillemont,,88600
+18 Rue de Bouillemont 88600,,,,18,Rue de Bouillemont,La Neuveville-devant-Lépanges,
+18 Rue de Bouillemont,6.668623,48.161122,,18,Rue de Bouillemont,,88600
+57 Rue de la Mairie Les Poulières,,,,57,Rue de la Mairie,,88600
+57 Rue de la Mairie 88600,,,,57,Rue de la Mairie,Les Poulières,
+57 Rue de la Mairie,6.797999,48.202256,,57,Rue de la Mairie,,88600
+13 Rue de Belle Vue Raon-l'Étape,,,,13,Rue de Belle Vue,,88110
+13 Rue de Belle Vue 88110,,,,13,Rue de Belle Vue,Raon-l'Étape,
+13 Rue de Belle Vue,6.85303,48.405012,,13,Rue de Belle Vue,,88110
+8BIS Rue Suchet Remiremont,,,,8BIS,Rue Suchet,,88200
+8BIS Rue Suchet 88200,,,,8BIS,Rue Suchet,Remiremont,
+8BIS Rue Suchet,6.58752,48.018065,,8BIS,Rue Suchet,,88200
+6 Chemin de la Ruelle Saint-Benoît-la-Chipotte,,,,6,Chemin de la Ruelle,,88700
+6 Chemin de la Ruelle 88700,,,,6,Chemin de la Ruelle,Saint-Benoît-la-Chipotte,
+6 Chemin de la Ruelle,6.734459,48.35527,,6,Chemin de la Ruelle,,88700
+26 Rue Rovel Saint-Dié-des-Vosges,,,,26,Rue Rovel,,88100
+26 Rue Rovel 88100,,,,26,Rue Rovel,Saint-Dié-des-Vosges,
+26 Rue Rovel,6.944663,48.292217,,26,Rue Rovel,,88100
+212 Rue du Bousson Saint-Michel-sur-Meurthe,,,,212,Rue du Bousson,,88470
+212 Rue du Bousson 88470,,,,212,Rue du Bousson,Saint-Michel-sur-Meurthe,
+212 Rue du Bousson,6.884638,48.309582,,212,Rue du Bousson,,88470
+26BIS Rue Grande Rue Saulxures-lès-Bulgnéville,,,,26BIS,Rue Grande Rue,,88140
+26BIS Rue Grande Rue 88140,,,,26BIS,Rue Grande Rue,Saulxures-lès-Bulgnéville,
+26BIS Rue Grande Rue,5.807235,48.199855,,26BIS,Rue Grande Rue,,88140
+7 Chemin des Épines Tendon,,,,7,Chemin des Épines,,88460
+7 Chemin des Épines 88460,,,,7,Chemin des Épines,Tendon,
+7 Chemin des Épines,6.676193,48.119403,,7,Chemin des Épines,,88460
+153 Rue du Docteur Guegniot Tignécourt,,,,153,Rue du Docteur Guegniot,,88320
+153 Rue du Docteur Guegniot 88320,,,,153,Rue du Docteur Guegniot,Tignécourt,
+153 Rue du Docteur Guegniot,5.892333,48.04213,,153,Rue du Docteur Guegniot,,88320
+4 Rue du Stade Le Val-d'Ajol,,,,4,Rue du Stade,,88340
+4 Rue du Stade 88340,,,,4,Rue du Stade,Le Val-d'Ajol,
+4 Rue du Stade,6.480783,47.926149,,4,Rue du Stade,,88340
+68 Rue de Nancy Vittel,,,,68,Rue de Nancy,,88800
+68 Rue de Nancy 88800,,,,68,Rue de Nancy,Vittel,
+68 Rue de Nancy,5.943299,48.198982,,68,Rue de Nancy,,88800

--- a/geocoder_tester/world/france/midipyrenees/test_addresses.csv
+++ b/geocoder_tester/world/france/midipyrenees/test_addresses.csv
@@ -1,400 +1,400 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-20 Rue du Béal Mirepoix,,,,20 Rue du Béal,,,,09500
-20 Rue du Béal 09500,,,,20 Rue du Béal,,,Mirepoix,
-20 Rue du Béal,1.875275,43.090606,,20 Rue du Béal,,,,09500
-88 Rue du Maréchal Clauzel Pamiers,,,,88 Rue du Maréchal Clauzel,,,,09100
-88 Rue du Maréchal Clauzel 09100,,,,88 Rue du Maréchal Clauzel,,,Pamiers,
-88 Rue du Maréchal Clauzel,1.615528,43.114813,,88 Rue du Maréchal Clauzel,,,,09100
-7 Avenue du Scios Saint-Paul-de-Jarrat,,,,7 Avenue du Scios,,,,09000
-7 Avenue du Scios 09000,,,,7 Avenue du Scios,,,Saint-Paul-de-Jarrat,
-7 Avenue du Scios,1.665204,42.914376,,7 Avenue du Scios,,,,09000
-22 Avenue des Pyrénées Villeneuve-du-Paréage,,,,22 Avenue des Pyrénées,,,,09100
-22 Avenue des Pyrénées 09100,,,,22 Avenue des Pyrénées,,,Villeneuve-du-Paréage,
-22 Avenue des Pyrénées,1.639625,43.148450,,22 Avenue des Pyrénées,,,,09100
-50 Rue de Marengo Baraqueville,,,,50 Rue de Marengo,,,,12160
-50 Rue de Marengo 12160,,,,50 Rue de Marengo,,,Baraqueville,
-50 Rue de Marengo,2.428229,44.279599,,50 Rue de Marengo,,,,12160
-35 Avenue de Calmont Espalion,,,,35 Avenue de Calmont,,,,12500
-35 Avenue de Calmont 12500,,,,35 Avenue de Calmont,,,Espalion,
-35 Avenue de Calmont,2.760378,44.517126,,35 Avenue de Calmont,,,,12500
-9 Rue du 8 Mai Livinhac-le-Haut,,,,9 Rue du 8 Mai,,,,12300
-9 Rue du 8 Mai 12300,,,,9 Rue du 8 Mai,,,Livinhac-le-Haut,
-9 Rue du 8 Mai,2.234604,44.591162,,9 Rue du 8 Mai,,,,12300
-350 Route de Creissels Millau,,,,350 Route de Creissels,,,,12100
-350 Route de Creissels 12100,,,,350 Route de Creissels,,,Millau,
-350 Route de Creissels,3.072684,44.090922,,350 Route de Creissels,,,,12100
-17 Avenue de la Castagnal Le Monastère,,,,17 Avenue de la Castagnal,,,,12000
-17 Avenue de la Castagnal 12000,,,,17 Avenue de la Castagnal,,,Le Monastère,
-17 Avenue de la Castagnal,2.570765,44.338704,,17 Avenue de la Castagnal,,,,12000
-19 Rue du Claux Onet-le-Château,,,,19 Rue du Claux,,,,12850
-19 Rue du Claux 12850,,,,19 Rue du Claux,,,Onet-le-Château,
-19 Rue du Claux,2.582102,44.368109,,19 Rue du Claux,,,,12850
-17 Place du Bourg Rodez,,,,17 Place du Bourg,,,,12000
-17 Place du Bourg 12000,,,,17 Place du Bourg,,,Rodez,
-17 Place du Bourg,2.576182,44.348581,,17 Place du Bourg,,,,12000
-673 Route de Couat Saint-Affrique,,,,673 Route de Couat,,,,12400
-673 Route de Couat 12400,,,,673 Route de Couat,,,Saint-Affrique,
-673 Route de Couat,2.891318,43.943398,,673 Route de Couat,,,,12400
-45 Avenue de Saint-Affrique Saint-Sernin-sur-Rance,,,,45 Avenue de Saint-Affrique,,,,12380
-45 Avenue de Saint-Affrique 12380,,,,45 Avenue de Saint-Affrique,,,Saint-Sernin-sur-Rance,
-45 Avenue de Saint-Affrique,2.612519,43.883029,,45 Avenue de Saint-Affrique,,,,12380
-2 Rue des Fours de la Ville Villefranche-de-Rouergue,,,,2 Rue des Fours de la Ville,,,,12200
-2 Rue des Fours de la Ville 12200,,,,2 Rue des Fours de la Ville,,,Villefranche-de-Rouergue,
-2 Rue des Fours de la Ville,2.036606,44.353242,,2 Rue des Fours de la Ville,,,,12200
-419 Chemin de Periac Aussonne,,,,419 Chemin de Periac,,,,31840
-419 Chemin de Periac 31840,,,,419 Chemin de Periac,,,Aussonne,
-419 Chemin de Periac,1.333443,43.672490,,419 Chemin de Periac,,,,31840
-4 Impasse du Champ de Mars Bagnères-de-Luchon,,,,4 Impasse du Champ de Mars,,,,31110
-4 Impasse du Champ de Mars 31110,,,,4 Impasse du Champ de Mars,,,Bagnères-de-Luchon,
-4 Impasse du Champ de Mars,0.588995,42.791852,,4 Impasse du Champ de Mars,,,,31110
-14 Résidence des Pyrénées Balma,,,,14 Résidence des Pyrénées,,,,31130
-14 Résidence des Pyrénées 31130,,,,14 Résidence des Pyrénées,,,Balma,
-14 Résidence des Pyrénées,1.493482,43.611426,,14 Résidence des Pyrénées,,,,31130
-146 Chemin de la Guiraudine Bessières,,,,146 Chemin de la Guiraudine,,,,31660
-146 Chemin de la Guiraudine 31660,,,,146 Chemin de la Guiraudine,,,Bessières,
-146 Chemin de la Guiraudine,1.578371,43.806913,,146 Chemin de la Guiraudine,,,,31660
-4 Impasse Saint-Jacques Blagnac,,,,4 Impasse Saint-Jacques,,,,31700
-4 Impasse Saint-Jacques 31700,,,,4 Impasse Saint-Jacques,,,Blagnac,
-4 Impasse Saint-Jacques,1.399946,43.634536,,4 Impasse Saint-Jacques,,,,31700
-25 Avenue du Bruguet Bruguières,,,,25 Avenue du Bruguet,,,,31150
-25 Avenue du Bruguet 31150,,,,25 Avenue du Bruguet,,,Bruguières,
-25 Avenue du Bruguet,1.414604,43.721670,,25 Avenue du Bruguet,,,,31150
-34 Rue Gambetta Carbonne,,,,34 Rue Gambetta,,,,31390
-34 Rue Gambetta 31390,,,,34 Rue Gambetta,,,Carbonne,
-34 Rue Gambetta,1.226088,43.295591,,34 Rue Gambetta,,,,31390
-15 Rue de la Barthe Castelginest,,,,15 Rue de la Barthe,,,,31780
-15 Rue de la Barthe 31780,,,,15 Rue de la Barthe,,,Castelginest,
-15 Rue de la Barthe,1.431792,43.697429,,15 Rue de la Barthe,,,,31780
-45 Grande Rue Castelnau-d'Estrétefonds,,,,45 Grande Rue,,,,31620
-45 Grande Rue 31620,,,,45 Grande Rue,,,Castelnau-d'Estrétefonds,
-45 Grande Rue,1.359837,43.781683,,45 Grande Rue,,,,31620
-12 Allée de l'Ariège Colomiers,,,,12 Allée de l'Ariège,,,,31770
-12 Allée de l'Ariège 31770,,,,12 Allée de l'Ariège,,,Colomiers,
-12 Allée de l'Ariège,1.347761,43.606676,,12 Allée de l'Ariège,,,,31770
-42 Allée de Naurouze Colomiers,,,,42 Allée de Naurouze,,,,31770
-42 Allée de Naurouze 31770,,,,42 Allée de Naurouze,,,Colomiers,
-42 Allée de Naurouze,1.348253,43.609151,,42 Allée de Naurouze,,,,31770
-16 Rue des Biches Cugnaux,,,,16 Rue des Biches,,,,31270
-16 Rue des Biches 31270,,,,16 Rue des Biches,,,Cugnaux,
-16 Rue des Biches,1.342217,43.539630,,16 Rue des Biches,,,,31270
-10 Rue Salvador Dali Daux,,,,10 Rue Salvador Dali,,,,31700
-10 Rue Salvador Dali 31700,,,,10 Rue Salvador Dali,,,Daux,
-10 Rue Salvador Dali,1.267223,43.691699,,10 Rue Salvador Dali,,,,31700
-10 Rue de la Tour de Pise Escalquens,,,,10 Rue de la Tour de Pise,,,,31750
-10 Rue de la Tour de Pise 31750,,,,10 Rue de la Tour de Pise,,,Escalquens,
-10 Rue de la Tour de Pise,1.563137,43.519955,,10 Rue de la Tour de Pise,,,,31750
-23 Rue des Hirondelles Fonsorbes,,,,23 Rue des Hirondelles,,,,31470
-23 Rue des Hirondelles 31470,,,,23 Rue des Hirondelles,,,Fonsorbes,
-23 Rue des Hirondelles,1.235674,43.535364,,23 Rue des Hirondelles,,,,31470
-5 Impasse de Saumaté Fronton,,,,5 Impasse de Saumaté,,,,31620
-5 Impasse de Saumaté 31620,,,,5 Impasse de Saumaté,,,Fronton,
-5 Impasse de Saumaté,1.369493,43.826764,,5 Impasse de Saumaté,,,,31620
-41 Rue de Vignabère Gourdan-Polignan,,,,41 Rue de Vignabère,,,,31210
-41 Rue de Vignabère 31210,,,,41 Rue de Vignabère,,,Gourdan-Polignan,
-41 Rue de Vignabère,0.582833,43.074152,,41 Rue de Vignabère,,,,31210
-11 Rue de Cier Huos,,,,11 Rue de Cier,,,,31210
-11 Rue de Cier 31210,,,,11 Rue de Cier,,,Huos,
-11 Rue de Cier,0.598731,43.073675,,11 Rue de Cier,,,,31210
-10 Passage Jean Dugaros Labastidette,,,,10 Passage Jean Dugaros,,,,31600
-10 Passage Jean Dugaros 31600,,,,10 Passage Jean Dugaros,,,Labastidette,
-10 Passage Jean Dugaros,1.247602,43.458682,,10 Passage Jean Dugaros,,,,31600
-18 Chemin de Triguebéoure Lapeyrouse-Fossat,,,,18 Chemin de Triguebéoure,,,,31180
-18 Chemin de Triguebéoure 31180,,,,18 Chemin de Triguebéoure,,,Lapeyrouse-Fossat,
-18 Chemin de Triguebéoure,1.523795,43.695258,,18 Chemin de Triguebéoure,,,,31180
-5 Impasse de la Cibelle Léguevin,,,,5 Impasse de la Cibelle,,,,31490
-5 Impasse de la Cibelle 31490,,,,5 Impasse de la Cibelle,,,Léguevin,
-5 Impasse de la Cibelle,1.229893,43.594228,,5 Impasse de la Cibelle,,,,31490
-17 Chemin de la Peyonne Longages,,,,17 Chemin de la Peyonne,,,,31410
-17 Chemin de la Peyonne 31410,,,,17 Chemin de la Peyonne,,,Longages,
-17 Chemin de la Peyonne,1.242855,43.351932,,17 Chemin de la Peyonne,,,,31410
-469 Route de Larra Merville,,,,469 Route de Larra,,,,31330
-469 Route de Larra 31330,,,,469 Route de Larra,,,Merville,
-469 Route de Larra,1.288913,43.719507,,469 Route de Larra,,,,31330
-2 Place Rhin et Danube Montastruc-la-Conseillère,,,,2 Place Rhin et Danube,,,,31380
-2 Place Rhin et Danube 31380,,,,2 Place Rhin et Danube,,,Montastruc-la-Conseillère,
-2 Place Rhin et Danube,1.584040,43.719011,,2 Place Rhin et Danube,,,,31380
-20 Rue du Salat Montrabé,,,,20 Rue du Salat,,,,31850
-20 Rue du Salat 31850,,,,20 Rue du Salat,,,Montrabé,
-20 Rue du Salat,1.520818,43.646065,,20 Rue du Salat,,,,31850
-8BIS Place Layrisson Muret,,,,8BIS Place Layrisson,,,,31600
-8BIS Place Layrisson 31600,,,,8BIS Place Layrisson,,,Muret,
-8BIS Place Layrisson,1.323743,43.460410,,8BIS Place Layrisson,,,,31600
-86 Route de Toulouse Noé,,,,86 Route de Toulouse,,,,31410
-86 Route de Toulouse 31410,,,,86 Route de Toulouse,,,Noé,
-86 Route de Toulouse,1.272693,43.351958,,86 Route de Toulouse,,,,31410
-2 Allée des Lys Pibrac,,,,2 Allée des Lys,,,,31820
-2 Allée des Lys 31820,,,,2 Allée des Lys,,,Pibrac,
-2 Allée des Lys,1.287443,43.614018,,2 Allée des Lys,,,,31820
-67 Avenue de la Casse Plaisance-du-Touch,,,,67 Avenue de la Casse,,,,31830
-67 Avenue de la Casse 31830,,,,67 Avenue de la Casse,,,Plaisance-du-Touch,
-67 Avenue de la Casse,1.283571,43.558159,,67 Avenue de la Casse,,,,31830
-6 Impasse de l'Autan Pompertuzat,,,,6 Impasse de l'Autan,,,,31450
-6 Impasse de l'Autan 31450,,,,6 Impasse de l'Autan,,,Pompertuzat,
-6 Impasse de l'Autan,1.525537,43.492975,,6 Impasse de l'Autan,,,,31450
-29 Allée Michel-Ange Quint-Fonsegrives,,,,29 Allée Michel-Ange,,,,31130
-29 Allée Michel-Ange 31130,,,,29 Allée Michel-Ange,,,Quint-Fonsegrives,
-29 Allée Michel-Ange,1.523721,43.581038,,29 Allée Michel-Ange,,,,31130
-19 Rue Edith Piaf Revel,,,,19 Rue Edith Piaf,,,,31250
-19 Rue Edith Piaf 31250,,,,19 Rue Edith Piaf,,,Revel,
-19 Rue Edith Piaf,1.993396,43.467229,,19 Rue Edith Piaf,,,,31250
-4 Rue du Pouech Roquefort-sur-Garonne,,,,4 Rue du Pouech,,,,31360
-4 Rue du Pouech 31360,,,,4 Rue du Pouech,,,Roquefort-sur-Garonne,
-4 Rue du Pouech,0.975269,43.164711,,4 Rue du Pouech,,,,31360
-36 Avenue Salvador Allende Saint-Alban,,,,36 Avenue Salvador Allende,,,,31140
-36 Avenue Salvador Allende 31140,,,,36 Avenue Salvador Allende,,,Saint-Alban,
-36 Avenue Salvador Allende,1.408942,43.686599,,36 Avenue Salvador Allende,,,,31140
-73 Rue de la République Saint-Gaudens,,,,73 Rue de la République,,,,31800
-73 Rue de la République 31800,,,,73 Rue de la République,,,Saint-Gaudens,
-73 Rue de la République,0.725995,43.108519,,73 Rue de la République,,,,31800
-1 Passage des Romarins Saint-Jean,,,,1 Passage des Romarins,,,,31240
-1 Passage des Romarins 31240,,,,1 Passage des Romarins,,,Saint-Jean,
-1 Passage des Romarins,1.500280,43.672879,,1 Passage des Romarins,,,,31240
-10 Place Bernard Sarrieu Saint-Mamet,,,,10 Place Bernard Sarrieu,,,,31110
-10 Place Bernard Sarrieu 31110,,,,10 Place Bernard Sarrieu,,,Saint-Mamet,
-10 Place Bernard Sarrieu,0.604430,42.781914,,10 Place Bernard Sarrieu,,,,31110
-2 Route de Toulouse Saint-Pierre-de-Lages,,,,2 Route de Toulouse,,,,31570
-2 Route de Toulouse 31570,,,,2 Route de Toulouse,,,Saint-Pierre-de-Lages,
-2 Route de Toulouse,1.626416,43.569242,,2 Route de Toulouse,,,,31570
-3BIS Chemin de Pins Saubens,,,,3BIS Chemin de Pins,,,,31600
-3BIS Chemin de Pins 31600,,,,3BIS Chemin de Pins,,,Saubens,
-3BIS Chemin de Pins,1.353752,43.477160,,3BIS Chemin de Pins,,,,31600
-39 Impasse Alexis de Tocqueville Toulouse,,,,39 Impasse Alexis de Tocqueville,,,,31998
-39 Impasse Alexis de Tocqueville 31998,,,,39 Impasse Alexis de Tocqueville,,,Toulouse,
-39 Impasse Alexis de Tocqueville,1.456219,43.649723,,39 Impasse Alexis de Tocqueville,,,,31998
-7 Rue Émile Barry Toulouse,,,,7 Rue Émile Barry,,,,31998
-7 Rue Émile Barry 31998,,,,7 Rue Émile Barry,,,Toulouse,
-7 Rue Émile Barry,1.471187,43.582890,,7 Rue Émile Barry,,,,31998
-78BIS Chemin des Capelles Toulouse,,,,78BIS Chemin des Capelles,,,,31998
-78BIS Chemin des Capelles 31998,,,,78BIS Chemin des Capelles,,,Toulouse,
-78BIS Chemin des Capelles,1.386358,43.603484,,78BIS Chemin des Capelles,,,,31998
-15 Rue de Coulmiers Toulouse,,,,15 Rue de Coulmiers,,,,31998
-15 Rue de Coulmiers 31998,,,,15 Rue de Coulmiers,,,Toulouse,
-15 Rue de Coulmiers,1.442824,43.612759,,15 Rue de Coulmiers,,,,31998
-19 Rue Ernest Feydeau Toulouse,,,,19 Rue Ernest Feydeau,,,,31998
-19 Rue Ernest Feydeau 31998,,,,19 Rue Ernest Feydeau,,,Toulouse,
-19 Rue Ernest Feydeau,1.470452,43.626609,,19 Rue Ernest Feydeau,,,,31998
-311B Avenue de Fronton Toulouse,,,,311B Avenue de Fronton,,,,31998
-311B Avenue de Fronton 31998,,,,311B Avenue de Fronton,,,Toulouse,
-311B Avenue de Fronton,1.431788,43.654267,,311B Avenue de Fronton,,,,31998
-8B Avenue de l'Hers Toulouse,,,,8B Avenue de l'Hers,,,,31998
-8B Avenue de l'Hers 31998,,,,8B Avenue de l'Hers,,,Toulouse,
-8B Avenue de l'Hers,1.478765,43.613088,,8B Avenue de l'Hers,,,,31998
-39 Rue Jules Clarétie Toulouse,,,,39 Rue Jules Clarétie,,,,31998
-39 Rue Jules Clarétie 31998,,,,39 Rue Jules Clarétie,,,Toulouse,
-39 Rue Jules Clarétie,1.465831,43.587717,,39 Rue Jules Clarétie,,,,31998
-3 Avenue Louis Blériot Toulouse,,,,3 Avenue Louis Blériot,,,,31998
-3 Avenue Louis Blériot 31998,,,,3 Avenue Louis Blériot,,,Toulouse,
-3 Avenue Louis Blériot,1.463928,43.600237,,3 Avenue Louis Blériot,,,,31998
-5 Rue Mireille Toulouse,,,,5 Rue Mireille,,,,31998
-5 Rue Mireille 31998,,,,5 Rue Mireille,,,Toulouse,
-5 Rue Mireille,1.475913,43.586157,,5 Rue Mireille,,,,31998
-27 Chemin de la Pélude Toulouse,,,,27 Chemin de la Pélude,,,,31998
-27 Chemin de la Pélude 31998,,,,27 Chemin de la Pélude,,,Toulouse,
-27 Chemin de la Pélude,1.460359,43.568729,,27 Chemin de la Pélude,,,,31998
-18 Chemin Reboul Toulouse,,,,18 Chemin Reboul,,,,31998
-18 Chemin Reboul 31998,,,,18 Chemin Reboul,,,Toulouse,
-18 Chemin Reboul,1.375817,43.582008,,18 Chemin Reboul,,,,31998
-42 Rue Saint-Thomas d'Aquin Toulouse,,,,42 Rue Saint-Thomas d'Aquin,,,,31998
-42 Rue Saint-Thomas d'Aquin 31998,,,,42 Rue Saint-Thomas d'Aquin,,,Toulouse,
-42 Rue Saint-Thomas d'Aquin,1.448863,43.580300,,42 Rue Saint-Thomas d'Aquin,,,,31998
-5 Rue des Troènes Toulouse,,,,5 Rue des Troènes,,,,31998
-5 Rue des Troènes 31998,,,,5 Rue des Troènes,,,Toulouse,
-5 Rue des Troènes,1.414155,43.613448,,5 Rue des Troènes,,,,31998
-27 Rue de la Digue Tournefeuille,,,,27 Rue de la Digue,,,,31170
-27 Rue de la Digue 31170,,,,27 Rue de la Digue,,,Tournefeuille,
-27 Rue de la Digue,1.346608,43.576890,,27 Rue de la Digue,,,,31170
-1 Rue de la Somme Tournefeuille,,,,1 Rue de la Somme,,,,31170
-1 Rue de la Somme 31170,,,,1 Rue de la Somme,,,Tournefeuille,
-1 Rue de la Somme,1.354722,43.580380,,1 Rue de la Somme,,,,31170
-315 Rue du Roitelet L'Union,,,,315 Rue du Roitelet,,,,31240
-315 Rue du Roitelet 31240,,,,315 Rue du Roitelet,,,L'Union,
-315 Rue du Roitelet,1.475561,43.664145,,315 Rue du Roitelet,,,,31240
-149A Route de Gargas Villariès,,,,149A Route de Gargas,,,,31380
-149A Route de Gargas 31380,,,,149A Route de Gargas,,,Villariès,
-149A Route de Gargas,1.481808,43.759822,,149A Route de Gargas,,,,31380
-2 Rue Stendhal Villemur-sur-Tarn,,,,2 Rue Stendhal,,,,31340
-2 Rue Stendhal 31340,,,,2 Rue Stendhal,,,Villemur-sur-Tarn,
-2 Rue Stendhal,1.494132,43.862727,,2 Rue Stendhal,,,,31340
-520 Chemin de Saint-Sèverin Larra,,,,520 Chemin de Saint-Sèverin,,,,31330
-520 Chemin de Saint-Sèverin 31330,,,,520 Chemin de Saint-Sèverin,,,Larra,
-520 Chemin de Saint-Sèverin,1.227467,43.727216,,520 Chemin de Saint-Sèverin,,,,31330
-15 Rue Montaigne Auch,,,,15 Rue Montaigne,,,,32000
-15 Rue Montaigne 32000,,,,15 Rue Montaigne,,,Auch,
-15 Rue Montaigne,0.593599,43.636495,,15 Rue Montaigne,,,,32000
-34 Rue Pierre Bazax Condom,,,,34 Rue Pierre Bazax,,,,32100
-34 Rue Pierre Bazax 32100,,,,34 Rue Pierre Bazax,,,Condom,
-34 Rue Pierre Bazax,0.370593,43.954792,,34 Rue Pierre Bazax,,,,32100
-2 Rue du Four Gimont,,,,2 Rue du Four,,,,32200
-2 Rue du Four 32200,,,,2 Rue du Four,,,Gimont,
-2 Rue du Four,0.877811,43.624691,,2 Rue du Four,,,,32200
-39 Rue des Frêres Danzas Lectoure,,,,39 Rue des Frêres Danzas,,,,32700
-39 Rue des Frêres Danzas 32700,,,,39 Rue des Frêres Danzas,,,Lectoure,
-39 Rue des Frêres Danzas,0.622142,43.932785,,39 Rue des Frêres Danzas,,,,32700
-25 Rue de la Paix Monguilhem,,,,25 Rue de la Paix,,,,32240
-25 Rue de la Paix 32240,,,,25 Rue de la Paix,,,Monguilhem,
-25 Rue de la Paix,-0.182436,43.856510,,25 Rue de la Paix,,,,32240
-8 Rue de Gascogne Samatan,,,,8 Rue de Gascogne,,,,32130
-8 Rue de Gascogne 32130,,,,8 Rue de Gascogne,,,Samatan,
-8 Rue de Gascogne,0.919386,43.491669,,8 Rue de Gascogne,,,,32130
-158 Rue de Montesquieu Cahors,,,,158 Rue de Montesquieu,,,,46000
-158 Rue de Montesquieu 46000,,,,158 Rue de Montesquieu,,,Cahors,
-158 Rue de Montesquieu,1.432391,44.456115,,158 Rue de Montesquieu,,,,46000
-2 Rue Jean Pons Figeac,,,,2 Rue Jean Pons,,,,46100
-2 Rue Jean Pons 46100,,,,2 Rue Jean Pons,,,Figeac,
-2 Rue Jean Pons,2.024248,44.611258,,2 Rue Jean Pons,,,,46100
-395 Route de Figeac Lamagdelaine,,,,395 Route de Figeac,,,,46090
-395 Route de Figeac 46090,,,,395 Route de Figeac,,,Lamagdelaine,
-395 Route de Figeac,1.489462,44.464150,,395 Route de Figeac,,,,46090
-834 Avenue Charles de Gaulle Saint-Laurent-les-Tours,,,,834 Avenue Charles de Gaulle,,,,46400
-834 Avenue Charles de Gaulle 46400,,,,834 Avenue Charles de Gaulle,,,Saint-Laurent-les-Tours,
-834 Avenue Charles de Gaulle,1.880234,44.867521,,834 Avenue Charles de Gaulle,,,,46400
-17 Rue du 11 Novembre Aureilhan,,,,17 Rue du 11 Novembre,,,,65800
-17 Rue du 11 Novembre 65800,,,,17 Rue du 11 Novembre,,,Aureilhan,
-17 Rue du 11 Novembre,0.090252,43.239205,,17 Rue du 11 Novembre,,,,65800
-13 Rue des Jonquilles Barbazan-Debat,,,,13 Rue des Jonquilles,,,,65690
-13 Rue des Jonquilles 65690,,,,13 Rue des Jonquilles,,,Barbazan-Debat,
-13 Rue des Jonquilles,0.114557,43.200972,,13 Rue des Jonquilles,,,,65690
-45 Route du Val d'Arros Cabanac,,,,45 Route du Val d'Arros,,,,65350
-45 Route du Val d'Arros 65350,,,,45 Route du Val d'Arros,,,Cabanac,
-45 Route du Val d'Arros,0.229914,43.277577,,45 Route du Val d'Arros,,,,65350
-11 Rue de l'Industrie Ibos,,,,11 Rue de l'Industrie,,,,65420
-11 Rue de l'Industrie 65420,,,,11 Rue de l'Industrie,,,Ibos,
-11 Rue de l'Industrie,-0.003152,43.234540,,11 Rue de l'Industrie,,,,65420
-591 Rue des Cités Lannemezan,,,,591 Rue des Cités,,,,65300
-591 Rue des Cités 65300,,,,591 Rue des Cités,,,Lannemezan,
-591 Rue des Cités,0.384133,43.103517,,591 Rue des Cités,,,,65300
-2A Avenue du Général Leclerc Lourdes,,,,2A Avenue du Général Leclerc,,,,65100
-2A Avenue du Général Leclerc 65100,,,,2A Avenue du Général Leclerc,,,Lourdes,
-2A Avenue du Général Leclerc,-0.045595,43.094215,,2A Avenue du Général Leclerc,,,,65100
-45 Allée Larbanés Maubourguet,,,,45 Allée Larbanés,,,,65700
-45 Allée Larbanés 65700,,,,45 Allée Larbanés,,,Maubourguet,
-45 Allée Larbanés,0.035290,43.467551,,45 Allée Larbanés,,,,65700
-9BIS Rue des Acacias Oursbelille,,,,9BIS Rue des Acacias,,,,65490
-9BIS Rue des Acacias 65490,,,,9BIS Rue des Acacias,,,Oursbelille,
-9BIS Rue des Acacias,0.063008,43.292879,,9BIS Rue des Acacias,,,,65490
-1 Rue Montalivet Sarrouilles,,,,1 Rue Montalivet,,,,65600
-1 Rue Montalivet 65600,,,,1 Rue Montalivet,,,Sarrouilles,
-1 Rue Montalivet,0.133299,43.221400,,1 Rue Montalivet,,,,65600
-3 Impasse Beaumarchais Tarbes,,,,3 Impasse Beaumarchais,,,,65000
-3 Impasse Beaumarchais 65000,,,,3 Impasse Beaumarchais,,,Tarbes,
-3 Impasse Beaumarchais,0.056451,43.238264,,3 Impasse Beaumarchais,,,,65000
-3BIS Rue Marcelin Berthelot Tarbes,,,,3BIS Rue Marcelin Berthelot,,,,65000
-3BIS Rue Marcelin Berthelot 65000,,,,3BIS Rue Marcelin Berthelot,,,Tarbes,
-3BIS Rue Marcelin Berthelot,0.086129,43.221717,,3BIS Rue Marcelin Berthelot,,,,65000
-2 Place Gambetta Vic-en-Bigorre,,,,2 Place Gambetta,,,,65500
-2 Place Gambetta 65500,,,,2 Place Gambetta,,,Vic-en-Bigorre,
-2 Place Gambetta,0.054735,43.385701,,2 Place Gambetta,,,,65500
-102 Rue Commandant Blanché Albi,,,,102 Rue Commandant Blanché,,,,81000
-102 Rue Commandant Blanché 81000,,,,102 Rue Commandant Blanché,,,Albi,
-102 Rue Commandant Blanché,2.155045,43.920900,,102 Rue Commandant Blanché,,,,81000
-17 Allée des Hortensias Albi,,,,17 Allée des Hortensias,,,,81000
-17 Allée des Hortensias 81000,,,,17 Allée des Hortensias,,,Albi,
-17 Allée des Hortensias,2.152183,43.938786,,17 Allée des Hortensias,,,,81000
-49 Chemin de Lapeyrouse Albi,,,,49 Chemin de Lapeyrouse,,,,81000
-49 Chemin de Lapeyrouse 81000,,,,49 Chemin de Lapeyrouse,,,Albi,
-49 Chemin de Lapeyrouse,2.172047,43.911883,,49 Chemin de Lapeyrouse,,,,81000
-58BIS Avenue de Lescure Arthès,,,,58BIS Avenue de Lescure,,,,81160
-58BIS Avenue de Lescure 81160,,,,58BIS Avenue de Lescure,,,Arthès,
-58BIS Avenue de Lescure,2.199924,43.954534,,58BIS Avenue de Lescure,,,,81160
-18 Rue des Cèdres Bout-du-Pont-de-Larn,,,,18 Rue des Cèdres,,,,81660
-18 Rue des Cèdres 81660,,,,18 Rue des Cèdres,,,Bout-du-Pont-de-Larn,
-18 Rue des Cèdres,2.400440,43.499636,,18 Rue des Cèdres,,,,81660
-44 Chemin de la Sarrade Cambon,,,,44 Chemin de la Sarrade,,,,81990
-44 Chemin de la Sarrade 81990,,,,44 Chemin de la Sarrade,,,Cambon,
-44 Chemin de la Sarrade,2.262183,43.919247,,44 Chemin de la Sarrade,,,,81990
-11 Rue de la Verrerie Carmaux,,,,11 Rue de la Verrerie,,,,81400
-11 Rue de la Verrerie 81400,,,,11 Rue de la Verrerie,,,Carmaux,
-11 Rue de la Verrerie,2.152068,44.051604,,11 Rue de la Verrerie,,,,81400
-108 Avenue Emilie de Villeneuve Castres,,,,108 Avenue Emilie de Villeneuve,,,,81100
-108 Avenue Emilie de Villeneuve 81100,,,,108 Avenue Emilie de Villeneuve,,,Castres,
-108 Avenue Emilie de Villeneuve,2.242110,43.597727,,108 Avenue Emilie de Villeneuve,,,,81100
-29 Rue Marceau Castres,,,,29 Rue Marceau,,,,81100
-29 Rue Marceau 81100,,,,29 Rue Marceau,,,Castres,
-29 Rue Marceau,2.234150,43.596623,,29 Rue Marceau,,,,81100
-47 Chemin de Tournemire Castres,,,,47 Chemin de Tournemire,,,,81100
-47 Chemin de Tournemire 81100,,,,47 Chemin de Tournemire,,,Castres,
-47 Chemin de Tournemire,2.282294,43.623520,,47 Chemin de Tournemire,,,,81100
-10 Impasse des Balitrands Gaillac,,,,10 Impasse des Balitrands,,,,81600
-10 Impasse des Balitrands 81600,,,,10 Impasse des Balitrands,,,Gaillac,
-10 Impasse des Balitrands,1.873140,43.898782,,10 Impasse des Balitrands,,,,81600
-3905 Chemin Toulze Gaillac,,,,3905 Chemin Toulze,,,,81600
-3905 Chemin Toulze 81600,,,,3905 Chemin Toulze,,,Gaillac,
-3905 Chemin Toulze,1.898205,43.925605,,3905 Chemin Toulze,,,,81600
-1 Passage de Saintonge Graulhet,,,,1 Passage de Saintonge,,,,81300
-1 Passage de Saintonge 81300,,,,1 Passage de Saintonge,,,Graulhet,
-1 Passage de Saintonge,1.998359,43.762835,,1 Passage de Saintonge,,,,81300
-10 Route de Vabre Lacrouzette,,,,10 Route de Vabre,,,,81210
-10 Route de Vabre 81210,,,,10 Route de Vabre,,,Lacrouzette,
-10 Route de Vabre,2.350142,43.663663,,10 Route de Vabre,,,,81210
-558 Chemin de la Rivayrolle Lavaur,,,,558 Chemin de la Rivayrolle,,,,81500
-558 Chemin de la Rivayrolle 81500,,,,558 Chemin de la Rivayrolle,,,Lavaur,
-558 Chemin de la Rivayrolle,1.765017,43.726153,,558 Chemin de la Rivayrolle,,,,81500
-12 Rue des Trincades Marssac-sur-Tarn,,,,12 Rue des Trincades,,,,81150
-12 Rue des Trincades 81150,,,,12 Rue des Trincades,,,Marssac-sur-Tarn,
-12 Rue des Trincades,2.033659,43.914421,,12 Rue des Trincades,,,,81150
-35 Rue de la Resse Mazamet,,,,35 Rue de la Resse,,,,81200
-35 Rue de la Resse 81200,,,,35 Rue de la Resse,,,Mazamet,
-35 Rue de la Resse,2.373371,43.484970,,35 Rue de la Resse,,,,81200
-8 Rue d'En Redon Pont-de-Larn,,,,8 Rue d'En Redon,,,,81660
-8 Rue d'En Redon 81660,,,,8 Rue d'En Redon,,,Pont-de-Larn,
-8 Rue d'En Redon,2.407498,43.513135,,8 Rue d'En Redon,,,,81660
-4 Résidence Les Jardins de Cantemerle Réalmont,,,,4 Résidence Les Jardins de Cantemerle,,,,81120
-4 Résidence Les Jardins de Cantemerle 81120,,,,4 Résidence Les Jardins de Cantemerle,,,Réalmont,
-4 Résidence Les Jardins de Cantemerle,2.182506,43.773593,,4 Résidence Les Jardins de Cantemerle,,,,81120
-8 Rue Gisclard Saint-Juéry,,,,8 Rue Gisclard,,,,81160
-8 Rue Gisclard 81160,,,,8 Rue Gisclard,,,Saint-Juéry,
-8 Rue Gisclard,2.207059,43.946941,,8 Rue Gisclard,,,,81160
-24 Rue de la Céramique Saint-Sulpice-la-Pointe,,,,24 Rue de la Céramique,,,,81370
-24 Rue de la Céramique 81370,,,,24 Rue de la Céramique,,,Saint-Sulpice-la-Pointe,
-24 Rue de la Céramique,1.676062,43.780721,,24 Rue de la Céramique,,,,81370
-5 Impasse des Lauriers Sorèze,,,,5 Impasse des Lauriers,,,,81540
-5 Impasse des Lauriers 81540,,,,5 Impasse des Lauriers,,,Sorèze,
-5 Impasse des Lauriers,2.061094,43.455193,,5 Impasse des Lauriers,,,,81540
-8 Chemin des Agals Viviers-lès-Montagnes,,,,8 Chemin des Agals,,,,81290
-8 Chemin des Agals 81290,,,,8 Chemin des Agals,,,Viviers-lès-Montagnes,
-8 Chemin des Agals,2.184001,43.565949,,8 Chemin des Agals,,,,81290
-1083 Route de la Bénèche Bioule,,,,1083 Route de la Bénèche,,,,82800
-1083 Route de la Bénèche 82800,,,,1083 Route de la Bénèche,,,Bioule,
-1083 Route de la Bénèche,1.555920,44.112465,,1083 Route de la Bénèche,,,,82800
-1998 Route des Fourrières Castelsarrasin,,,,1998 Route des Fourrières,,,,82100
-1998 Route des Fourrières 82100,,,,1998 Route des Fourrières,,,Castelsarrasin,
-1998 Route des Fourrières,1.152883,44.041996,,1998 Route des Fourrières,,,,82100
-2 Avenue du 8 Mai Caussade,,,,2 Avenue du 8 Mai,,,,82300
-2 Avenue du 8 Mai 82300,,,,2 Avenue du 8 Mai,,,Caussade,
-2 Avenue du 8 Mai,1.535793,44.161527,,2 Avenue du 8 Mai,,,,82300
-22 Avenue du Ramier Finhan,,,,22 Avenue du Ramier,,,,82700
-22 Avenue du Ramier 82700,,,,22 Avenue du Ramier,,,Finhan,
-22 Avenue du Ramier,1.213110,43.912290,,22 Avenue du Ramier,,,,82700
-134 Impasse Cazy Lacourt-Saint-Pierre,,,,134 Impasse Cazy,,,,82290
-134 Impasse Cazy 82290,,,,134 Impasse Cazy,,,Lacourt-Saint-Pierre,
-134 Impasse Cazy,1.279054,43.991185,,134 Impasse Cazy,,,,82290
-115 Impasse Cayssac Mirabel,,,,115 Impasse Cayssac,,,,82440
-115 Impasse Cayssac 82440,,,,115 Impasse Cayssac,,,Mirabel,
-115 Impasse Cayssac,1.397445,44.131762,,115 Impasse Cayssac,,,,82440
-13 Rue de la République Moissac,,,,13 Rue de la République,,,,82200
-13 Rue de la République 82200,,,,13 Rue de la République,,,Moissac,
-13 Rue de la République,1.084938,44.104206,,13 Rue de la République,,,,82200
-29 Rue Du Bac Montauban,,,,29 Rue Du Bac,,,,82000
-29 Rue Du Bac 82000,,,,29 Rue Du Bac,,,Montauban,
-29 Rue Du Bac,1.341756,44.019047,,29 Rue Du Bac,,,,82000
-1 Rue Edouard Manet Montauban,,,,1 Rue Edouard Manet,,,,82000
-1 Rue Edouard Manet 82000,,,,1 Rue Edouard Manet,,,Montauban,
-1 Rue Edouard Manet,1.371552,44.023216,,1 Rue Edouard Manet,,,,82000
-170 Chemin de Lapèyre Montauban,,,,170 Chemin de Lapèyre,,,,82000
-170 Chemin de Lapèyre 82000,,,,170 Chemin de Lapèyre,,,Montauban,
-170 Chemin de Lapèyre,1.320814,43.971842,,170 Chemin de Lapèyre,,,,82000
-1420 Rue de la Première Armée Montauban,,,,1420 Rue de la Première Armée,,,,82000
-1420 Rue de la Première Armée 82000,,,,1420 Rue de la Première Armée,,,Montauban,
-1420 Rue de la Première Armée,1.345754,44.004965,,1420 Rue de la Première Armée,,,,82000
-260 Chemin des Rosiers Montbeton,,,,260 Chemin des Rosiers,,,,82290
-260 Chemin des Rosiers 82290,,,,260 Chemin des Rosiers,,,Montbeton,
-260 Chemin des Rosiers,1.265919,44.014544,,260 Chemin des Rosiers,,,,82290
-21 Rue Marcelin Viguié Nègrepelisse,,,,21 Rue Marcelin Viguié,,,,82800
-21 Rue Marcelin Viguié 82800,,,,21 Rue Marcelin Viguié,,,Nègrepelisse,
-21 Rue Marcelin Viguié,1.522437,44.074839,,21 Rue Marcelin Viguié,,,,82800
-2486 Vieille Route Vieille Route de Montauban Saint-Étienne-de-Tulmont,,,,2486 Vieille Route Vieille Route de Montauban,,,,82410
-2486 Vieille Route Vieille Route de Montauban 82410,,,,2486 Vieille Route Vieille Route de Montauban,,,Saint-Étienne-de-Tulmont,
-2486 Vieille Route Vieille Route de Montauban,1.441828,44.051440,,2486 Vieille Route Vieille Route de Montauban,,,,82410
-28 Avenue Georges d'Esparbes Valence,,,,28 Avenue Georges d'Esparbes,,,,82400
-28 Avenue Georges d'Esparbes 82400,,,,28 Avenue Georges d'Esparbes,,,Valence,
-28 Avenue Georges d'Esparbes,0.897972,44.105391,,28 Avenue Georges d'Esparbes,,,,82400
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+20 Rue du Béal Mirepoix,,,,20,Rue du Béal,,9500
+20 Rue du Béal 09500,,,,20,Rue du Béal,Mirepoix,
+20 Rue du Béal,1.875275,43.090606,,20,Rue du Béal,,9500
+88 Rue du Maréchal Clauzel Pamiers,,,,88,Rue du Maréchal Clauzel,,9100
+88 Rue du Maréchal Clauzel 09100,,,,88,Rue du Maréchal Clauzel,Pamiers,
+88 Rue du Maréchal Clauzel,1.615528,43.114813,,88,Rue du Maréchal Clauzel,,9100
+7 Avenue du Scios Saint-Paul-de-Jarrat,,,,7,Avenue du Scios,,9000
+7 Avenue du Scios 09000,,,,7,Avenue du Scios,Saint-Paul-de-Jarrat,
+7 Avenue du Scios,1.665204,42.914376,,7,Avenue du Scios,,9000
+22 Avenue des Pyrénées Villeneuve-du-Paréage,,,,22,Avenue des Pyrénées,,9100
+22 Avenue des Pyrénées 09100,,,,22,Avenue des Pyrénées,Villeneuve-du-Paréage,
+22 Avenue des Pyrénées,1.639625,43.14845,,22,Avenue des Pyrénées,,9100
+50 Rue de Marengo Baraqueville,,,,50,Rue de Marengo,,12160
+50 Rue de Marengo 12160,,,,50,Rue de Marengo,Baraqueville,
+50 Rue de Marengo,2.428229,44.279599,,50,Rue de Marengo,,12160
+35 Avenue de Calmont Espalion,,,,35,Avenue de Calmont,,12500
+35 Avenue de Calmont 12500,,,,35,Avenue de Calmont,Espalion,
+35 Avenue de Calmont,2.760378,44.517126,,35,Avenue de Calmont,,12500
+9 Rue du 8 Mai Livinhac-le-Haut,,,,9,Rue du 8 Mai,,12300
+9 Rue du 8 Mai 12300,,,,9,Rue du 8 Mai,Livinhac-le-Haut,
+9 Rue du 8 Mai,2.234604,44.591162,,9,Rue du 8 Mai,,12300
+350 Route de Creissels Millau,,,,350,Route de Creissels,,12100
+350 Route de Creissels 12100,,,,350,Route de Creissels,Millau,
+350 Route de Creissels,3.072684,44.090922,,350,Route de Creissels,,12100
+17 Avenue de la Castagnal Le Monastère,,,,17,Avenue de la Castagnal,,12000
+17 Avenue de la Castagnal 12000,,,,17,Avenue de la Castagnal,Le Monastère,
+17 Avenue de la Castagnal,2.570765,44.338704,,17,Avenue de la Castagnal,,12000
+19 Rue du Claux Onet-le-Château,,,,19,Rue du Claux,,12850
+19 Rue du Claux 12850,,,,19,Rue du Claux,Onet-le-Château,
+19 Rue du Claux,2.582102,44.368109,,19,Rue du Claux,,12850
+17 Place du Bourg Rodez,,,,17,Place du Bourg,,12000
+17 Place du Bourg 12000,,,,17,Place du Bourg,Rodez,
+17 Place du Bourg,2.576182,44.348581,,17,Place du Bourg,,12000
+673 Route de Couat Saint-Affrique,,,,673,Route de Couat,,12400
+673 Route de Couat 12400,,,,673,Route de Couat,Saint-Affrique,
+673 Route de Couat,2.891318,43.943398,,673,Route de Couat,,12400
+45 Avenue de Saint-Affrique Saint-Sernin-sur-Rance,,,,45,Avenue de Saint-Affrique,,12380
+45 Avenue de Saint-Affrique 12380,,,,45,Avenue de Saint-Affrique,Saint-Sernin-sur-Rance,
+45 Avenue de Saint-Affrique,2.612519,43.883029,,45,Avenue de Saint-Affrique,,12380
+2 Rue des Fours de la Ville Villefranche-de-Rouergue,,,,2,Rue des Fours de la Ville,,12200
+2 Rue des Fours de la Ville 12200,,,,2,Rue des Fours de la Ville,Villefranche-de-Rouergue,
+2 Rue des Fours de la Ville,2.036606,44.353242,,2,Rue des Fours de la Ville,,12200
+419 Chemin de Periac Aussonne,,,,419,Chemin de Periac,,31840
+419 Chemin de Periac 31840,,,,419,Chemin de Periac,Aussonne,
+419 Chemin de Periac,1.333443,43.67249,,419,Chemin de Periac,,31840
+4 Impasse du Champ de Mars Bagnères-de-Luchon,,,,4,Impasse du Champ de Mars,,31110
+4 Impasse du Champ de Mars 31110,,,,4,Impasse du Champ de Mars,Bagnères-de-Luchon,
+4 Impasse du Champ de Mars,0.588995,42.791852,,4,Impasse du Champ de Mars,,31110
+14 Résidence des Pyrénées Balma,,,,14,Résidence des Pyrénées,,31130
+14 Résidence des Pyrénées 31130,,,,14,Résidence des Pyrénées,Balma,
+14 Résidence des Pyrénées,1.493482,43.611426,,14,Résidence des Pyrénées,,31130
+146 Chemin de la Guiraudine Bessières,,,,146,Chemin de la Guiraudine,,31660
+146 Chemin de la Guiraudine 31660,,,,146,Chemin de la Guiraudine,Bessières,
+146 Chemin de la Guiraudine,1.578371,43.806913,,146,Chemin de la Guiraudine,,31660
+4 Impasse Saint-Jacques Blagnac,,,,4,Impasse Saint-Jacques,,31700
+4 Impasse Saint-Jacques 31700,,,,4,Impasse Saint-Jacques,Blagnac,
+4 Impasse Saint-Jacques,1.399946,43.634536,,4,Impasse Saint-Jacques,,31700
+25 Avenue du Bruguet Bruguières,,,,25,Avenue du Bruguet,,31150
+25 Avenue du Bruguet 31150,,,,25,Avenue du Bruguet,Bruguières,
+25 Avenue du Bruguet,1.414604,43.72167,,25,Avenue du Bruguet,,31150
+34 Rue Gambetta Carbonne,,,,34,Rue Gambetta,,31390
+34 Rue Gambetta 31390,,,,34,Rue Gambetta,Carbonne,
+34 Rue Gambetta,1.226088,43.295591,,34,Rue Gambetta,,31390
+15 Rue de la Barthe Castelginest,,,,15,Rue de la Barthe,,31780
+15 Rue de la Barthe 31780,,,,15,Rue de la Barthe,Castelginest,
+15 Rue de la Barthe,1.431792,43.697429,,15,Rue de la Barthe,,31780
+45 Grande Rue Castelnau-d'Estrétefonds,,,,45,Grande Rue,,31620
+45 Grande Rue 31620,,,,45,Grande Rue,Castelnau-d'Estrétefonds,
+45 Grande Rue,1.359837,43.781683,,45,Grande Rue,,31620
+12 Allée de l'Ariège Colomiers,,,,12,Allée de l'Ariège,,31770
+12 Allée de l'Ariège 31770,,,,12,Allée de l'Ariège,Colomiers,
+12 Allée de l'Ariège,1.347761,43.606676,,12,Allée de l'Ariège,,31770
+42 Allée de Naurouze Colomiers,,,,42,Allée de Naurouze,,31770
+42 Allée de Naurouze 31770,,,,42,Allée de Naurouze,Colomiers,
+42 Allée de Naurouze,1.348253,43.609151,,42,Allée de Naurouze,,31770
+16 Rue des Biches Cugnaux,,,,16,Rue des Biches,,31270
+16 Rue des Biches 31270,,,,16,Rue des Biches,Cugnaux,
+16 Rue des Biches,1.342217,43.53963,,16,Rue des Biches,,31270
+10 Rue Salvador Dali Daux,,,,10,Rue Salvador Dali,,31700
+10 Rue Salvador Dali 31700,,,,10,Rue Salvador Dali,Daux,
+10 Rue Salvador Dali,1.267223,43.691699,,10,Rue Salvador Dali,,31700
+10 Rue de la Tour de Pise Escalquens,,,,10,Rue de la Tour de Pise,,31750
+10 Rue de la Tour de Pise 31750,,,,10,Rue de la Tour de Pise,Escalquens,
+10 Rue de la Tour de Pise,1.563137,43.519955,,10,Rue de la Tour de Pise,,31750
+23 Rue des Hirondelles Fonsorbes,,,,23,Rue des Hirondelles,,31470
+23 Rue des Hirondelles 31470,,,,23,Rue des Hirondelles,Fonsorbes,
+23 Rue des Hirondelles,1.235674,43.535364,,23,Rue des Hirondelles,,31470
+5 Impasse de Saumaté Fronton,,,,5,Impasse de Saumaté,,31620
+5 Impasse de Saumaté 31620,,,,5,Impasse de Saumaté,Fronton,
+5 Impasse de Saumaté,1.369493,43.826764,,5,Impasse de Saumaté,,31620
+41 Rue de Vignabère Gourdan-Polignan,,,,41,Rue de Vignabère,,31210
+41 Rue de Vignabère 31210,,,,41,Rue de Vignabère,Gourdan-Polignan,
+41 Rue de Vignabère,0.582833,43.074152,,41,Rue de Vignabère,,31210
+11 Rue de Cier Huos,,,,11,Rue de Cier,,31210
+11 Rue de Cier 31210,,,,11,Rue de Cier,Huos,
+11 Rue de Cier,0.598731,43.073675,,11,Rue de Cier,,31210
+10 Passage Jean Dugaros Labastidette,,,,10,Passage Jean Dugaros,,31600
+10 Passage Jean Dugaros 31600,,,,10,Passage Jean Dugaros,Labastidette,
+10 Passage Jean Dugaros,1.247602,43.458682,,10,Passage Jean Dugaros,,31600
+18 Chemin de Triguebéoure Lapeyrouse-Fossat,,,,18,Chemin de Triguebéoure,,31180
+18 Chemin de Triguebéoure 31180,,,,18,Chemin de Triguebéoure,Lapeyrouse-Fossat,
+18 Chemin de Triguebéoure,1.523795,43.695258,,18,Chemin de Triguebéoure,,31180
+5 Impasse de la Cibelle Léguevin,,,,5,Impasse de la Cibelle,,31490
+5 Impasse de la Cibelle 31490,,,,5,Impasse de la Cibelle,Léguevin,
+5 Impasse de la Cibelle,1.229893,43.594228,,5,Impasse de la Cibelle,,31490
+17 Chemin de la Peyonne Longages,,,,17,Chemin de la Peyonne,,31410
+17 Chemin de la Peyonne 31410,,,,17,Chemin de la Peyonne,Longages,
+17 Chemin de la Peyonne,1.242855,43.351932,,17,Chemin de la Peyonne,,31410
+469 Route de Larra Merville,,,,469,Route de Larra,,31330
+469 Route de Larra 31330,,,,469,Route de Larra,Merville,
+469 Route de Larra,1.288913,43.719507,,469,Route de Larra,,31330
+2 Place Rhin et Danube Montastruc-la-Conseillère,,,,2,Place Rhin et Danube,,31380
+2 Place Rhin et Danube 31380,,,,2,Place Rhin et Danube,Montastruc-la-Conseillère,
+2 Place Rhin et Danube,1.58404,43.719011,,2,Place Rhin et Danube,,31380
+20 Rue du Salat Montrabé,,,,20,Rue du Salat,,31850
+20 Rue du Salat 31850,,,,20,Rue du Salat,Montrabé,
+20 Rue du Salat,1.520818,43.646065,,20,Rue du Salat,,31850
+8BIS Place Layrisson Muret,,,,8BIS,Place Layrisson,,31600
+8BIS Place Layrisson 31600,,,,8BIS,Place Layrisson,Muret,
+8BIS Place Layrisson,1.323743,43.46041,,8BIS,Place Layrisson,,31600
+86 Route de Toulouse Noé,,,,86,Route de Toulouse,,31410
+86 Route de Toulouse 31410,,,,86,Route de Toulouse,Noé,
+86 Route de Toulouse,1.272693,43.351958,,86,Route de Toulouse,,31410
+2 Allée des Lys Pibrac,,,,2,Allée des Lys,,31820
+2 Allée des Lys 31820,,,,2,Allée des Lys,Pibrac,
+2 Allée des Lys,1.287443,43.614018,,2,Allée des Lys,,31820
+67 Avenue de la Casse Plaisance-du-Touch,,,,67,Avenue de la Casse,,31830
+67 Avenue de la Casse 31830,,,,67,Avenue de la Casse,Plaisance-du-Touch,
+67 Avenue de la Casse,1.283571,43.558159,,67,Avenue de la Casse,,31830
+6 Impasse de l'Autan Pompertuzat,,,,6,Impasse de l'Autan,,31450
+6 Impasse de l'Autan 31450,,,,6,Impasse de l'Autan,Pompertuzat,
+6 Impasse de l'Autan,1.525537,43.492975,,6,Impasse de l'Autan,,31450
+29 Allée Michel-Ange Quint-Fonsegrives,,,,29,Allée Michel-Ange,,31130
+29 Allée Michel-Ange 31130,,,,29,Allée Michel-Ange,Quint-Fonsegrives,
+29 Allée Michel-Ange,1.523721,43.581038,,29,Allée Michel-Ange,,31130
+19 Rue Edith Piaf Revel,,,,19,Rue Edith Piaf,,31250
+19 Rue Edith Piaf 31250,,,,19,Rue Edith Piaf,Revel,
+19 Rue Edith Piaf,1.993396,43.467229,,19,Rue Edith Piaf,,31250
+4 Rue du Pouech Roquefort-sur-Garonne,,,,4,Rue du Pouech,,31360
+4 Rue du Pouech 31360,,,,4,Rue du Pouech,Roquefort-sur-Garonne,
+4 Rue du Pouech,0.975269,43.164711,,4,Rue du Pouech,,31360
+36 Avenue Salvador Allende Saint-Alban,,,,36,Avenue Salvador Allende,,31140
+36 Avenue Salvador Allende 31140,,,,36,Avenue Salvador Allende,Saint-Alban,
+36 Avenue Salvador Allende,1.408942,43.686599,,36,Avenue Salvador Allende,,31140
+73 Rue de la République Saint-Gaudens,,,,73,Rue de la République,,31800
+73 Rue de la République 31800,,,,73,Rue de la République,Saint-Gaudens,
+73 Rue de la République,0.725995,43.108519,,73,Rue de la République,,31800
+1 Passage des Romarins Saint-Jean,,,,1,Passage des Romarins,,31240
+1 Passage des Romarins 31240,,,,1,Passage des Romarins,Saint-Jean,
+1 Passage des Romarins,1.50028,43.672879,,1,Passage des Romarins,,31240
+10 Place Bernard Sarrieu Saint-Mamet,,,,10,Place Bernard Sarrieu,,31110
+10 Place Bernard Sarrieu 31110,,,,10,Place Bernard Sarrieu,Saint-Mamet,
+10 Place Bernard Sarrieu,0.60443,42.781914,,10,Place Bernard Sarrieu,,31110
+2 Route de Toulouse Saint-Pierre-de-Lages,,,,2,Route de Toulouse,,31570
+2 Route de Toulouse 31570,,,,2,Route de Toulouse,Saint-Pierre-de-Lages,
+2 Route de Toulouse,1.626416,43.569242,,2,Route de Toulouse,,31570
+3BIS Chemin de Pins Saubens,,,,3BIS,Chemin de Pins,,31600
+3BIS Chemin de Pins 31600,,,,3BIS,Chemin de Pins,Saubens,
+3BIS Chemin de Pins,1.353752,43.47716,,3BIS,Chemin de Pins,,31600
+39 Impasse Alexis de Tocqueville Toulouse,,,,39,Impasse Alexis de Tocqueville,,31998
+39 Impasse Alexis de Tocqueville 31998,,,,39,Impasse Alexis de Tocqueville,Toulouse,
+39 Impasse Alexis de Tocqueville,1.456219,43.649723,,39,Impasse Alexis de Tocqueville,,31998
+7 Rue Émile Barry Toulouse,,,,7,Rue Émile Barry,,31998
+7 Rue Émile Barry 31998,,,,7,Rue Émile Barry,Toulouse,
+7 Rue Émile Barry,1.471187,43.58289,,7,Rue Émile Barry,,31998
+78BIS Chemin des Capelles Toulouse,,,,78BIS,Chemin des Capelles,,31998
+78BIS Chemin des Capelles 31998,,,,78BIS,Chemin des Capelles,Toulouse,
+78BIS Chemin des Capelles,1.386358,43.603484,,78BIS,Chemin des Capelles,,31998
+15 Rue de Coulmiers Toulouse,,,,15,Rue de Coulmiers,,31998
+15 Rue de Coulmiers 31998,,,,15,Rue de Coulmiers,Toulouse,
+15 Rue de Coulmiers,1.442824,43.612759,,15,Rue de Coulmiers,,31998
+19 Rue Ernest Feydeau Toulouse,,,,19,Rue Ernest Feydeau,,31998
+19 Rue Ernest Feydeau 31998,,,,19,Rue Ernest Feydeau,Toulouse,
+19 Rue Ernest Feydeau,1.470452,43.626609,,19,Rue Ernest Feydeau,,31998
+311B Avenue de Fronton Toulouse,,,,311B,Avenue de Fronton,,31998
+311B Avenue de Fronton 31998,,,,311B,Avenue de Fronton,Toulouse,
+311B Avenue de Fronton,1.431788,43.654267,,311B,Avenue de Fronton,,31998
+8B Avenue de l'Hers Toulouse,,,,8B,Avenue de l'Hers,,31998
+8B Avenue de l'Hers 31998,,,,8B,Avenue de l'Hers,Toulouse,
+8B Avenue de l'Hers,1.478765,43.613088,,8B,Avenue de l'Hers,,31998
+39 Rue Jules Clarétie Toulouse,,,,39,Rue Jules Clarétie,,31998
+39 Rue Jules Clarétie 31998,,,,39,Rue Jules Clarétie,Toulouse,
+39 Rue Jules Clarétie,1.465831,43.587717,,39,Rue Jules Clarétie,,31998
+3 Avenue Louis Blériot Toulouse,,,,3,Avenue Louis Blériot,,31998
+3 Avenue Louis Blériot 31998,,,,3,Avenue Louis Blériot,Toulouse,
+3 Avenue Louis Blériot,1.463928,43.600237,,3,Avenue Louis Blériot,,31998
+5 Rue Mireille Toulouse,,,,5,Rue Mireille,,31998
+5 Rue Mireille 31998,,,,5,Rue Mireille,Toulouse,
+5 Rue Mireille,1.475913,43.586157,,5,Rue Mireille,,31998
+27 Chemin de la Pélude Toulouse,,,,27,Chemin de la Pélude,,31998
+27 Chemin de la Pélude 31998,,,,27,Chemin de la Pélude,Toulouse,
+27 Chemin de la Pélude,1.460359,43.568729,,27,Chemin de la Pélude,,31998
+18 Chemin Reboul Toulouse,,,,18,Chemin Reboul,,31998
+18 Chemin Reboul 31998,,,,18,Chemin Reboul,Toulouse,
+18 Chemin Reboul,1.375817,43.582008,,18,Chemin Reboul,,31998
+42 Rue Saint-Thomas d'Aquin Toulouse,,,,42,Rue Saint-Thomas d'Aquin,,31998
+42 Rue Saint-Thomas d'Aquin 31998,,,,42,Rue Saint-Thomas d'Aquin,Toulouse,
+42 Rue Saint-Thomas d'Aquin,1.448863,43.5803,,42,Rue Saint-Thomas d'Aquin,,31998
+5 Rue des Troènes Toulouse,,,,5,Rue des Troènes,,31998
+5 Rue des Troènes 31998,,,,5,Rue des Troènes,Toulouse,
+5 Rue des Troènes,1.414155,43.613448,,5,Rue des Troènes,,31998
+27 Rue de la Digue Tournefeuille,,,,27,Rue de la Digue,,31170
+27 Rue de la Digue 31170,,,,27,Rue de la Digue,Tournefeuille,
+27 Rue de la Digue,1.346608,43.57689,,27,Rue de la Digue,,31170
+1 Rue de la Somme Tournefeuille,,,,1,Rue de la Somme,,31170
+1 Rue de la Somme 31170,,,,1,Rue de la Somme,Tournefeuille,
+1 Rue de la Somme,1.354722,43.58038,,1,Rue de la Somme,,31170
+315 Rue du Roitelet L'Union,,,,315,Rue du Roitelet,,31240
+315 Rue du Roitelet 31240,,,,315,Rue du Roitelet,L'Union,
+315 Rue du Roitelet,1.475561,43.664145,,315,Rue du Roitelet,,31240
+149A Route de Gargas Villariès,,,,149A,Route de Gargas,,31380
+149A Route de Gargas 31380,,,,149A,Route de Gargas,Villariès,
+149A Route de Gargas,1.481808,43.759822,,149A,Route de Gargas,,31380
+2 Rue Stendhal Villemur-sur-Tarn,,,,2,Rue Stendhal,,31340
+2 Rue Stendhal 31340,,,,2,Rue Stendhal,Villemur-sur-Tarn,
+2 Rue Stendhal,1.494132,43.862727,,2,Rue Stendhal,,31340
+520 Chemin de Saint-Sèverin Larra,,,,520,Chemin de Saint-Sèverin,,31330
+520 Chemin de Saint-Sèverin 31330,,,,520,Chemin de Saint-Sèverin,Larra,
+520 Chemin de Saint-Sèverin,1.227467,43.727216,,520,Chemin de Saint-Sèverin,,31330
+15 Rue Montaigne Auch,,,,15,Rue Montaigne,,32000
+15 Rue Montaigne 32000,,,,15,Rue Montaigne,Auch,
+15 Rue Montaigne,0.593599,43.636495,,15,Rue Montaigne,,32000
+34 Rue Pierre Bazax Condom,,,,34,Rue Pierre Bazax,,32100
+34 Rue Pierre Bazax 32100,,,,34,Rue Pierre Bazax,Condom,
+34 Rue Pierre Bazax,0.370593,43.954792,,34,Rue Pierre Bazax,,32100
+2 Rue du Four Gimont,,,,2,Rue du Four,,32200
+2 Rue du Four 32200,,,,2,Rue du Four,Gimont,
+2 Rue du Four,0.877811,43.624691,,2,Rue du Four,,32200
+39 Rue des Frêres Danzas Lectoure,,,,39,Rue des Frêres Danzas,,32700
+39 Rue des Frêres Danzas 32700,,,,39,Rue des Frêres Danzas,Lectoure,
+39 Rue des Frêres Danzas,0.622142,43.932785,,39,Rue des Frêres Danzas,,32700
+25 Rue de la Paix Monguilhem,,,,25,Rue de la Paix,,32240
+25 Rue de la Paix 32240,,,,25,Rue de la Paix,Monguilhem,
+25 Rue de la Paix,-0.182436,43.85651,,25,Rue de la Paix,,32240
+8 Rue de Gascogne Samatan,,,,8,Rue de Gascogne,,32130
+8 Rue de Gascogne 32130,,,,8,Rue de Gascogne,Samatan,
+8 Rue de Gascogne,0.919386,43.491669,,8,Rue de Gascogne,,32130
+158 Rue de Montesquieu Cahors,,,,158,Rue de Montesquieu,,46000
+158 Rue de Montesquieu 46000,,,,158,Rue de Montesquieu,Cahors,
+158 Rue de Montesquieu,1.432391,44.456115,,158,Rue de Montesquieu,,46000
+2 Rue Jean Pons Figeac,,,,2,Rue Jean Pons,,46100
+2 Rue Jean Pons 46100,,,,2,Rue Jean Pons,Figeac,
+2 Rue Jean Pons,2.024248,44.611258,,2,Rue Jean Pons,,46100
+395 Route de Figeac Lamagdelaine,,,,395,Route de Figeac,,46090
+395 Route de Figeac 46090,,,,395,Route de Figeac,Lamagdelaine,
+395 Route de Figeac,1.489462,44.46415,,395,Route de Figeac,,46090
+834 Avenue Charles de Gaulle Saint-Laurent-les-Tours,,,,834,Avenue Charles de Gaulle,,46400
+834 Avenue Charles de Gaulle 46400,,,,834,Avenue Charles de Gaulle,Saint-Laurent-les-Tours,
+834 Avenue Charles de Gaulle,1.880234,44.867521,,834,Avenue Charles de Gaulle,,46400
+17 Rue du 11 Novembre Aureilhan,,,,17,Rue du 11 Novembre,,65800
+17 Rue du 11 Novembre 65800,,,,17,Rue du 11 Novembre,Aureilhan,
+17 Rue du 11 Novembre,0.090252,43.239205,,17,Rue du 11 Novembre,,65800
+13 Rue des Jonquilles Barbazan-Debat,,,,13,Rue des Jonquilles,,65690
+13 Rue des Jonquilles 65690,,,,13,Rue des Jonquilles,Barbazan-Debat,
+13 Rue des Jonquilles,0.114557,43.200972,,13,Rue des Jonquilles,,65690
+45 Route du Val d'Arros Cabanac,,,,45,Route du Val d'Arros,,65350
+45 Route du Val d'Arros 65350,,,,45,Route du Val d'Arros,Cabanac,
+45 Route du Val d'Arros,0.229914,43.277577,,45,Route du Val d'Arros,,65350
+11 Rue de l'Industrie Ibos,,,,11,Rue de l'Industrie,,65420
+11 Rue de l'Industrie 65420,,,,11,Rue de l'Industrie,Ibos,
+11 Rue de l'Industrie,-0.003152,43.23454,,11,Rue de l'Industrie,,65420
+591 Rue des Cités Lannemezan,,,,591,Rue des Cités,,65300
+591 Rue des Cités 65300,,,,591,Rue des Cités,Lannemezan,
+591 Rue des Cités,0.384133,43.103517,,591,Rue des Cités,,65300
+2A Avenue du Général Leclerc Lourdes,,,,2A,Avenue du Général Leclerc,,65100
+2A Avenue du Général Leclerc 65100,,,,2A,Avenue du Général Leclerc,Lourdes,
+2A Avenue du Général Leclerc,-0.045595,43.094215,,2A,Avenue du Général Leclerc,,65100
+45 Allée Larbanés Maubourguet,,,,45,Allée Larbanés,,65700
+45 Allée Larbanés 65700,,,,45,Allée Larbanés,Maubourguet,
+45 Allée Larbanés,0.03529,43.467551,,45,Allée Larbanés,,65700
+9BIS Rue des Acacias Oursbelille,,,,9BIS,Rue des Acacias,,65490
+9BIS Rue des Acacias 65490,,,,9BIS,Rue des Acacias,Oursbelille,
+9BIS Rue des Acacias,0.063008,43.292879,,9BIS,Rue des Acacias,,65490
+1 Rue Montalivet Sarrouilles,,,,1,Rue Montalivet,,65600
+1 Rue Montalivet 65600,,,,1,Rue Montalivet,Sarrouilles,
+1 Rue Montalivet,0.133299,43.2214,,1,Rue Montalivet,,65600
+3 Impasse Beaumarchais Tarbes,,,,3,Impasse Beaumarchais,,65000
+3 Impasse Beaumarchais 65000,,,,3,Impasse Beaumarchais,Tarbes,
+3 Impasse Beaumarchais,0.056451,43.238264,,3,Impasse Beaumarchais,,65000
+3BIS Rue Marcelin Berthelot Tarbes,,,,3BIS,Rue Marcelin Berthelot,,65000
+3BIS Rue Marcelin Berthelot 65000,,,,3BIS,Rue Marcelin Berthelot,Tarbes,
+3BIS Rue Marcelin Berthelot,0.086129,43.221717,,3BIS,Rue Marcelin Berthelot,,65000
+2 Place Gambetta Vic-en-Bigorre,,,,2,Place Gambetta,,65500
+2 Place Gambetta 65500,,,,2,Place Gambetta,Vic-en-Bigorre,
+2 Place Gambetta,0.054735,43.385701,,2,Place Gambetta,,65500
+102 Rue Commandant Blanché Albi,,,,102,Rue Commandant Blanché,,81000
+102 Rue Commandant Blanché 81000,,,,102,Rue Commandant Blanché,Albi,
+102 Rue Commandant Blanché,2.155045,43.9209,,102,Rue Commandant Blanché,,81000
+17 Allée des Hortensias Albi,,,,17,Allée des Hortensias,,81000
+17 Allée des Hortensias 81000,,,,17,Allée des Hortensias,Albi,
+17 Allée des Hortensias,2.152183,43.938786,,17,Allée des Hortensias,,81000
+49 Chemin de Lapeyrouse Albi,,,,49,Chemin de Lapeyrouse,,81000
+49 Chemin de Lapeyrouse 81000,,,,49,Chemin de Lapeyrouse,Albi,
+49 Chemin de Lapeyrouse,2.172047,43.911883,,49,Chemin de Lapeyrouse,,81000
+58BIS Avenue de Lescure Arthès,,,,58BIS,Avenue de Lescure,,81160
+58BIS Avenue de Lescure 81160,,,,58BIS,Avenue de Lescure,Arthès,
+58BIS Avenue de Lescure,2.199924,43.954534,,58BIS,Avenue de Lescure,,81160
+18 Rue des Cèdres Bout-du-Pont-de-Larn,,,,18,Rue des Cèdres,,81660
+18 Rue des Cèdres 81660,,,,18,Rue des Cèdres,Bout-du-Pont-de-Larn,
+18 Rue des Cèdres,2.40044,43.499636,,18,Rue des Cèdres,,81660
+44 Chemin de la Sarrade Cambon,,,,44,Chemin de la Sarrade,,81990
+44 Chemin de la Sarrade 81990,,,,44,Chemin de la Sarrade,Cambon,
+44 Chemin de la Sarrade,2.262183,43.919247,,44,Chemin de la Sarrade,,81990
+11 Rue de la Verrerie Carmaux,,,,11,Rue de la Verrerie,,81400
+11 Rue de la Verrerie 81400,,,,11,Rue de la Verrerie,Carmaux,
+11 Rue de la Verrerie,2.152068,44.051604,,11,Rue de la Verrerie,,81400
+108 Avenue Emilie de Villeneuve Castres,,,,108,Avenue Emilie de Villeneuve,,81100
+108 Avenue Emilie de Villeneuve 81100,,,,108,Avenue Emilie de Villeneuve,Castres,
+108 Avenue Emilie de Villeneuve,2.24211,43.597727,,108,Avenue Emilie de Villeneuve,,81100
+29 Rue Marceau Castres,,,,29,Rue Marceau,,81100
+29 Rue Marceau 81100,,,,29,Rue Marceau,Castres,
+29 Rue Marceau,2.23415,43.596623,,29,Rue Marceau,,81100
+47 Chemin de Tournemire Castres,,,,47,Chemin de Tournemire,,81100
+47 Chemin de Tournemire 81100,,,,47,Chemin de Tournemire,Castres,
+47 Chemin de Tournemire,2.282294,43.62352,,47,Chemin de Tournemire,,81100
+10 Impasse des Balitrands Gaillac,,,,10,Impasse des Balitrands,,81600
+10 Impasse des Balitrands 81600,,,,10,Impasse des Balitrands,Gaillac,
+10 Impasse des Balitrands,1.87314,43.898782,,10,Impasse des Balitrands,,81600
+3905 Chemin Toulze Gaillac,,,,3905,Chemin Toulze,,81600
+3905 Chemin Toulze 81600,,,,3905,Chemin Toulze,Gaillac,
+3905 Chemin Toulze,1.898205,43.925605,,3905,Chemin Toulze,,81600
+1 Passage de Saintonge Graulhet,,,,1,Passage de Saintonge,,81300
+1 Passage de Saintonge 81300,,,,1,Passage de Saintonge,Graulhet,
+1 Passage de Saintonge,1.998359,43.762835,,1,Passage de Saintonge,,81300
+10 Route de Vabre Lacrouzette,,,,10,Route de Vabre,,81210
+10 Route de Vabre 81210,,,,10,Route de Vabre,Lacrouzette,
+10 Route de Vabre,2.350142,43.663663,,10,Route de Vabre,,81210
+558 Chemin de la Rivayrolle Lavaur,,,,558,Chemin de la Rivayrolle,,81500
+558 Chemin de la Rivayrolle 81500,,,,558,Chemin de la Rivayrolle,Lavaur,
+558 Chemin de la Rivayrolle,1.765017,43.726153,,558,Chemin de la Rivayrolle,,81500
+12 Rue des Trincades Marssac-sur-Tarn,,,,12,Rue des Trincades,,81150
+12 Rue des Trincades 81150,,,,12,Rue des Trincades,Marssac-sur-Tarn,
+12 Rue des Trincades,2.033659,43.914421,,12,Rue des Trincades,,81150
+35 Rue de la Resse Mazamet,,,,35,Rue de la Resse,,81200
+35 Rue de la Resse 81200,,,,35,Rue de la Resse,Mazamet,
+35 Rue de la Resse,2.373371,43.48497,,35,Rue de la Resse,,81200
+8 Rue d'En Redon Pont-de-Larn,,,,8,Rue d'En Redon,,81660
+8 Rue d'En Redon 81660,,,,8,Rue d'En Redon,Pont-de-Larn,
+8 Rue d'En Redon,2.407498,43.513135,,8,Rue d'En Redon,,81660
+4 Résidence Les Jardins de Cantemerle Réalmont,,,,4,Résidence Les Jardins de Cantemerle,,81120
+4 Résidence Les Jardins de Cantemerle 81120,,,,4,Résidence Les Jardins de Cantemerle,Réalmont,
+4 Résidence Les Jardins de Cantemerle,2.182506,43.773593,,4,Résidence Les Jardins de Cantemerle,,81120
+8 Rue Gisclard Saint-Juéry,,,,8,Rue Gisclard,,81160
+8 Rue Gisclard 81160,,,,8,Rue Gisclard,Saint-Juéry,
+8 Rue Gisclard,2.207059,43.946941,,8,Rue Gisclard,,81160
+24 Rue de la Céramique Saint-Sulpice-la-Pointe,,,,24,Rue de la Céramique,,81370
+24 Rue de la Céramique 81370,,,,24,Rue de la Céramique,Saint-Sulpice-la-Pointe,
+24 Rue de la Céramique,1.676062,43.780721,,24,Rue de la Céramique,,81370
+5 Impasse des Lauriers Sorèze,,,,5,Impasse des Lauriers,,81540
+5 Impasse des Lauriers 81540,,,,5,Impasse des Lauriers,Sorèze,
+5 Impasse des Lauriers,2.061094,43.455193,,5,Impasse des Lauriers,,81540
+8 Chemin des Agals Viviers-lès-Montagnes,,,,8,Chemin des Agals,,81290
+8 Chemin des Agals 81290,,,,8,Chemin des Agals,Viviers-lès-Montagnes,
+8 Chemin des Agals,2.184001,43.565949,,8,Chemin des Agals,,81290
+1083 Route de la Bénèche Bioule,,,,1083,Route de la Bénèche,,82800
+1083 Route de la Bénèche 82800,,,,1083,Route de la Bénèche,Bioule,
+1083 Route de la Bénèche,1.55592,44.112465,,1083,Route de la Bénèche,,82800
+1998 Route des Fourrières Castelsarrasin,,,,1998,Route des Fourrières,,82100
+1998 Route des Fourrières 82100,,,,1998,Route des Fourrières,Castelsarrasin,
+1998 Route des Fourrières,1.152883,44.041996,,1998,Route des Fourrières,,82100
+2 Avenue du 8 Mai Caussade,,,,2,Avenue du 8 Mai,,82300
+2 Avenue du 8 Mai 82300,,,,2,Avenue du 8 Mai,Caussade,
+2 Avenue du 8 Mai,1.535793,44.161527,,2,Avenue du 8 Mai,,82300
+22 Avenue du Ramier Finhan,,,,22,Avenue du Ramier,,82700
+22 Avenue du Ramier 82700,,,,22,Avenue du Ramier,Finhan,
+22 Avenue du Ramier,1.21311,43.91229,,22,Avenue du Ramier,,82700
+134 Impasse Cazy Lacourt-Saint-Pierre,,,,134,Impasse Cazy,,82290
+134 Impasse Cazy 82290,,,,134,Impasse Cazy,Lacourt-Saint-Pierre,
+134 Impasse Cazy,1.279054,43.991185,,134,Impasse Cazy,,82290
+115 Impasse Cayssac Mirabel,,,,115,Impasse Cayssac,,82440
+115 Impasse Cayssac 82440,,,,115,Impasse Cayssac,Mirabel,
+115 Impasse Cayssac,1.397445,44.131762,,115,Impasse Cayssac,,82440
+13 Rue de la République Moissac,,,,13,Rue de la République,,82200
+13 Rue de la République 82200,,,,13,Rue de la République,Moissac,
+13 Rue de la République,1.084938,44.104206,,13,Rue de la République,,82200
+29 Rue Du Bac Montauban,,,,29,Rue Du Bac,,82000
+29 Rue Du Bac 82000,,,,29,Rue Du Bac,Montauban,
+29 Rue Du Bac,1.341756,44.019047,,29,Rue Du Bac,,82000
+1 Rue Edouard Manet Montauban,,,,1,Rue Edouard Manet,,82000
+1 Rue Edouard Manet 82000,,,,1,Rue Edouard Manet,Montauban,
+1 Rue Edouard Manet,1.371552,44.023216,,1,Rue Edouard Manet,,82000
+170 Chemin de Lapèyre Montauban,,,,170,Chemin de Lapèyre,,82000
+170 Chemin de Lapèyre 82000,,,,170,Chemin de Lapèyre,Montauban,
+170 Chemin de Lapèyre,1.320814,43.971842,,170,Chemin de Lapèyre,,82000
+1420 Rue de la Première Armée Montauban,,,,1420,Rue de la Première Armée,,82000
+1420 Rue de la Première Armée 82000,,,,1420,Rue de la Première Armée,Montauban,
+1420 Rue de la Première Armée,1.345754,44.004965,,1420,Rue de la Première Armée,,82000
+260 Chemin des Rosiers Montbeton,,,,260,Chemin des Rosiers,,82290
+260 Chemin des Rosiers 82290,,,,260,Chemin des Rosiers,Montbeton,
+260 Chemin des Rosiers,1.265919,44.014544,,260,Chemin des Rosiers,,82290
+21 Rue Marcelin Viguié Nègrepelisse,,,,21,Rue Marcelin Viguié,,82800
+21 Rue Marcelin Viguié 82800,,,,21,Rue Marcelin Viguié,Nègrepelisse,
+21 Rue Marcelin Viguié,1.522437,44.074839,,21,Rue Marcelin Viguié,,82800
+2486 Vieille Route Vieille Route de Montauban Saint-Étienne-de-Tulmont,,,,2486,Vieille Route Vieille Route de Montauban,,82410
+2486 Vieille Route Vieille Route de Montauban 82410,,,,2486,Vieille Route Vieille Route de Montauban,Saint-Étienne-de-Tulmont,
+2486 Vieille Route Vieille Route de Montauban,1.441828,44.05144,,2486,Vieille Route Vieille Route de Montauban,,82410
+28 Avenue Georges d'Esparbes Valence,,,,28,Avenue Georges d'Esparbes,,82400
+28 Avenue Georges d'Esparbes 82400,,,,28,Avenue Georges d'Esparbes,Valence,
+28 Avenue Georges d'Esparbes,0.897972,44.105391,,28,Avenue Georges d'Esparbes,,82400

--- a/geocoder_tester/world/france/nordpasdecalais/test_addresses.csv
+++ b/geocoder_tester/world/france/nordpasdecalais/test_addresses.csv
@@ -1,833 +1,833 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-19 Rue Denis Cordonnier Aniche,,,,19 Rue Denis Cordonnier,,,,59580
-19 Rue Denis Cordonnier 59580,,,,19 Rue Denis Cordonnier,,,Aniche,
-19 Rue Denis Cordonnier,3.250339,50.323376,,19 Rue Denis Cordonnier,,,,59580
-119 Rue Carpeaux Villeneuve-d'Ascq,,,,119 Rue Carpeaux,,,,59650
-119 Rue Carpeaux 59650,,,,119 Rue Carpeaux,,,Villeneuve-d'Ascq,
-11 Rue des Genêts Villeneuve-d'Ascq,,,,11 Rue des Genêts,,,,59650
-11 Rue des Genêts 59650,,,,11 Rue des Genêts,,,Villeneuve-d'Ascq,
-18 Rue Saint-Sauveur Villeneuve-d'Ascq,,,,18 Rue Saint-Sauveur,,,,59650
-18 Rue Saint-Sauveur 59650,,,,18 Rue Saint-Sauveur,,,Villeneuve-d'Ascq,
-18 Rue Saint-Sauveur,3.141394,50.627746,,18 Rue Saint-Sauveur,,,,59650
-31 Rue des Anorelles Anor,,,,31 Rue des Anorelles,,,,59186
-31 Rue des Anorelles 59186,,,,31 Rue des Anorelles,,,Anor,
-31 Rue des Anorelles,4.134764,49.998113,,31 Rue des Anorelles,,,,59186
-8 Rue Kléber Anzin,,,,8 Rue Kléber,,,,59410
-8 Rue Kléber 59410,,,,8 Rue Kléber,,,Anzin,
-8 Rue Kléber,3.500907,50.374232,,8 Rue Kléber,,,,59410
-3 Cours Carniaux Armentières,,,,3 Cour Carniaud,,,,59280
-3 Cours Carniaux 59280,,,,3 Cour Carniaud,,,Armentières,
-3 Cours Carniaux,2.879964,50.688477,,3 Cour Carniaud,,,,59280
-64BIS Rue de Metz Armentières,,,,64 B Rue de Metz,,,,59280
-64BIS Rue de Metz 59280,,,,64 B Rue de Metz,,,Armentières,
-64 B Rue de Metz,2.889957,50.687328,,64 B Rue de Metz,,,,59280
-16 Place des Eglantines Attiches,,,,16 Place des Eglantines,,,,59551
-16 Place des Eglantines 59551,,,,16 Place des Eglantines,,,Attiches,
-16 Place des Eglantines,3.065758,50.524763,,16 Place des Eglantines,,,,59551
-7 Rue Condorcet Auby,,,,7 Rue Condorcet,,,,59950
-7 Rue Condorcet 59950,,,,7 Rue Condorcet,,,Auby,
-45 Rue Albert-Schweitzer Aulnoye-Aymeries,,,,45 Rue Albert-Schweitzer,,,,59620
-45 Rue Albert-Schweitzer 59620,,,,45 Rue Albert-Schweitzer,,,Aulnoye-Aymeries,
-45 Rue Albert-Schweitzer,3.848887,50.207203,,45 Rue Albert-Schweitzer,,,,59620
-28 Rue des Jardins Avesnelles,,,,28 Rue des Jardins,,,,59440
-28 Rue des Jardins 59440,,,,28 Rue des Jardins,,,Avesnelles,
-28 Rue des Jardins,3.948079,50.120090,,28 Rue des Jardins,,,,59440
-13 Rue d'Estree Bachant,,,,13 Rue d'Estree,,,,59138
-13 Rue d'Estree 59138,,,,13 Rue d'Estree,,,Bachant,
-13 Rue d'Estree,3.855022,50.209278,,13 Rue d'Estree,,,,59138
-100 Rue Philippe Van Tieghem Bailleul,,,,100 Rue Philippe Van Tieghem,,,,59270
-100 Rue Philippe Van Tieghem 59270,,,,100 Rue Philippe Van Tieghem,,,Bailleul,
-100 Rue Philippe Van Tieghem,2.728873,50.734869,,100 Rue Philippe Van Tieghem,,,,59270
-34 Hameau de Beaupuits La Bassée,,,,34 Hameau de Beaupuits,,,,59480
-34 Hameau de Beaupuits 59480,,,,34 Hameau de Beaupuits,,,La Bassée,
-34 Hameau de Beaupuits,2.799730,50.548204,,34 Hameau de Beaupuits,,,,59480
-18 Rue de Fournes Beaucamps-Ligny,,,,18 Rue de Fournes,,,,59134
-18 Rue de Fournes 59134,,,,18 Rue de Fournes,,,Beaucamps-Ligny,
-18 Rue de Fournes,2.914258,50.604176,,18 Rue de Fournes,,,,59134
-1 Rue du Moulin Berlaimont,,,,1 Rue du Moulin,,,,59145
-1 Rue du Moulin 59145,,,,1 Rue du Moulin,,,Berlaimont,
-1 Rue du Moulin,3.816387,50.202380,,1 Rue du Moulin,,,,59145
-12 Rue Jean Chanat Beuvrages,,,,12 Rue Jean Chanat,,,,59192
-12 Rue Jean Chanat 59192,,,,12 Rue Jean Chanat,,,Beuvrages,
-12 Rue Jean Chanat,3.508408,50.381089,,12 Rue Jean Chanat,,,,59192
-97 Rue du Moulin Boeschepe,,,,97 Rue du Moulin,,,,59299
-97 Rue du Moulin 59299,,,,97 Rue du Moulin,,,Boeschepe,
-97 Rue du Moulin,2.688706,50.800570,,97 Rue du Moulin,,,,59299
-796 Domaine de la Vigne Bondues,,,,796 Domaine de la Vigne,,,,59910
-796 Domaine de la Vigne 59910,,,,796 Domaine de la Vigne,,,Bondues,
-796 Domaine de la Vigne,3.075937,50.713709,,796 Domaine de la Vigne,,,,59910
-9 Rue Schadet Vercoustre Bourbourg,,,,9 Rue Schadet Vercoustre,,,,59630
-9 Rue Schadet Vercoustre 59630,,,,9 Rue Schadet Vercoustre,,,Bourbourg,
-9 Rue Schadet Vercoustre,2.196252,50.948307,,9 Rue Schadet Vercoustre,,,,59630
-270 Rue de la Paix Boussois,,,,270 Rue de la Paix,,,,59168
-270 Rue de la Paix 59168,,,,270 Rue de la Paix,,,Boussois,
-270 Rue de la Paix,4.040773,50.293517,,270 Rue de la Paix,,,,59168
-25 Route de Rubrouck Cd 911 Broxeele,,,,25 Route de Rubrouck Cd 911,,,,59470
-25 Route de Rubrouck Cd 911 59470,,,,25 Route de Rubrouck Cd 911,,,Broxeele,
-25 Route de Rubrouck Cd 911,2.317148,50.829900,,25 Route de Rubrouck Cd 911,,,,59470
-25 Rue Lesage Bruille-lez-Marchiennes,,,,25 Rue Lesage,,,,59490
-25 Rue Lesage 59490,,,,25 Rue Lesage,,,Bruille-lez-Marchiennes,
-25 Rue Lesage,3.244433,50.365048,2,25 Rue Lesage,,,,59490
-71 Rue d'Artois Cambrai,,,,71 Rue d'Artois,,,,59400
-71 Rue d'Artois 59400,,,,71 Rue d'Artois,,,Cambrai,
-71 Rue d'Artois,3.255944,50.160947,,71 Rue d'Artois,,,,59400
-5 Rue Jean Racine Cambrai,,,,5 Rue Jean Racine,,,,59400
-5 Rue Jean Racine 59400,,,,5 Rue Jean Racine,,,Cambrai,
-5 Rue Jean Racine,3.256965,50.165885,,5 Rue Jean Racine,,,,59400
-5 Allée Saint-Roch Cambrai,,,,5 Allée Saint-Roch,,,,59400
-5 Allée Saint-Roch 59400,,,,5 Allée Saint-Roch,,,Cambrai,
-5 Allée Saint-Roch,3.239989,50.180002,,5 Allée Saint-Roch,,,,59400
-967 Rue Basilic Straete Cappelle-Brouck,,,,967 Rue Basilic Straete,,,,59630
-967 Rue Basilic Straete 59630,,,,967 Rue Basilic Straete,,,Cappelle-Brouck,
-967 Rue Basilic Straete,2.238490,50.910373,,967 Rue Basilic Straete,,,,59630
-115 Rue de Bruxelles Caudry,,,,115 Rue de Bruxelles,,,,59540
-115 Rue de Bruxelles 59540,,,,115 Rue de Bruxelles,,,Caudry,
-115 Rue de Bruxelles,3.410777,50.131644,,115 Rue de Bruxelles,,,,59540
-17 Rue Stephenson Caudry,,,,17 Rue Stephenson,,,,59540
-17 Rue Stephenson 59540,,,,17 Rue Stephenson,,,Caudry,
-17 Rue Stephenson,3.420761,50.126288,,17 Rue Stephenson,,,,59540
-34 Rue du Bon Passage Chéreng,,,,34 Rue du Bon Passage,,,,59152
-34 Rue du Bon Passage 59152,,,,34 Rue du Bon Passage,,,Chéreng,
-34 Rue du Bon Passage,3.204850,50.608204,,34 Rue du Bon Passage,,,,59152
-58 Rue Martha Desrumeaux Comines,,,,58 Rue Martha Desrumaux,,,,59560
-58 Rue Martha Desrumeaux 59560,,,,58 Rue Martha Desrumaux,,,Comines,
-58 Rue Martha Desrumeaux,3.020017,50.766500,,58 Rue Martha Desrumaux,,,,59560
-21 Rue du Quesnoy Condé-sur-l'Escaut,,,,21 Rue du Quesnoy,,,,59163
-21 Rue du Quesnoy 59163,,,,21 Rue du Quesnoy,,,Condé-sur-l'Escaut,
-21 Rue du Quesnoy,3.594722,50.445786,2,21 Rue du Quesnoy,,,,59163
-69 Boulevard Jean Jaurès Coudekerque-Branche,,,,69 Boulevard Jean Jaurès,,,,59210
-69 Boulevard Jean Jaurès 59210,,,,69 Boulevard Jean Jaurès,,,Coudekerque-Branche,
-69 Boulevard Jean Jaurès,2.379438,51.021507,,69 Boulevard Jean Jaurès,,,,59210
-2 Rue Pierre de Coubertin Courchelettes,,,,2 Rue Pierre de Coubertin,,,,59552
-2 Rue Pierre de Coubertin 59552,,,,2 Rue Pierre de Coubertin,,,Courchelettes,
-2 Rue Pierre de Coubertin,3.057501,50.348526,,2 Rue Pierre de Coubertin,,,,59552
-73 Rue Anatole France Croix,,,,73 Rue Anatole France,,,,59170
-73 Rue Anatole France 59170,,,,73 Rue Anatole France,,,Croix,
-73 Rue Anatole France,3.156332,50.684844,5,73 Rue Anatole France,,,,59170
-43 Rue Paul Lafargue Croix,,,,43 Rue Paul Lafargue,,,,59170
-43 Rue Paul Lafargue 59170,,,,43 Rue Paul Lafargue,,,Croix,
-43 Rue Paul Lafargue,3.155249,50.686021,,43 Rue Paul Lafargue,,,,59170
-20E Rue du Général de Gaulle Cysoing,,,,20 E Rue du Général de Gaulle,,,,59830
-20E Rue du Général de Gaulle 59830,,,,20 E Rue du Général de Gaulle,,,Cysoing,
-20E Rue du Général de Gaulle,3.218773,50.570480,,20 E Rue du Général de Gaulle,,,,59830
-240 Rue Charles Bourseul Douai,,,,240 Rue Charles Bourseul,,,,59500
-240 Rue Charles Bourseul 59500,,,,240 Rue Charles Bourseul,,,Douai,
-240 Rue Charles Bourseul,3.074509,50.379867,,240 Rue Charles Bourseul,,,,59500
-89 Rue Léo Delibes Douai,,,,89 Rue Léo Delibes,,,,59500
-89 Rue Léo Delibes 59500,,,,89 Rue Léo Delibes,,,Douai,
-89 Rue Léo Delibes,3.098754,50.378096,,89 Rue Léo Delibes,,,,59500
-32 Rue Victor Pecqueur Douai,,,,32 Rue Victor Pecqueur,,,,59500
-32 Rue Victor Pecqueur 59500,,,,32 Rue Victor Pecqueur,,,Douai,
-32 Rue Victor Pecqueur,3.084533,50.391887,,32 Rue Victor Pecqueur,,,,59500
-30 Rue Alfred Dumont Dunkerque,,,,30 Rue Alfred Dumont,,,,59140
-30 Rue Alfred Dumont 59140,,,,30 Rue Alfred Dumont,,,Dunkerque,
-30 Rue Alfred Dumont,2.377278,51.030606,,30 Rue Alfred Dumont,,,,59140
-543 Rue Arago Dunkerque,,,,543 Rue Arago,,,,59240
-543 Rue Arago 59240,,,,543 Rue Arago,,,Dunkerque,
-543 Rue Arago,2.403552,51.044322,,543 Rue Arago,,,,59240
-52 Rue des Fusiliers Marins Dunkerque,,,,52 Rue des Fusiliers Marins,,,,59430
-52 Rue des Fusiliers Marins 59430,,,,52 Rue des Fusiliers Marins,,,Dunkerque,
-52 Rue des Fusiliers Marins,2.345248,51.034846,,52 Rue des Fusiliers Marins,,,,59430
-133 Rue de la Moissonnière Dunkerque,,,,133 Rue de la Moissonnière,,,,59640
-133 Rue de la Moissonnière 59640,,,,133 Rue de la Moissonnière,,,Dunkerque,
-133 Rue de la Moissonnière,2.315725,51.025215,,133 Rue de la Moissonnière,,,,59640
-635 Rue de Zuydcoote Dunkerque,,,,635 Rue de Zuydcoote,,,,59240
-635 Rue de Zuydcoote 59240,,,,635 Rue de Zuydcoote,,,Dunkerque,
-635 Rue de Zuydcoote,2.427879,51.047466,,635 Rue de Zuydcoote,,,,59240
-56 Rue Gambetta Dunkerque,,,,56 Rue Gambetta,,,,59430
-56 Rue Gambetta 59430,,,,56 Rue Gambetta,,,Dunkerque,
-56 Rue Gambetta,2.350174,51.026210,,56 Rue Gambetta,,,,59430
-93 Rue de l'Hazewinde Eecke,,,,93 Rue de l'Hazewinde,,,,59114
-93 Rue de l'Hazewinde 59114,,,,93 Rue de l'Hazewinde,,,Eecke,
-93 Rue de l'Hazewinde,2.593041,50.780304,,93 Rue de l'Hazewinde,,,,59114
-404 Avenue Jules Guesde Escaudain,,,,404 Avenue Jules Guesde,,,,59124
-404 Avenue Jules Guesde 59124,,,,404 Avenue Jules Guesde,,,Escaudain,
-404 Avenue Jules Guesde,3.330919,50.329008,,404 Avenue Jules Guesde,,,,59124
-4 Allée des Peupliers Escobecques,,,,4 Allée des Peupliers,,,,59320
-4 Allée des Peupliers 59320,,,2,4 Allée des Peupliers,,,Escobecques,
-4 Allée des Peupliers,2.937156,50.618826,3,4 Allée des Peupliers,,,,59320
-19 Rue de Thun l'Eveque Eswars,,,,19 Rue de Thun l'Eveque,,,,59161
-19 Rue de Thun l'Eveque 59161,,,,19 Rue de Thun l'Eveque,,,Eswars,
-19 Rue de Thun l'Eveque,3.272098,50.222170,,19 Rue de Thun l'Eveque,,,,59161
-228 Rue Jean Jaurès Faches-Thumesnil,,,,228 Rue Jean Jaurès,,,,59155
-228 Rue Jean Jaurès 59155,,,,228 Rue Jean Jaurès,,,Faches-Thumesnil,
-228 Rue Jean Jaurès,3.074016,50.604837,2,228 Rue Jean Jaurès,,,,59155
-2 Rue Alfred-Derkenne Feignies,,,,2 Rue Alfred-Derkenne,,,,59750
-2 Rue Alfred-Derkenne 59750,,,,2 Rue Alfred-Derkenne,,,Feignies,
-2 Rue Alfred-Derkenne,3.917436,50.298104,,2 Rue Alfred-Derkenne,,,,59750
-75 Rue Suzanne Lanoy Fenain,,,,75 Rue Suzanne Lanoy,,,,59179
-75 Rue Suzanne Lanoy 59179,,,,75 Rue Suzanne Lanoy,,,Fenain,
-75 Rue Suzanne Lanoy,3.295850,50.366135,,75 Rue Suzanne Lanoy,,,,59179
-79BIS Rue Marceau Martin Flers-en-Escrebieux,,,,79 BIS Rue Marceau Martin,,,,59128
-79BIS Rue Marceau Martin 59128,,,,79 BIS Rue Marceau Martin,,,Flers-en-Escrebieux,
-79BIS Rue Marceau Martin,3.091407,50.399575,,79 BIS Rue Marceau Martin,,,,59128
-41 Rue Lamartine Fontaine-au-Pire,,,,41 Rue Lamartine,,,,59157
-41 Rue Lamartine 59157,,,,41 Rue Lamartine,,,Fontaine-au-Pire,
-41 Rue Lamartine,3.374668,50.133814,,41 Rue Lamartine,,,,59157
-4 Impasse Marcy Fourmies,,,,4 Impasse Marcy,,,,59610
-4 Impasse Marcy 59610,,,,4 Impasse Marcy,,,Fourmies,
-4 Impasse Marcy,4.040814,50.013599,,4 Impasse Marcy,,,,59610
-84 Rue Jacques Renard Fresnes-sur-Escaut,,,,84 Rue Jacques Renard,,,,59970
-84 Rue Jacques Renard 59970,,,,84 Rue Jacques Renard,,,Fresnes-sur-Escaut,
-84 Rue Jacques Renard,3.555527,50.438435,,84 Rue Jacques Renard,,,,59970
-22A Rue des Écoles Ghyvelde,,,,22 A Rue des Écoles,,,,59254
-22A Rue des Écoles 59254,,,,22 A Rue des Écoles,,,Ghyvelde,
-22A Rue des Écoles,2.524502,51.050100,2,22 A Rue des Écoles,,,,59254
-10 Rue Gustave Mélantois Gondecourt,,,,10 Rue Gustave Mélantois,,,,59147
-10 Rue Gustave Mélantois 59147,,,,10 Rue Gustave Mélantois,,,Gondecourt,
-10 Rue Gustave Mélantois,2.981813,50.541273,,10 Rue Gustave Mélantois,,,,59147
-77 Rue de Gravelines Grand-Fort-Philippe,,,,77 Rue de Gravelines,,,,59153
-77 Rue de Gravelines 59153,,,,77 Rue de Gravelines,,,Grand-Fort-Philippe,
-77 Rue de Gravelines,2.105327,50.998279,,77 Rue de Gravelines,,,,59153
-14 Rue de la Plage Gravelines,,,,14 Rue de la Plage,,,,59820
-14 Rue de la Plage 59820,,,,14 Rue de la Plage,,,Gravelines,
-14 Rue de la Plage,2.132981,50.991071,2,14 Rue de la Plage,,,,59820
-12 Rue Arthur Houte Halluin,,,,12 Rue Arthur Houte,,,,59250
-12 Rue Arthur Houte 59250,,,,12 Rue Arthur Houte,,,Halluin,
-12 Rue Arthur Houte,3.127454,50.779975,,12 Rue Arthur Houte,,,,59250
-81 Rue Maurice Simono Halluin,,,,81 Rue Maurice Simono,,,,59250
-81 Rue Maurice Simono 59250,,,,81 Rue Maurice Simono,,,Halluin,
-81 Rue Maurice Simono,3.120149,50.785824,,81 Rue Maurice Simono,,,,59250
-1 BIS Rue d'Avesnes Le Sec Haspres,,,,1 BIS Rue d'Avesnes Le Sec,,,,59198
-1 BIS Rue d'Avesnes Le Sec 59198,,,,1 BIS Rue d'Avesnes Le Sec,,,Haspres,
-1 BIS Rue d'Avesnes Le Sec,3.411783,50.256013,,1 BIS Rue d'Avesnes Le Sec,,,,59198
-69 Avenue de la Pépinière Haubourdin,,,,69 Avenue de la Pépinière,,,,59320
-69 Avenue de la Pépinière 59320,,,,69 Avenue de la Pépinière,,,Haubourdin,
-69 Avenue de la Pépinière,2.970606,50.609344,,69 Avenue de la Pépinière,,,,59320
-183 Avenue du Général Leclerc Hautmont,,,,183 Avenue du Général Leclerc,,,,59330
-183 Avenue du Général Leclerc 59330,,,,183 Avenue du Général Leclerc,,,Hautmont,
-183 Avenue du Général Leclerc,3.910328,50.243280,,183 Avenue du Général Leclerc,,,,59330
-138 Rue de la Croix Haynecourt,,,,138 Rue de la Croix,,,,59268
-138 Rue de la Croix 59268,,,,138 Rue de la Croix,,,Haynecourt,
-138 Rue de la Croix,3.162923,50.212839,,138 Rue de la Croix,,,,59268
-34 Avenue Masson Beau Hazebrouck,,,,34 Avenue Masson Beau,,,,59190
-34 Avenue Masson Beau 59190,,,,34 Avenue Masson Beau,,,Hazebrouck,
-34 Avenue Masson Beau,2.537314,50.727763,,34 Avenue Masson Beau,,,,59190
-35T Rue Briet Hem,,,,35 TER Rue Briet,,,,59510
-35T Rue Briet 59510,,,,35 TER Rue Briet,,,Hem,
-35T Rue Briet,3.190776,50.669223,,35 TER Rue Briet,,,,59510
-35T Rue du Trié Hem,,,,35T Rue du Trié,,,,59510
-35T Rue du Trié 59510,,,,35T Rue du Trié,,,Hem,
-35T Rue du Trié,3.170736,50.662216,,35T Rue du Trié,,,,59510
-435 Rue de la Rosière Herrin,,,,435 Rue de la Rosière,,,,59147
-435 Rue de la Rosière 59147,,,,435 Rue de la Rosière,,,Herrin,
-435 Rue de la Rosière,2.965071,50.546279,,435 Rue de la Rosière,,,,59147
-60 Rue Paul Lafargue Hornaing,,,,60 Rue Paul Lafargue,,,,59171
-60 Rue Paul Lafargue 59171,,,,60 Rue Paul Lafargue,,,Hornaing,
-60 Rue Paul Lafargue,3.340594,50.368279,,60 Rue Paul Lafargue,,,,59171
-6 Allée des Tilleuls Houplines,,,,6 Allée des Tilleuls,,,,59116
-6 Allée des Tilleuls 59116,,,,6 Allée des Tilleuls,,,Houplines,
-6 Allée des Tilleuls,2.915761,50.699086,,6 Allée des Tilleuls,,,,59116
-184 Rue Auguste-Marchal Jeumont,,,,184 Rue Auguste-Marchal,,,,59460
-184 Rue Auguste-Marchal 59460,,,,184 Rue Auguste-Marchal,,,Jeumont,
-184 Rue Auguste-Marchal,4.089842,50.294301,,184 Rue Auguste-Marchal,,,,59460
-60 Rue des Clématites Lallaing,,,,60 Rue des Clématites,,,,59167
-60 Rue des Clématites 59167,,,,60 Rue des Clématites,,,Lallaing,
-60 Rue des Clématites,3.158504,50.385744,,60 Rue des Clématites,,,,59167
-58 Rue Georges Boidin Lambersart,,,,58 Rue Georges Boidin,,,,59130
-58 Rue Georges Boidin 59130,,,,58 Rue Georges Boidin,,,Lambersart,
-58 Rue Georges Boidin,3.025622,50.641394,,58 Rue Georges Boidin,,,,59130
-1T Rue de Verlinghem Lambersart,,,,1 ter Rue de Verlinghem,,,,59130
-1T Rue de Verlinghem 59130,,,,1 ter Rue de Verlinghem,,,Lambersart,
-1T Rue de Verlinghem,3.024410,50.653979,,1 ter Rue de Verlinghem,,,,59130
-4 Rue de Tournai Lannoy,,,,4 Rue de Tournai,,,,59390
-4 Rue de Tournai 59390,,,,4 Rue de Tournai,,,Lannoy,
-4 Rue de Tournai,3.211316,50.666924,2,4 Rue de Tournai,,,,59390
-105 Rue du Maréchal Leclerc Leers,,,,105 Rue du Maréchal Leclerc,,,,59115
-105 Rue du Maréchal Leclerc 59115,,,,105 Rue du Maréchal Leclerc,,,Leers,
-105 Rue du Maréchal Leclerc,3.224415,50.685248,,105 Rue du Maréchal Leclerc,,,,59115
-22 Rue d'Iena Lesquin,,,,22 Rue d'Iena,,,,59810
-22 Rue d'Iena 59810,,,,22 Rue d'Iena,,,Lesquin,
-22 Rue d'Iena,3.110028,50.587426,3,22 Rue d'Iena,,,,59810
-41 Rue de Beaux-Monts Liessies,,,,41 Rue des Beaux-Monts,,,,59740
-41 Rue de Beaux-Monts 59740,,,,41 Rue des Beaux-Monts,,,Liessies,
-41 Rue de Beaux-Monts,4.082586,50.124005,,41 Rue des Beaux-Monts,,,,59740
-119 Rue Barthélémy Delespaul Lille,,,,119 Rue Barthélémy Delespaul,,,,59000
-119 Rue Barthélémy Delespaul 59000,,,,119 Rue Barthélémy Delespaul,,,Lille,
-119 Rue Barthélémy Delespaul,3.065487,50.624199,,119 Rue Barthélémy Delespaul,,,,59000
-27 Rue du Chaufour Lille,,,,27 Rue du Chaufour,,,,59000
-27 Rue du Chaufour 59000,,,,27 Rue du Chaufour,,,Lille,
-27 Rue du Chaufour,3.048511,50.625807,,27 Rue du Chaufour,,,,59000
-54 Boulevard de l'Épine Lille,,,,54 Boulevard de l'Épine,,,,59260
-54 Boulevard de l'Épine 59260,,,,54 Boulevard de l'Épine,,,Lille,
-54 Boulevard de l'Épine,3.106904,50.620387,,54 Boulevard de l'Épine,,,,59260
-15 Rue Gustave Nadaud Lille,,,,15 Rue Gustave Nadaud,,,,59000
-15 Rue Gustave Nadaud 59000,,,,15 Rue Gustave Nadaud,,,Lille,
-15 Rue Gustave Nadaud,3.045269,50.613480,,15 Rue Gustave Nadaud,,,,59000
-37 Rue de Lens Lille,,,,37 Rue de Lens,,,,59000
-37 Rue de Lens 59000,,,,37 Rue de Lens,,,Lille,
-37 Rue de Lens,3.062420,50.624967,,37 Rue de Lens,,,,59000
-14 Rue des Modeleurs Lille,,,,14 Rue des Modeleurs,,,,59260
-14 Rue des Modeleurs 59260,,,,14 Rue des Modeleurs,,,Lille,
-14 Rue des Modeleurs,3.103481,50.626239,,14 Rue des Modeleurs,,,,59260
-41 Rue du Professeur Langevin Lille,,,,41 Rue du Professeur Langevin,,,,59000
-41 Rue du Professeur Langevin 59000,,,,41 Rue du Professeur Langevin,,,Lille,
-41 Rue du Professeur Langevin,3.087164,50.617687,,41 Rue du Professeur Langevin,,,,59000
-25 Rue de Tourville Lille,,,,25 Rue de Tourville,,,,59000
-25 Rue de Tourville 59000,,,,25 Rue de Tourville,,,Lille,
-25 Rue de Tourville,3.026860,50.631026,,25 Rue de Tourville,,,,59000
-5 Rue François J Deroullers Lille,,,,5 Rue François Joseph Deroullers,,,,59160
-5 Rue François J Deroullers 59160,,,,5 Rue François Joseph Deroullers,,,Lille,
-5 Rue François J Deroullers,2.981528,50.647078,,5 Rue François Joseph Deroullers,,,,59160
-57 Cité Bacquet Lille,,,,57 Cité Bacquet,,,,59260
-57 Cité Bacquet 59260,,,,57 Cité Bacquet,,,Lille,
-57 Cité Bacquet,3.102247,50.634071,,57 Cité Bacquet,,,,59260
-40 Rue de Pont-sur-Sambre La Longueville,,,,40 Rue de Pont-sur-Sambre,,,,59570
-40 Rue de Pont-sur-Sambre 59570,,,,40 Rue de Pont-sur-Sambre,,,La Longueville,
-40 Rue de Pont-sur-Sambre,3.855835,50.279000,,40 Rue de Pont-sur-Sambre,,,,59570
-157 Rue Georges Clemenceau Loos,,,,157 Rue Georges Clemenceau,,,,59120
-157 Rue Georges Clemenceau 59120,,,,157 Rue Georges Clemenceau,,,Loos,
-157 Rue Georges Clemenceau,3.010221,50.615663,,157 Rue Georges Clemenceau,,,,59120
-14BIS Ruelle de la Frête Louvignies-Quesnoy,,,,14 BIS Ruelle de la Frête,,,,59530
-14BIS Ruelle de la Frête 59530,,,,14 BIS Ruelle de la Frête,,,Louvignies-Quesnoy,
-14BIS Ruelle de la Frête,3.638996,50.222443,,14 BIS Ruelle de la Frête,,,,59530
-54 Rue Henri Ghesquière Lys-lez-Lannoy,,,,54 Rue Henri Ghesquière,,,,59390
-54 Rue Henri Ghesquière 59390,,,,54 Rue Henri Ghesquière,,,Lys-lez-Lannoy,
-54 Rue Henri Ghesquière,3.207610,50.672364,2,54 Rue Henri Ghesquière,,,,59390
-35 Rue Jeanne d'Arc La Madeleine,,,,35 Rue Jeanne d'Arc,,,,59110
-35 Rue Jeanne d'Arc 59110,,,,35 Rue Jeanne d'Arc,,,La Madeleine,
-35 Rue Jeanne d'Arc,3.067200,50.659361,5,35 Rue Jeanne d'Arc,,,,59110
-2 Rue de Beaurevoir Malincourt,,,,2 Rue de Beaurevoir,,,,59127
-2 Rue de Beaurevoir 59127,,,,2 Rue de Beaurevoir,,,Malincourt,
-2 Rue de Beaurevoir,3.326748,50.045848,,2 Rue de Beaurevoir,,,,59127
-17 Rue des Châtaigniers Marcq-en-Barœul,,,,17 Rue des Châtaigniers,,,,59700
-17 Rue des Châtaigniers 59700,,,,17 Rue des Châtaigniers,,,Marcq-en-Barœul,
-17 Rue des Châtaigniers,3.099402,50.683486,,17 Rue des Châtaigniers,,,,59700
-16 Rue Marc Sangnier Marcq-en-Barœul,,,,16 Rue Marc Sangnier,,,,59700
-16 Rue Marc Sangnier 59700,,,,16 Rue Marc Sangnier,,,Marcq-en-Barœul,
-16 Rue Marc Sangnier,3.098585,50.673768,3,16 Rue Marc Sangnier,,,,59700
-3 Rue d'Artres Maresches,,,,3 Rue d'Artres,,,,59990
-3 Rue d'Artres 59990,,,,3 Rue d'Artres,,,Maresches,
-3 Rue d'Artres,3.574746,50.293586,2,3 Rue d'Artres,,,,59990
-6 Rue des Tulipes Marly,,,,6 Rue des Tulipes,,,,59770
-6 Rue des Tulipes 59770,,,,6 Rue des Tulipes,,,Marly,
-6 Rue des Tulipes,3.546305,50.343249,,6 Rue des Tulipes,,,,59770
-19 Rue Saint-Venant Marquette-lez-Lille,,,,19 Rue Saint-Venant,,,,59520
-19 Rue Saint-Venant 59520,,,,19 Rue Saint-Venant,,,Marquette-lez-Lille,
-19 Rue Saint-Venant,3.053130,50.670610,,19 Rue Saint-Venant,,,,59520
-12 Rue Charles Grivilers Mastaing,,,,12 Rue Charles Grivilers,,,,59172
-12 Rue Charles Grivilers 59172,,,,12 Rue Charles Grivilers,,,Mastaing,
-12 Rue Charles Grivilers,3.309081,50.305725,,12 Rue Charles Grivilers,,,,59172
-141 Boulevard Jean-de-la-Fontaine Maubeuge,,,,141 Boulevard Jean-de-la-Fontaine,,,,59600
-141 Boulevard Jean-de-la-Fontaine 59600,,,,141 Boulevard Jean-de-la-Fontaine,,,Maubeuge,
-141 Boulevard Jean-de-la-Fontaine,3.965613,50.294906,,141 Boulevard Jean-de-la-Fontaine,,,,59600
-4 Rue d'Honnechy Maurois,,,,4 Rue d'Honnechy,,,,59980
-4 Rue d'Honnechy 59980,,,,4 Rue d'Honnechy,,,Maurois,
-4 Rue d'Honnechy,3.468269,50.073082,,4 Rue d'Honnechy,,,,59980
-19 Allée des Peupliers Merville,,,,19 Allée des Peupliers,,,,59660
-19 Allée des Peupliers 59660,,,,19 Allée des Peupliers,,,Merville,
-19 Allée des Peupliers,2.632940,50.639541,,19 Allée des Peupliers,,,,59660
-160 Rue du Becquerel Mons-en-Barœul,,,,160 Rue du Becquerel,,,,59370
-160 Rue du Becquerel 59370,,,,160 Rue du Becquerel,,,Mons-en-Barœul,
-160 Rue du Becquerel,3.099317,50.635803,,160 Rue du Becquerel,,,,59370
-1 Rue de la Feuillée Montay,,,,1 Rue de la Feuillée,,,,59360
-1 Rue de la Feuillée 59360,,,,1 Rue de la Feuillée,,,Montay,
-1 Rue de la Feuillée,3.539689,50.118812,,1 Rue de la Feuillée,,,,59360
-361 Rue du Congo Mouvaux,,,,361 Rue du Congo,,,,59420
-361 Rue du Congo 59420,,,,361 Rue du Congo,,,Mouvaux,
-361 Rue du Congo,3.153066,50.703059,,361 Rue du Congo,,,,59420
-16 Rue Montigny Neuf-Berquin,,,,16 Rue Montigny,,,,59940
-16 Rue Montigny 59940,,,,16 Rue Montigny,,,Neuf-Berquin,
-16 Rue Montigny,2.677298,50.660866,,16 Rue Montigny,,,,59940
-96 Rue du Général de Gaulle La Neuville,,,,96 Rue du Général de Gaulle,,,,59239
-96 Rue du Général de Gaulle 59239,,,,96 Rue du Général de Gaulle,,,La Neuville,
-96 Rue du Général de Gaulle,3.047970,50.491887,2,96 Rue du Général de Gaulle,,,,59239
-94 Avenue des Lilas Nieppe,,,,94 Avenue des Lilas,,,,59850
-94 Avenue des Lilas 59850,,,,94 Avenue des Lilas,,,Nieppe,
-94 Avenue des Lilas,2.845615,50.700406,,94 Avenue des Lilas,,,,59850
-185 Rue de la Haute Ville Odomez,,,,185 Rue de la Haute Ville,,,,59970
-185 Rue de la Haute Ville 59970,,,,185 Rue de la Haute Ville,,,Odomez,
-185 Rue de la Haute Ville,3.525402,50.450805,,185 Rue de la Haute Ville,,,,59970
-104 Rue Claude Jean Orchies,,,,104 Rue Claude Jean,,,,59310
-104 Rue Claude Jean 59310,,,,104 Rue Claude Jean,,,Orchies,
-104 Rue Claude Jean,3.251419,50.468616,,104 Rue Claude Jean,,,,59310
-609 Route de Wormhout Oudezeele,,,,609 Route de Wormhout,,,,59670
-609 Route de Wormhout 59670,,,,609 Route de Wormhout,,,Oudezeele,
-609 Route de Wormhout,2.506480,50.851650,,609 Route de Wormhout,,,,59670
-18 Rue Pasteur Pérenchies,,,,18 Rue Pasteur,,,,59840
-18 Rue Pasteur 59840,,,,18 Rue Pasteur,,,Pérenchies,
-18 Rue Pasteur,2.970613,50.667235,2,18 Rue Pasteur,,,,59840
-1 Chemin des Moulins Vc 2 Pitgam,,,,1 Chemin des Moulins Vc 2,,,,59284
-1 Chemin des Moulins Vc 2 59284,,,,1 Chemin des Moulins Vc 2,,,Pitgam,
-1 Chemin des Moulins Vc 2,2.336700,50.933208,,1 Chemin des Moulins Vc 2,,,,59284
-13 Clos des Pommiers Préseau,,,,13 Clos des Pommiers,,,,59990
-13 Clos des Pommiers 59990,,,,13 Clos des Pommiers,,,Préseau,
-13 Clos des Pommiers,3.571570,50.309031,,13 Clos des Pommiers,,,,59990
-36 Route de Wylder Quaëdypre,,,,36 Route de Wylder,,,,59380
-36 Route de Wylder 59380,,,,36 Route de Wylder,,,Quaëdypre,
-36 Route de Wylder,2.456855,50.933267,,36 Route de Wylder,,,,59380
-45 Rue du Maréchal Foch Quesnoy-sur-Deûle,,,,45 Rue du Maréchal Foch,,,,59890
-45 Rue du Maréchal Foch 59890,,,,45 Rue du Maréchal Foch,,,Quesnoy-sur-Deûle,
-45 Rue du Maréchal Foch,3.003627,50.711636,2,45 Rue du Maréchal Foch,,,,59890
-56B Ruelle Patelette Râches,,,,56 BIS Ruelle Patelette,,,,59194
-56B Ruelle Patelette 59194,,,,56 BIS Ruelle Patelette,,,Râches,
-56B Ruelle Patelette,3.133180,50.411388,,56 BIS Ruelle Patelette,,,,59194
-37 Rue Henri Barbusse Raismes,,,,37 Rue Henri Barbusse,,,,59590
-37 Rue Henri Barbusse 59590,,,,37 Rue Henri Barbusse,,,Raismes,
-37 Rue Henri Barbusse,3.496558,50.384737,,37 Rue Henri Barbusse,,,,59590
-12 Rue du Château Renescure,,,,12 Rue du Château,,,,59173
-12 Rue du Château 59173,,,,12 Rue du Château,,,Renescure,
-12 Rue du Château,2.367303,50.728072,,12 Rue du Château,,,,59173
-14 Rue André Malraux Ronchin,,,,14 Rue André Malraux,,,,59790
-14 Rue André Malraux 59790,,,,14 Rue André Malraux,,,Ronchin,
-14 Rue André Malraux,3.085307,50.606800,,14 Rue André Malraux,,,,59790
-6 Rue de l'Abbé Lemire Roncq,,,,6 Rue de l'Abbé Lemire,,,,59223
-6 Rue de l'Abbé Lemire 59223,,,,6 Rue de l'Abbé Lemire,,,Roncq,
-6 Rue de l'Abbé Lemire,3.130111,50.734933,2,6 Rue de l'Abbé Lemire,,,,59223
-10 Rue Arthur Rimbaud Roost-Warendin,,,,10 Rue Arthur Rimbaud,,,,59286
-10 Rue Arthur Rimbaud 59286,,,,10 Rue Arthur Rimbaud,,,Roost-Warendin,
-10 Rue Arthur Rimbaud,3.113307,50.418723,2,10 Rue Arthur Rimbaud,,,,59286
-16 Boulevard de Beaurepaire Roubaix,,,,16 Boulevard de Beaurepaire,,,,59100
-16 Boulevard de Beaurepaire 59100,,,,16 Boulevard de Beaurepaire,,,Roubaix,
-16 Boulevard de Beaurepaire,3.191057,50.691005,,16 Boulevard de Beaurepaire,,,,59100
-9 Rue Desaix Roubaix,,,,9 Rue Desaix,,,,59100
-9 Rue Desaix 59100,,,,9 Rue Desaix,,,Roubaix,
-9 Rue Desaix,3.192618,50.688999,,9 Rue Desaix,,,,59100
-294 Rue Ingres Roubaix,,,,294 Rue Ingres,,,,59100
-294 Rue Ingres 59100,,,,294 Rue Ingres,,,Roubaix,
-294 Rue Ingres,3.186472,50.674927,,294 Rue Ingres,,,,59100
-16 Rue Marengo Roubaix,,,,16 Rue Marengo,,,,59100
-16 Rue Marengo 59100,,,,16 Rue Marengo,,,Roubaix,
-16 Rue Marengo,3.174831,50.704305,,16 Rue Marengo,,,,59100
-38 Boulevard de la République Roubaix,,,,38 Boulevard de la République,,,,59100
-38 Boulevard de la République 59100,,,,38 Boulevard de la République,,,Roubaix,
-38 Boulevard de la République,3.161079,50.701551,,38 Boulevard de la République,,,,59100
-46 Rue du Grand-Fort Rousies,,,,46 Rue du Grand-Fort,,,,59131
-46 Rue du Grand-Fort 59131,,,,46 Rue du Grand-Fort,,,Rousies,
-46 Rue du Grand-Fort,3.977902,50.266603,,46 Rue du Grand-Fort,,,,59131
-28 Rue Pasteur Sainghin-en-Mélantois,,,,28 Rue Pasteur,,,,59262
-28 Rue Pasteur 59262,,,,28 Rue Pasteur,,,Sainghin-en-Mélantois,
-28 Rue Pasteur,3.177454,50.589714,,28 Rue Pasteur,,,,59262
-158 Rue de la Collinière Saint-Amand-les-Eaux,,,,158 Rue de la Collinière,,,,59230
-158 Rue de la Collinière 59230,,,,158 Rue de la Collinière,,,Saint-Amand-les-Eaux,
-158 Rue de la Collinière,3.430691,50.436078,,158 Rue de la Collinière,,,,59230
-25 Rue de Thumelart Saint-Amand-les-Eaux,,,,25 Rue de Thumelart,,,,59230
-25 Rue de Thumelart 59230,,,,25 Rue de Thumelart,,,Saint-Amand-les-Eaux,
-25 Rue de Thumelart,3.442172,50.446925,,25 Rue de Thumelart,,,,59230
-9 Rue Victor Hugo Saint-Aubert,,,,9 Rue Victor Hugo,,,,59188
-9 Rue Victor Hugo 59188,,,,9 Rue Victor Hugo,,,Saint-Aubert,
-9 Rue Victor Hugo,3.420311,50.206752,,9 Rue Victor Hugo,,,,59188
-32A Rue Charles Giraud Saint-Saulve,,,,32A Rue Charles Giraud,,,,59880
-32A Rue Charles Giraud 59880,,,,32A Rue Charles Giraud,,,Saint-Saulve,
-32A Rue Charles Giraud,3.557418,50.373649,,32A Rue Charles Giraud,,,,59880
-12 Rue Emile Dubois Salomé,,,,12 Rue Emile Dubois,,,,59496
-12 Rue Emile Dubois 59496,,,,12 Rue Emile Dubois,,,Salomé,
-12 Rue Emile Dubois,2.848427,50.534044,,12 Rue Emile Dubois,,,,59496
-38 Rue Arthur Breucq Saultain,,,,38 Rue Arthur Breucq,,,,59990
-38 Rue Arthur Breucq 59990,,,,38 Rue Arthur Breucq,,,Saultain,
-38 Rue Arthur Breucq,3.572094,50.333981,,38 Rue Arthur Breucq,,,,59990
-32 Rue de la Naviette Seclin,,,,32 Rue de la Naviette,,,,59113
-32 Rue de la Naviette 59113,,,,32 Rue de la Naviette,,,Seclin,
-32 Rue de la Naviette,3.013429,50.541161,,32 Rue de la Naviette,,,,59113
-40 Rue Alcide Moché Sin-le-Noble,,,,40 Rue Alcide Moché,,,,59450
-40 Rue Alcide Moché 59450,,,,40 Rue Alcide Moché,,,Sin-le-Noble,
-40 Rue Alcide Moché,3.114885,50.366988,,40 Rue Alcide Moché,,,,59450
-12 Résidence Alexia Iv Sin-le-Noble,,,,12 Résidence Alexia Iv,,,,59450
-12 Résidence Alexia Iv 59450,,,,12 Résidence Alexia Iv,,,Sin-le-Noble,
-12 Résidence Alexia Iv,3.099176,50.345457,,12 Résidence Alexia Iv,,,,59450
-19 Rue de Fayence Somain,,,,19 Rue de Fayence,,,,59490
-19 Rue de Fayence 59490,,,,19 Rue de Fayence,,,Somain,
-19 Rue de Fayence,3.268381,50.372871,,19 Rue de Fayence,,,,59490
-7 Chemin de Champs Steene,,,,7 Chemin de Champs,,,,59380
-7 Chemin de Champs 59380,,,,7 Chemin de Champs,,,Steene,
-7 Chemin de Champs,2.371346,50.950241,,7 Chemin de Champs,,,,59380
-7 Rue Jean Jaurès Templemars,,,,7 Rue Jean Jaurès,,,,59175
-7 Rue Jean Jaurès 59175,,,,7 Rue Jean Jaurès,,,Templemars,
-7 Rue Jean Jaurès,3.055701,50.568724,,7 Rue Jean Jaurès,,,,59175
-188 Rue des Pierres Téteghem,,,,188 Rue des Pierres,,,,59229
-188 Rue des Pierres 59229,,,,188 Rue des Pierres,,,Téteghem-Coudekerque-Village,
-188 Rue des Pierres,2.454387,51.007269,,188 Rue des Pierres,,,,59229
-16 Rue des Azalées Toufflers,,,,16 Rue des Azalées,,,,59390
-16 Rue des Azalées 59390,,,,16 Rue des Azalées,,,Toufflers,
-16 Rue des Azalées,3.225370,50.664541,,16 Rue des Azalées,,,,59390
-379 Rue du Blanc Seau Tourcoing,,,,379 Rue du Blanc Seau,,,,59200
-379 Rue du Blanc Seau 59200,,,,379 Rue du Blanc Seau,,,Tourcoing,
-379 Rue du Blanc Seau,3.152676,50.700555,,379 Rue du Blanc Seau,,,,59200
-20 Rue de Creil Tourcoing,,,,20 Rue de Creil,,,,59200
-20 Rue de Creil 59200,,,,20 Rue de Creil,,,Tourcoing,
-20 Rue de Creil,3.176990,50.725963,,20 Rue de Creil,,,,59200
-37 Rue du Général Douay Tourcoing,,,,37 Rue du Général Douay,,,,59200
-37 Rue du Général Douay 59200,,,,37 Rue du Général Douay,,,Tourcoing,
-37 Rue du Général Douay,3.144455,50.727136,,37 Rue du Général Douay,,,,59200
-103 Rue de Magenta Tourcoing,,,,103 Rue de Magenta,,,,59200
-103 Rue de Magenta 59200,,,,103 Rue de Magenta,,,Tourcoing,
-103 Rue de Magenta,3.160952,50.708694,,103 Rue de Magenta,,,,59200
-143 Chaussée Pierre Curie Tourcoing,,,,143 Chaussée Pierre Curie,,,,59200
-143 Chaussée Pierre Curie 59200,,,,143 Chaussée Pierre Curie,,,Tourcoing,
-143 Chaussée Pierre Curie,3.179949,50.734156,,143 Chaussée Pierre Curie,,,,59200
-7 Place de la Victoire Tourcoing,,,,7 Place de la Victoire,,,,59200
-7 Place de la Victoire 59200,,,,7 Place de la Victoire,,,Tourcoing,
-7 Place de la Victoire,3.157999,50.718157,,7 Place de la Victoire,,,,59200
-8 Résidence J Dupont R d'Peupliers Trith-Saint-Léger,,,,8 Résidence J Dupont R d'Peupliers,,,,59125
-8 Résidence J Dupont R d'Peupliers 59125,,,,8 Résidence J Dupont R d'Peupliers,,,Trith-Saint-Léger,
-8 Résidence J Dupont R d'Peupliers,3.508119,50.338944,,8 Résidence J Dupont R d'Peupliers,,,,59125
-5 Avenue de Denain Valenciennes,,,,5 Avenue de Denain,,,,59300
-5 Avenue de Denain 59300,,,,5 Avenue de Denain,,,Valenciennes,
-5 Avenue de Denain,3.503930,50.356503,,5 Avenue de Denain,,,,59300
-11 Avenue du Maréchal Leclerc Valenciennes,,,,11 Avenue du Maréchal Leclerc,,,,59300
-11 Avenue du Maréchal Leclerc 59300,,,,11 Avenue du Maréchal Leclerc,,,Valenciennes,
-11 Avenue du Maréchal Leclerc,3.519411,50.363943,,11 Avenue du Maréchal Leclerc,,,,59300
-47 Clos des Tonneliers Le Vignoble Valenciennes,,,,47 Clos des Tonneliers Le Vignoble,,,,59300
-47 Clos des Tonneliers Le Vignoble 59300,,,,47 Clos des Tonneliers Le Vignoble,,,Valenciennes,
-47 Clos des Tonneliers Le Vignoble,3.503491,50.350439,,47 Clos des Tonneliers Le Vignoble,,,,59300
-289 Rue du Pain Sec Vieux-Berquin,,,,289 Rue du Pain Sec,,,,59232
-289 Rue du Pain Sec 59232,,,,289 Rue du Pain Sec,,,Vieux-Berquin,
-289 Rue du Pain Sec,2.591522,50.709381,,289 Rue du Pain Sec,,,,59232
-2 Rue Aimable Liénard Vieux-Reng,,,,2 Rue Aimable Liénard,,,,59600
-2 Rue Aimable Liénard 59600,,,,2 Rue Aimable Liénard,,,Vieux-Reng,
-2 Rue Aimable Liénard,4.066714,50.326416,,2 Rue Aimable Liénard,,,,59600
-21 Voie Communale Groupement du Montsorel Wahagnies,,,,21 Voie Communale Groupement du Montsorel,,,,59261
-21 Voie Communale Groupement du Montsorel 59261,,,,21 Voie Communale Groupement du Montsorel,,,Wahagnies,
-21 Voie Communale Groupement du Montsorel,3.037608,50.479890,,21 Voie Communale Groupement du Montsorel,,,,59261
-169 Rue de l'Agrippin Wambrechies,,,,169 Rue de l'Agrippin,,,,59118
-169 Rue de l'Agrippin 59118,,,,169 Rue de l'Agrippin,,,Wambrechies,
-169 Rue de l'Agrippin,3.045818,50.686316,,169 Rue de l'Agrippin,,,,59118
-38 Rue Firmaine Warlaing,,,,38 Rue Firmaine,,,,59870
-38 Rue Firmaine 59870,,,,38 Rue Firmaine,,,Warlaing,
-38 Rue Firmaine,3.315390,50.411146,,38 Rue Firmaine,,,,59870
-54 Avenue de la Marne Wasquehal,,,,54 Avenue de la Marne,,,,59290
-54 Avenue de la Marne 59290,,,,54 Avenue de la Marne,,,Wasquehal,
-54 Avenue de la Marne,3.126854,50.688405,,54 Avenue de la Marne,,,,59290
-2 Rue Marcel Fertein Wattignies,,,,2 Rue Marcel Fertein,,,,59139
-2 Rue Marcel Fertein 59139,,,,2 Rue Marcel Fertein,,,Wattignies,
-2 Rue Marcel Fertein,3.050171,50.600171,,2 Rue Marcel Fertein,,,,59139
-39 Rue Couteau Wattrelos,,,,39 Rue Couteau,,,,59150
-39 Rue Couteau 59150,,,,39 Rue Couteau,,,Wattrelos,
-39 Rue Couteau,3.201617,50.697077,,39 Rue Couteau,,,,59150
-16 Square Léon Marlot Wattrelos,,,,16 Square Léon Marlot,,,,59150
-16 Square Léon Marlot 59150,,,,16 Square Léon Marlot,,,Wattrelos,
-16 Square Léon Marlot,3.205423,50.699003,,16 Square Léon Marlot,,,,59150
-432BIS Rue du Sapin Vert Wattrelos,,,,432BIS Rue du Sapin Vert,,,,59150
-432BIS Rue du Sapin Vert 59150,,,,432BIS Rue du Sapin Vert,,,Wattrelos,
-432BIS Rue du Sapin Vert,3.184997,50.713501,,432BIS Rue du Sapin Vert,,,,59150
-55 Rue Raymond Poincaré Wavrin,,,,55 Rue Raymond Poincaré,,,,59136
-55 Rue Raymond Poincaré 59136,,,,55 Rue Raymond Poincaré,,,Wavrin,
-55 Rue Raymond Poincaré,2.946462,50.571316,,55 Rue Raymond Poincaré,,,,59136
-54 Rue Théodore Brasme Wicres,,,,54 Rue Théodore Brasme,,,,59134
-54 Rue Théodore Brasme 59134,,,,54 Rue Théodore Brasme,,,Wicres,
-54 Rue Théodore Brasme,2.865642,50.570858,,54 Rue Théodore Brasme,,,,59134
-434 Route de Steenvoorde Wormhout,,,,434 Route de Steenvoorde,,,,59470
-434 Route de Steenvoorde 59470,,,,434 Route de Steenvoorde,,,Wormhout,
-434 Route de Steenvoorde,2.473476,50.879144,,434 Route de Steenvoorde,,,,59470
-300 Rue d'Avesnes Agnez-lès-Duisans,,,,300 Rue d'Avesnes,,,,62161
-300 Rue d'Avesnes 62161,,,,300 Rue d'Avesnes,,,Agnez-lès-Duisans,
-300 Rue d'Avesnes,2.650494,50.313989,,300 Rue d'Avesnes,,,,62161
-74 Rue Henri Béthouart Airon-Saint-Vaast,,,,74 Rue Henri Béthouart,,,,62180
-74 Rue Henri Béthouart 62180,,,,74 Rue Henri Béthouart,,,Airon-Saint-Vaast,
-74 Rue Henri Béthouart,1.660878,50.432106,,74 Rue Henri Béthouart,,,,62180
-6 Chaussée Brunehaut Amettes,,,,6 Chaussée Brunehaut,,,,62260
-6 Chaussée Brunehaut 62260,,,,6 Chaussée Brunehaut,,,Amettes,
-6 Chaussée Brunehaut,2.406646,50.532101,,6 Chaussée Brunehaut,,,,62260
-9 Rue des Hortensias Annezin,,,,9 Rue des Hortensias,,,,62232
-9 Rue des Hortensias 62232,,,,9 Rue des Hortensias,,,Annezin,
-9 Rue des Hortensias,2.613845,50.537138,,9 Rue des Hortensias,,,,62232
-32 Rue d'Oppy Arleux-en-Gohelle,,,,32 Rue d'Oppy,,,,62580
-32 Rue d'Oppy 62580,,,,32 Rue d'Oppy,,,Arleux-en-Gohelle,
-32 Rue d'Oppy,2.873808,50.361775,,32 Rue d'Oppy,,,,62580
-9 Rue du Bloc Arras,,,,9 Rue du Bloc,,,,62000
-9 Rue du Bloc 62000,,,,9 Rue du Bloc,,,Arras,
-9 Rue du Bloc,2.772323,50.293568,,9 Rue du Bloc,,,,62000
-26 Avenue Jean Jaurès Arras,,,,26 Avenue Jean Jaurès,,,,62000
-26 Avenue Jean Jaurès 62000,,,,26 Avenue Jean Jaurès,,,Arras,
-26 Avenue Jean Jaurès,2.779460,50.279490,,26 Avenue Jean Jaurès,,,,62000
-4 Impasse Zéphyr Thomas Arras,,,,4 Impasse Zéphyr Thomas,,,,62000
-4 Impasse Zéphyr Thomas 62000,,,,4 Impasse Zéphyr Thomas,,,Arras,
-4 Impasse Zéphyr Thomas,2.748897,50.292704,,4 Impasse Zéphyr Thomas,,,,62000
-22 Rue du Paradis Auchel,,,,22 Rue du Paradis,,,,62260
-22 Rue du Paradis 62260,,,,22 Rue du Paradis,,,Auchel,
-22 Rue du Paradis,2.482407,50.512785,,22 Rue du Paradis,,,,62260
-15 Rue Accary Audresselles,,,,15 Rue Accary,,,,62164
-15 Rue Accary 62164,,,,15 Rue Accary,,,Audresselles,
-15 Rue Accary,1.592125,50.822883,,15 Rue Accary,,,,62164
-14 Rue Boussingault Avion,,,,14 Rue Boussingault,,,,62210
-14 Rue Boussingault 62210,,,,14 Rue Boussingault,,,Avion,
-14 Rue Boussingault,2.835133,50.408002,,14 Rue Boussingault,,,,62210
-3BIS Rue de Moyenneville Ayette,,,,3BIS Rue de Moyenneville,,,,62116
-3BIS Rue de Moyenneville 62116,,,,3BIS Rue de Moyenneville,,,Ayette,
-3BIS Rue de Moyenneville,2.736687,50.176547,,3BIS Rue de Moyenneville,,,,62116
-45 Rue d'Houdain Barlin,,,,45 Rue d'Houdain,,,,62620
-45 Rue d'Houdain 62620,,,,45 Rue d'Houdain,,,Barlin,
-45 Rue d'Houdain,2.610775,50.459324,,45 Rue d'Houdain,,,,62620
-15 Rue Simone Jagu Beaurains,,,,15 Rue Simone Jagu,,,,62217
-15 Rue Simone Jagu 62217,,,,15 Rue Simone Jagu,,,Beaurains,
-15 Rue Simone Jagu,2.782739,50.267254,,15 Rue Simone Jagu,,,,62217
-4 Rue de la Marine Berck,,,,4 Rue de la Marine,,,,62600
-4 Rue de la Marine 62600,,,,4 Rue de la Marine,,,Berck,
-4 Rue de la Marine,1.583967,50.407390,,4 Rue de la Marine,,,,62600
-307 RUE DU BEAU MARAIS Béthune,,,,307 RUE DU BEAU MARAIS,,,,62400
-307 RUE DU BEAU MARAIS 62400,,,,307 RUE DU BEAU MARAIS,,,Béthune,
-307 RUE DU BEAU MARAIS,2.649996,50.532409,,307 RUE DU BEAU MARAIS,,,,62400
-2 Rue Parmentier Béthune,,,,2 Rue Parmentier,,,,62400
-2 Rue Parmentier 62400,,,,2 Rue Parmentier,,,Béthune,
-2 Rue Parmentier,2.626935,50.527897,,2 Rue Parmentier,,,,62400
-155 Rue Germon Beuvry,,,,155 Rue Germon,,,,62660
-155 Rue Germon 62660,,,,155 Rue Germon,,,Beuvry,
-155 Rue Germon,2.691955,50.532343,,155 Rue Germon,,,,62660
-4 Rue Lamartine Billy-Berclau,,,,4 Rue Lamartine,,,,62138
-4 Rue Lamartine 62138,,,,4 Rue Lamartine,,,Billy-Berclau,
-4 Rue Lamartine,2.877387,50.523379,,4 Rue Lamartine,,,,62138
-31 Rue de l'Hermitage Blendecques,,,,31 Rue de l'Hermitage,,,,62575
-31 Rue de l'Hermitage 62575,,,,31 Rue de l'Hermitage,,,Blendecques,
-31 Rue de l'Hermitage,2.266427,50.712505,,31 Rue de l'Hermitage,,,,62575
-44 Rue de l'Amiral Bruix Boulogne-sur-Mer,,,,44 Rue de l'Amiral Bruix,,,,62200
-44 Rue de l'Amiral Bruix 62200,,,,44 Rue de l'Amiral Bruix,,,Boulogne-sur-Mer,
-44 Rue de l'Amiral Bruix,1.603580,50.723069,,44 Rue de l'Amiral Bruix,,,,62200
-89 Rue Faidherbe Boulogne-sur-Mer,,,,89 Rue Faidherbe,,,,62200
-89 Rue Faidherbe 62200,,,,89 Rue Faidherbe,,,Boulogne-sur-Mer,
-89 Rue Faidherbe,1.606249,50.725833,,89 Rue Faidherbe,,,,62200
-318 Boulevard Sainte-Beuve Boulogne-sur-Mer,,,,318 Boulevard Sainte-Beuve,,,,62200
-318 Boulevard Sainte-Beuve 62200,,,,318 Boulevard Sainte-Beuve,,,Boulogne-sur-Mer,
-318 Boulevard Sainte-Beuve,1.594486,50.735660,,318 Boulevard Sainte-Beuve,,,,62200
-26 Rue de Corbehem Brebières,,,,26 Rue de Corbehem,,,,62117
-26 Rue de Corbehem 62117,,,,26 Rue de Corbehem,,,Brebières,
-26 Rue de Corbehem,3.025246,50.337436,,26 Rue de Corbehem,,,,62117
-126 Rue Coquel Bruay-la-Buissière,,,,126 Rue Coquel,,,,62700
-126 Rue Coquel 62700,,,,126 Rue Coquel,,,Bruay-la-Buissière,
-126 Rue Coquel,2.543460,50.490531,,126 Rue Coquel,,,,62700
-12 Rue de Pologne Bruay-la-Buissière,,,,12 Rue de Pologne,,,,62700
-12 Rue de Pologne 62700,,,,12 Rue de Pologne,,,Bruay-la-Buissière,
-12 Rue de Pologne,2.530334,50.491633,,12 Rue de Pologne,,,,62700
-1 Rue d'Enghien Bully-les-Mines,,,,1 Rue d'Enghien,,,,62160
-1 Rue d'Enghien 62160,,,,1 Rue d'Enghien,,,Bully-les-Mines,
-1 Rue d'Enghien,2.740679,50.441568,,1 Rue d'Enghien,,,,62160
-2 Rue des Planchettes Busnes,,,,2 Rue des Planchettes,,,,62350
-2 Rue des Planchettes 62350,,,,2 Rue des Planchettes,,,Busnes,
-2 Rue des Planchettes,2.516540,50.588893,,2 Rue des Planchettes,,,,62350
-24 Rue du Château D'Eau Calais,,,,24 Rue du Château D'Eau,,,,62100
-24 Rue du Château D'Eau 62100,,,,24 Rue du Château D'Eau,,,Calais,
-24 Rue du Château D'Eau,1.851840,50.945275,,24 Rue du Château D'Eau,,,,62100
-1 Quai de la Gendarmerie Calais,,,,1 Quai de la Gendarmerie,,,,62100
-1 Quai de la Gendarmerie 62100,,,,1 Quai de la Gendarmerie,,,Calais,
-1 Quai de la Gendarmerie,1.858472,50.952986,,1 Quai de la Gendarmerie,,,,62100
-40 Rue de Malaga Calais,,,,40 Rue de Malaga,,,,62100
-40 Rue de Malaga 62100,,,,40 Rue de Malaga,,,Calais,
-40 Rue de Malaga,1.834182,50.945823,,40 Rue de Malaga,,,,62100
-34BIS Chemin de Régniers Calais,,,,34BIS Chemin de Régniers,,,,62100
-34BIS Chemin de Régniers 62100,,,,34BIS Chemin de Régniers,,,Calais,
-34BIS Chemin de Régniers,1.853723,50.934830,,34BIS Chemin de Régniers,,,,62100
-115 Rue de Camblain Calonne-Ricouart,,,,115 Rue de Camblain,,,,62470
-115 Rue de Camblain 62470,,,,115 Rue de Camblain,,,Calonne-Ricouart,
-115 Rue de Camblain,2.467224,50.497597,,115 Rue de Camblain,,,,62470
-50 Allée des Milouins Camiers,,,,50 Allée des Milouins,,,,62176
-50 Allée des Milouins 62176,,,,50 Allée des Milouins,,,Camiers,
-50 Allée des Milouins,1.598317,50.571714,,50 Allée des Milouins,,,,62176
-76 Rue Émile Zola Carvin,,,,76 Rue Émile Zola,,,,62220
-76 Rue Émile Zola 62220,,,,76 Rue Émile Zola,,,Carvin,
-76 Rue Émile Zola,2.953786,50.494631,,76 Rue Émile Zola,,,,62220
-15 Rue Laure Marelle Cauchy-à-la-Tour,,,,15 Rue Laure Marelle,,,,62260
-15 Rue Laure Marelle 62260,,,,15 Rue Laure Marelle,,,Cauchy-à-la-Tour,
-15 Rue Laure Marelle,2.456806,50.504145,,15 Rue Laure Marelle,,,,62260
-2BIS Rue de l'Église Condette,,,,2BIS Rue de l'Église,,,,62360
-2BIS Rue de l'Église 62360,,,,2BIS Rue de l'Église,,,Condette,
-2BIS Rue de l'Église,1.639961,50.653854,,2BIS Rue de l'Église,,,,62360
-118BIS Rue Principale Coulomby,,,,118BIS Rue Principale,,,,62380
-118BIS Rue Principale 62380,,,,118BIS Rue Principale,,,Coulomby,
-118BIS Rue Principale,2.011533,50.706109,,118BIS Rue Principale,,,,62380
-3 Rue des Martinets Courrières,,,,3 Rue des Martinets,,,,62710
-3 Rue des Martinets 62710,,,,3 Rue des Martinets,,,Courrières,
-3 Rue des Martinets,2.957550,50.455963,,3 Rue des Martinets,,,,62710
-496 Rue Emile Grevet Cucq,,,,496 Rue Emile Grevet,,,,62780
-496 Rue Emile Grevet 62780,,,,496 Rue Emile Grevet,,,Cucq,
-496 Rue Emile Grevet,1.626047,50.501951,,496 Rue Emile Grevet,,,,62780
-25 Rue de Verdun Dainville,,,,25 Rue de Verdun,,,,62000
-25 Rue de Verdun 62000,,,,25 Rue de Verdun,,,Dainville,
-25 Rue de Verdun,2.730205,50.280899,,25 Rue de Verdun,,,,62000
-13 Rue Ionesco Divion,,,,13 Rue Ionesco,,,,62460
-13 Rue Ionesco 62460,,,,13 Rue Ionesco,,,Divion,
-13 Rue Ionesco,2.491434,50.473712,,13 Rue Ionesco,,,,62460
-30 Rue Cuvillier Douvrin,,,,30 Rue Cuvillier,,,,62138
-30 Rue Cuvillier 62138,,,,30 Rue Cuvillier,,,Douvrin,
-30 Rue Cuvillier,2.829620,50.510804,,30 Rue Cuvillier,,,,62138
-1410 Rue de Cassel Ecques,,,,1410 Rue de Cassel,,,,62129
-1410 Rue de Cassel 62129,,,,1410 Rue de Cassel,,,Ecques,
-1410 Rue de Cassel,2.295753,50.661206,,1410 Rue de Cassel,,,,62129
-59 Rue de la Courtille Équihen-Plage,,,,59 Rue de la Courtille,,,,62224
-59 Rue de la Courtille 62224,,,,59 Rue de la Courtille,,,Équihen-Plage,
-59 Rue de la Courtille,1.575372,50.681205,,59 Rue de la Courtille,,,,62224
-1 Rue du Château d'Eau Étaples,,,,1 Rue du Château d'Eau,,,,62630
-1 Rue du Château d'Eau 62630,,,,1 Rue du Château d'Eau,,,Étaples,
-1 Rue du Château d'Eau,1.652837,50.518803,,1 Rue du Château d'Eau,,,,62630
-65 Rue d'Arras Fampoux,,,,65 Rue d'Arras,,,,62118
-65 Rue d'Arras 62118,,,,65 Rue d'Arras,,,Fampoux,
-65 Rue d'Arras,2.863444,50.301568,,65 Rue d'Arras,,,,62118
-29 Rue de la Malassise Fleurbaix,,,,29 Rue de la Malassise,,,,62840
-29 Rue de la Malassise 62840,,,,29 Rue de la Malassise,,,Fleurbaix,
-29 Rue de la Malassise,2.836445,50.652153,,29 Rue de la Malassise,,,,62840
-17 Rue Léo Lagrange Fresnicourt-le-Dolmen,,,,17 Rue Léo Lagrange,,,,62150
-17 Rue Léo Lagrange 62150,,,,17 Rue Léo Lagrange,,,Fresnicourt-le-Dolmen,
-17 Rue Léo Lagrange,2.586904,50.423836,,17 Rue Léo Lagrange,,,,62150
-33 Rue Marcel Sembat Givenchy-en-Gohelle,,,,33 Rue Marcel Sembat,,,,62580
-33 Rue Marcel Sembat 62580,,,,33 Rue Marcel Sembat,,,Givenchy-en-Gohelle,
-33 Rue Marcel Sembat,2.768739,50.394576,,33 Rue Marcel Sembat,,,,62580
-6 Rue Louis Legay Grenay,,,,6 Rue Louis Legay,,,,62160
-6 Rue Louis Legay 62160,,,,6 Rue Louis Legay,,,Grenay,
-6 Rue Louis Legay,2.743214,50.446963,,6 Rue Louis Legay,,,,62160
-14 Avenue de Verdun Guînes,,,,14 Avenue de Verdun,,,,62340
-14 Avenue de Verdun 62340,,,,14 Avenue de Verdun,,,Guînes,
-14 Avenue de Verdun,1.863325,50.865374,,14 Avenue de Verdun,,,,62340
-16 Rue de l'Église Ham-en-Artois,,,,16 Rue de l'Église,,,,62190
-16 Rue de l'Église 62190,,,,16 Rue de l'Église,,,Ham-en-Artois,
-16 Rue de l'Église,2.453457,50.589796,,16 Rue de l'Église,,,,62190
-20 Rue de Saint-Claude Harnes,,,,20 Rue de Saint-Claude,,,,62440
-20 Rue de Saint-Claude 62440,,,,20 Rue de Saint-Claude,,,Harnes,
-20 Rue de Saint-Claude,2.885522,50.443679,,20 Rue de Saint-Claude,,,,62440
-67 Rue du Docteur Laennec Hénin-Beaumont,,,,67 Rue du Docteur Laennec,,,,62110
-67 Rue du Docteur Laennec 62110,,,,67 Rue du Docteur Laennec,,,Hénin-Beaumont,
-67 Rue du Docteur Laennec,2.946247,50.430665,,67 Rue du Docteur Laennec,,,,62110
-133 Rue Mirabeau Hénin-Beaumont,,,,133 Rue Mirabeau,,,,62110
-133 Rue Mirabeau 62110,,,,133 Rue Mirabeau,,,Hénin-Beaumont,
-133 Rue Mirabeau,2.943184,50.426527,,133 Rue Mirabeau,,,,62110
-16 Rue Berthelot Hersin-Coupigny,,,,16 Rue Berthelot,,,,62530
-16 Rue Berthelot 62530,,,,16 Rue Berthelot,,,Hersin-Coupigny,
-16 Rue Berthelot,2.651906,50.454255,,16 Rue Berthelot,,,,62530
-67 Rue d'Aire Heuchin,,,,67 Rue d'Aire,,,,62134
-67 Rue d'Aire 62134,,,,67 Rue d'Aire,,,Heuchin,
-67 Rue d'Aire,2.273693,50.480533,,67 Rue d'Aire,,,,62134
-73 Rue de Vincq Houlle,,,,73 Rue de Vincq,,,,62910
-73 Rue de Vincq 62910,,,,73 Rue de Vincq,,,Houlle,
-73 Rue de Vincq,2.196549,50.809475,,73 Rue de Vincq,,,,62910
-15 Rue de la Roupie Isbergues,,,,15 Rue de la Roupie,,,,62330
-15 Rue de la Roupie 62330,,,,15 Rue de la Roupie,,,Isbergues,
-15 Rue de la Roupie,2.436322,50.630290,,15 Rue de la Roupie,,,,62330
-12 Rue de Prédefin Laires,,,,12 Rue de Prédefin,,,,62960
-12 Rue de Prédefin 62960,,,,12 Rue de Prédefin,,,Laires,
-12 Rue de Prédefin,2.257489,50.537882,,12 Rue de Prédefin,,,,62960
-29 Rue de Doullens Leforest,,,,29 Rue de Doullens,,,,62790
-29 Rue de Doullens 62790,,,,29 Rue de Doullens,,,Leforest,
-29 Rue de Doullens,3.057061,50.442445,,29 Rue de Doullens,,,,62790
-6 Rue du 19 Mars 1962 Lens,,,,6 Rue du 19 Mars 1962,,,,62300
-6 Rue du 19 Mars 1962 62300,,,,6 Rue du 19 Mars 1962,,,Lens,
-6 Rue du 19 Mars 1962,2.840617,50.431926,,6 Rue du 19 Mars 1962,,,,62300
-209 Rue Molière Lens,,,,209 Rue Molière,,,,62300
-209 Rue Molière 62300,,,,209 Rue Molière,,,Lens,
-209 Rue Molière,2.796306,50.437101,,209 Rue Molière,,,,62300
-2132 Rue Delflie Lestrem,,,,2132 Rue Delflie,,,,62136
-2132 Rue Delflie 62136,,,,2132 Rue Delflie,,,Lestrem,
-2132 Rue Delflie,2.653285,50.600295,,2132 Rue Delflie,,,,62136
-5 Rue Denfert Rochereau Liévin,,,,5 Rue Denfert Rochereau,,,,62800
-5 Rue Denfert Rochereau 62800,,,,5 Rue Denfert Rochereau,,,Liévin,
-5 Rue Denfert Rochereau,2.773937,50.414615,,5 Rue Denfert Rochereau,,,,62800
-4 Rue Mozart Liévin,,,,4 Rue Wolfgang Mozart,,,,62800
-4 Rue Mozart 62800,,,,4 Rue Wolfgang Mozart,,,Liévin,
-4 Rue Mozart,2.764032,50.420897,,4 Rue Wolfgang Mozart,,,,62800
-135 Rue de la Haye Lillers,,,,135 Rue de la Haye,,,,62190
-135 Rue de la Haye 62190,,,,135 Rue de la Haye,,,Lillers,
-135 Rue de la Haye,2.458961,50.564003,,135 Rue de la Haye,,,,62190
-53 Rue Léon Blum Loison-sous-Lens,,,,53 Rue Léon Blum,,,,62218
-53 Rue Léon Blum 62218,,,,53 Rue Léon Blum,,,Loison-sous-Lens,
-53 Rue Léon Blum,2.862614,50.438520,,53 Rue Léon Blum,,,,62218
-20 Rue Decrombecque Loos-en-Gohelle,,,,20 Rue Decrombecque,,,,62750
-20 Rue Decrombecque 62750,,,,20 Rue Decrombecque,,,Loos-en-Gohelle,
-20 Rue Decrombecque,2.799763,50.457953,,20 Rue Decrombecque,,,,62750
-5 Rue des Charbonniers Magnicourt-en-Comte,,,,5 Rue des Charbonniers,,,,62127
-5 Rue des Charbonniers 62127,,,,5 Rue des Charbonniers,,,Magnicourt-en-Comte,
-5 Rue des Charbonniers,2.485575,50.403960,,5 Rue des Charbonniers,,,,62127
-630 Avenue de Verdun Marck,,,,630 Avenue de Verdun,,,,62730
-630 Avenue de Verdun 62730,,,,630 Avenue de Verdun,,,Marck,
-630 Avenue de Verdun,1.939797,50.953148,,630 Avenue de Verdun,,,,62730
-48 Rue d'Etrun Marœuil,,,,48 Rue d'Etrun,,,,62161
-48 Rue d'Etrun 62161,,,,48 Rue d'Etrun,,,Marœuil,
-48 Rue d'Etrun,2.705610,50.321447,,48 Rue d'Etrun,,,,62161
-5 Ruelle Monniez Mazingarbe,,,,5 Ruelle Monniez,,,,62670
-5 Ruelle Monniez 62670,,,,5 Ruelle Monniez,,,Mazingarbe,
-5 Ruelle Monniez,2.720090,50.474622,,5 Ruelle Monniez,,,,62670
-119B Rue Pierre Simon Méricourt,,,,119B Rue Pierre Simon,,,,62680
-119B Rue Pierre Simon 62680,,,,119B Rue Pierre Simon,,,Méricourt,
-119B Rue Pierre Simon,2.882195,50.411390,,119B Rue Pierre Simon,,,,62680
-21 Rue Thomas Meurchin,,,,21 Rue Thomas,,,,62410
-21 Rue Thomas 62410,,,,21 Rue Thomas,,,Meurchin,
-21 Rue Thomas,2.881511,50.497457,,21 Rue Thomas,,,,62410
-25 Rue de Sartène Montigny-en-Gohelle,,,,25 Rue de Sartène,,,,62640
-25 Rue de Sartène 62640,,,,25 Rue de Sartène,,,Montigny-en-Gohelle,
-25 Rue de Sartène,2.939533,50.430042,,25 Rue de Sartène,,,,62640
-2 Allée des Geais Neufchâtel-Hardelot,,,,2 Allée des Geais,,,,62152
-2 Allée des Geais 62152,,,,2 Allée des Geais,,,Neufchâtel-Hardelot,
-2 Allée des Geais,1.601782,50.630593,,2 Allée des Geais,,,,62152
-8022 Rue Fleming Nœux-les-Mines,,,,8022 Rue Fleming,,,,62290
-8022 Rue Fleming 62290,,,,8022 Rue Fleming,,,Nœux-les-Mines,
-8022 Rue Fleming,2.656455,50.477240,,8022 Rue Fleming,,,,62290
-63 Rue Arthur Lamendin Noyelles-Godault,,,,63 Rue Arthur Lamendin,,,,62950
-63 Rue Arthur Lamendin 62950,,,,63 Rue Arthur Lamendin,,,Noyelles-Godault,
-63 Rue Arthur Lamendin,2.998968,50.416686,,63 Rue Arthur Lamendin,,,,62950
-91 Rue du 11 Novembre Noyelles-sous-Lens,,,,91 Rue du 11 Novembre,,,,62221
-91 Rue du 11 Novembre 62221,,,,91 Rue du 11 Novembre,,,Noyelles-sous-Lens,
-91 Rue du 11 Novembre,2.875325,50.433573,,91 Rue du 11 Novembre,,,,62221
-4 Impasse Savary Bouquet Oignies,,,,4 Impasse Savary Bouquet,,,,62590
-4 Impasse Savary Bouquet 62590,,,,4 Impasse Savary Bouquet,,,Oignies,
-4 Impasse Savary Bouquet,3.011311,50.467954,,4 Impasse Savary Bouquet,,,,62590
-2 Square Musset Outreau,,,,2 Square Musset,,,,62230
-2 Square Musset 62230,,,,2 Square Musset,,,Outreau,
-2 Square Musset,1.586048,50.702582,,2 Square Musset,,,,62230
-37 Rue de Verdun Pas-en-Artois,,,,37 Rue de Verdun,,,,62760
-37 Rue de Verdun 62760,,,,37 Rue de Verdun,,,Pas-en-Artois,
-37 Rue de Verdun,2.484169,50.160290,,37 Rue de Verdun,,,,62760
-195 Rue Carnot Le Portel,,,,195 Rue Carnot,,,,62480
-195 Rue Carnot 62480,,,,195 Rue Carnot,,,Le Portel,
-195 Rue Carnot,1.581045,50.710159,,195 Rue Carnot,,,,62480
-42 Rue du Marais Quiestède,,,,42 Rue du Marais,,,,62120
-42 Rue du Marais 62120,,,,42 Rue du Marais,,,Quiestède,
-42 Rue du Marais,2.339940,50.680402,,42 Rue du Marais,,,,62120
-33 Rue de la Moulière Remilly-Wirquin,,,,33 Rue de la Moulière,,,,62380
-33 Rue de la Moulière 62380,,,,33 Rue de la Moulière,,,Remilly-Wirquin,
-33 Rue de la Moulière,2.157895,50.663168,,33 Rue de la Moulière,,,,62380
-300 Rue du Moulin de Landrethun Rodelinghem,,,,300 Rue du Moulin de Landrethun,,,,62610
-300 Rue du Moulin de Landrethun 62610,,,,300 Rue du Moulin de Landrethun,,,Rodelinghem,
-300 Rue du Moulin de Landrethun,1.945174,50.830030,,300 Rue du Moulin de Landrethun,,,,62610
-10 Ruelle de l'Hôpital Ruitz,,,,10 Ruelle de l'Hôpital,,,,62620
-10 Ruelle de l'Hôpital 62620,,,,10 Ruelle de l'Hôpital,,,Ruitz,
-10 Ruelle de l'Hôpital,2.593997,50.466773,,10 Ruelle de l'Hôpital,,,,62620
-40 Rue Jean Jacques Rousseau Sains-en-Gohelle,,,,40 Rue Jean Jacques Rousseau,,,,62114
-40 Rue Jean Jacques Rousseau 62114,,,,40 Rue Jean Jacques Rousseau,,,Sains-en-Gohelle,
-40 Rue Jean Jacques Rousseau,2.681755,50.450067,,40 Rue Jean Jacques Rousseau,,,,62114
-81 Rue de Calais Saint-Folquin,,,,81 Rue de Calais,,,,62370
-81 Rue de Calais 62370,,,,81 Rue de Calais,,,Saint-Folquin,
-81 Rue de Calais,2.123362,50.945957,,81 Rue de Calais,,,,62370
-47 Avenue du Moulin Saint-Léonard,,,,47 Avenue du Moulin,,,,62360
-47 Avenue du Moulin 62360,,,,47 Avenue du Moulin,,,Saint-Léonard,
-47 Avenue du Moulin,1.629806,50.687663,,47 Avenue du Moulin,,,,62360
-54 Rue Marteau Saint-Martin-Boulogne,,,,54 Rue Marteau,,,,62280
-54 Rue Marteau 62280,,,,54 Rue Marteau,,,Saint-Martin-Boulogne,
-54 Rue Marteau,1.636167,50.726677,,54 Rue Marteau,,,,62280
-23B Rue du Doulac Saint-Omer,,,,23B Rue du Doulac,,,,62500
-23B Rue du Doulac 62500,,,,23B Rue du Doulac,,,Saint-Omer,
-23B Rue du Doulac,2.268552,50.767091,,23B Rue du Doulac,,,,62500
-3 Rue Lamartine Saint-Pol-sur-Ternoise,,,,3 Rue Lamartine,,,,62130
-3 Rue Lamartine 62130,,,,3 Rue Lamartine,,,Saint-Pol-sur-Ternoise,
-3 Rue Lamartine,2.335829,50.385229,,3 Rue Lamartine,,,,62130
-11 Rue de Ronchin Sallaumines,,,,11 Rue de Ronchin,,,,62430
-11 Rue de Ronchin 62430,,,,11 Rue de Ronchin,,,Sallaumines,
-11 Rue de Ronchin,2.860679,50.417529,,11 Rue de Ronchin,,,,62430
-39 Rue du Marais Savy-Berlette,,,,39 Rue du Marais,,,,62690
-39 Rue du Marais 62690,,,,39 Rue du Marais,,,Savy-Berlette,
-39 Rue du Marais,2.571683,50.356247,,39 Rue du Marais,,,,62690
-5 Ruellette La Ruellette Teneur,,,,5 Ruellette La Ruellette,,,,62134
-5 Ruellette La Ruellette 62134,,,,5 Ruellette La Ruellette,,,Teneur,
-5 Ruellette La Ruellette,2.233334,50.453258,,5 Ruellette La Ruellette,,,,62134
-85 Rue de Londres Le Touquet-Paris-Plage,,,,85 Rue de Londres,,,,62520
-85 Rue de Londres 62520,,,,85 Rue de Londres,,,Le Touquet-Paris-Plage,
-85 Rue de Londres,1.583615,50.522788,,85 Rue de Londres,,,,62520
-4 Rue Courbet Vendin-le-Vieil,,,,4 Rue Courbet,,,,62880
-4 Rue Courbet 62880,,,,4 Rue Courbet,,,Vendin-le-Vieil,
-4 Rue Courbet,2.840093,50.449185,,4 Rue Courbet,,,,62880
-27 Rue Constant Martin Verquin,,,,27 Rue Constant Martin,,,,62131
-27 Rue Constant Martin 62131,,,,27 Rue Constant Martin,,,Verquin,
-27 Rue Constant Martin,2.641294,50.501418,,27 Rue Constant Martin,,,,62131
-15 Rue Roger Salengro Vimy,,,,15 Rue Roger Salengro,,,,62580
-15 Rue Roger Salengro 62580,,,,15 Rue Roger Salengro,,,Vimy,
-15 Rue Roger Salengro,2.801865,50.370954,,15 Rue Roger Salengro,,,,62580
-8 Rue du Haut Wamin,,,,8 Rue du Haut,,,,62770
-8 Rue du Haut 62770,,,,8 Rue du Haut,,,Wamin,
-8 Rue du Haut,2.055461,50.415592,,8 Rue du Haut,,,,62770
-20 Rue Jean Moulin Wimereux,,,,20 Rue Jean Moulin,,,,62930
-20 Rue Jean Moulin 62930,,,,20 Rue Jean Moulin,,,Wimereux,
-20 Rue Jean Moulin,1.614382,50.775737,,20 Rue Jean Moulin,,,,62930
-7 Avenue de la Verrerie Wingles,,,,7 Avenue de la Verrerie,,,,62410
-7 Avenue de la Verrerie 62410,,,,7 Avenue de la Verrerie,,,Wingles,
-7 Avenue de la Verrerie,2.870264,50.493851,,7 Avenue de la Verrerie,,,,62410
-1596 Rue de la Montoire Zutkerque,,,,1596 Rue de la Montoire,,,,62370
-1596 Rue de la Montoire 62370,,,,1596 Rue de la Montoire,,,Zutkerque,
-1596 Rue de la Montoire,2.028339,50.851355,,1596 Rue de la Montoire,,,,62370
-augustines arras,,,2,Petit Chemin des Augustines,,,Arras,
-augustines arras,,,,Rue des Augustines,,,Arras,
-rue jean jaures Helemmes,,,,Rue Jean Jaurès,,,,59491
-rue charles saint venant lomme,,,,Rue Charles Saint-Venant,,,Lille,59160
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+19 Rue Denis Cordonnier Aniche,,,,19,Rue Denis Cordonnier,,59580
+19 Rue Denis Cordonnier 59580,,,,19,Rue Denis Cordonnier,Aniche,
+19 Rue Denis Cordonnier,3.250339,50.323376,,19,Rue Denis Cordonnier,,59580
+119 Rue Carpeaux Villeneuve-d'Ascq,,,,119,Rue Carpeaux,,59650
+119 Rue Carpeaux 59650,,,,119,Rue Carpeaux,Villeneuve-d'Ascq,
+11 Rue des Genêts Villeneuve-d'Ascq,,,,11,Rue des Genêts,,59650
+11 Rue des Genêts 59650,,,,11,Rue des Genêts,Villeneuve-d'Ascq,
+18 Rue Saint-Sauveur Villeneuve-d'Ascq,,,,18,Rue Saint-Sauveur,,59650
+18 Rue Saint-Sauveur 59650,,,,18,Rue Saint-Sauveur,Villeneuve-d'Ascq,
+18 Rue Saint-Sauveur,3.141394,50.627746,,18,Rue Saint-Sauveur,,59650
+31 Rue des Anorelles Anor,,,,31,Rue des Anorelles,,59186
+31 Rue des Anorelles 59186,,,,31,Rue des Anorelles,Anor,
+31 Rue des Anorelles,4.134764,49.998113,,31,Rue des Anorelles,,59186
+8 Rue Kléber Anzin,,,,8,Rue Kléber,,59410
+8 Rue Kléber 59410,,,,8,Rue Kléber,Anzin,
+8 Rue Kléber,3.500907,50.374232,,8,Rue Kléber,,59410
+3 Cours Carniaux Armentières,,,,3,Cour Carniaud,,59280
+3 Cours Carniaux 59280,,,,3,Cour Carniaud,Armentières,
+3 Cours Carniaux,2.879964,50.688477,,3,Cour Carniaud,,59280
+64BIS Rue de Metz Armentières,,,,64,Rue de Metz,,59280
+64BIS Rue de Metz 59280,,,,64,Rue de Metz,Armentières,
+64 B Rue de Metz,2.889957,50.687328,,64,Rue de Metz,,59280
+16 Place des Eglantines Attiches,,,,16,Place des Eglantines,,59551
+16 Place des Eglantines 59551,,,,16,Place des Eglantines,Attiches,
+16 Place des Eglantines,3.065758,50.524763,,16,Place des Eglantines,,59551
+7 Rue Condorcet Auby,,,,7,Rue Condorcet,,59950
+7 Rue Condorcet 59950,,,,7,Rue Condorcet,Auby,
+45 Rue Albert-Schweitzer Aulnoye-Aymeries,,,,45,Rue Albert-Schweitzer,,59620
+45 Rue Albert-Schweitzer 59620,,,,45,Rue Albert-Schweitzer,Aulnoye-Aymeries,
+45 Rue Albert-Schweitzer,3.848887,50.207203,,45,Rue Albert-Schweitzer,,59620
+28 Rue des Jardins Avesnelles,,,,28,Rue des Jardins,,59440
+28 Rue des Jardins 59440,,,,28,Rue des Jardins,Avesnelles,
+28 Rue des Jardins,3.948079,50.12009,,28,Rue des Jardins,,59440
+13 Rue d'Estree Bachant,,,,13,Rue d'Estree,,59138
+13 Rue d'Estree 59138,,,,13,Rue d'Estree,Bachant,
+13 Rue d'Estree,3.855022,50.209278,,13,Rue d'Estree,,59138
+100 Rue Philippe Van Tieghem Bailleul,,,,100,Rue Philippe Van Tieghem,,59270
+100 Rue Philippe Van Tieghem 59270,,,,100,Rue Philippe Van Tieghem,Bailleul,
+100 Rue Philippe Van Tieghem,2.728873,50.734869,,100,Rue Philippe Van Tieghem,,59270
+34 Hameau de Beaupuits La Bassée,,,,34,Hameau de Beaupuits,,59480
+34 Hameau de Beaupuits 59480,,,,34,Hameau de Beaupuits,La Bassée,
+34 Hameau de Beaupuits,2.79973,50.548204,,34,Hameau de Beaupuits,,59480
+18 Rue de Fournes Beaucamps-Ligny,,,,18,Rue de Fournes,,59134
+18 Rue de Fournes 59134,,,,18,Rue de Fournes,Beaucamps-Ligny,
+18 Rue de Fournes,2.914258,50.604176,,18,Rue de Fournes,,59134
+1 Rue du Moulin Berlaimont,,,,1,Rue du Moulin,,59145
+1 Rue du Moulin 59145,,,,1,Rue du Moulin,Berlaimont,
+1 Rue du Moulin,3.816387,50.20238,,1,Rue du Moulin,,59145
+12 Rue Jean Chanat Beuvrages,,,,12,Rue Jean Chanat,,59192
+12 Rue Jean Chanat 59192,,,,12,Rue Jean Chanat,Beuvrages,
+12 Rue Jean Chanat,3.508408,50.381089,,12,Rue Jean Chanat,,59192
+97 Rue du Moulin Boeschepe,,,,97,Rue du Moulin,,59299
+97 Rue du Moulin 59299,,,,97,Rue du Moulin,Boeschepe,
+97 Rue du Moulin,2.688706,50.80057,,97,Rue du Moulin,,59299
+796 Domaine de la Vigne Bondues,,,,796,Domaine de la Vigne,,59910
+796 Domaine de la Vigne 59910,,,,796,Domaine de la Vigne,Bondues,
+796 Domaine de la Vigne,3.075937,50.713709,,796,Domaine de la Vigne,,59910
+9 Rue Schadet Vercoustre Bourbourg,,,,9,Rue Schadet Vercoustre,,59630
+9 Rue Schadet Vercoustre 59630,,,,9,Rue Schadet Vercoustre,Bourbourg,
+9 Rue Schadet Vercoustre,2.196252,50.948307,,9,Rue Schadet Vercoustre,,59630
+270 Rue de la Paix Boussois,,,,270,Rue de la Paix,,59168
+270 Rue de la Paix 59168,,,,270,Rue de la Paix,Boussois,
+270 Rue de la Paix,4.040773,50.293517,,270,Rue de la Paix,,59168
+25 Route de Rubrouck Cd 911 Broxeele,,,,25,Route de Rubrouck Cd 911,,59470
+25 Route de Rubrouck Cd 911 59470,,,,25,Route de Rubrouck Cd 911,Broxeele,
+25 Route de Rubrouck Cd 911,2.317148,50.8299,,25,Route de Rubrouck Cd 911,,59470
+25 Rue Lesage Bruille-lez-Marchiennes,,,,25,Rue Lesage,,59490
+25 Rue Lesage 59490,,,,25,Rue Lesage,Bruille-lez-Marchiennes,
+25 Rue Lesage,3.244433,50.365048,2,25,Rue Lesage,,59490
+71 Rue d'Artois Cambrai,,,,71,Rue d'Artois,,59400
+71 Rue d'Artois 59400,,,,71,Rue d'Artois,Cambrai,
+71 Rue d'Artois,3.255944,50.160947,,71,Rue d'Artois,,59400
+5 Rue Jean Racine Cambrai,,,,5,Rue Jean Racine,,59400
+5 Rue Jean Racine 59400,,,,5,Rue Jean Racine,Cambrai,
+5 Rue Jean Racine,3.256965,50.165885,,5,Rue Jean Racine,,59400
+5 Allée Saint-Roch Cambrai,,,,5,Allée Saint-Roch,,59400
+5 Allée Saint-Roch 59400,,,,5,Allée Saint-Roch,Cambrai,
+5 Allée Saint-Roch,3.239989,50.180002,,5,Allée Saint-Roch,,59400
+967 Rue Basilic Straete Cappelle-Brouck,,,,967,Rue Basilic Straete,,59630
+967 Rue Basilic Straete 59630,,,,967,Rue Basilic Straete,Cappelle-Brouck,
+967 Rue Basilic Straete,2.23849,50.910373,,967,Rue Basilic Straete,,59630
+115 Rue de Bruxelles Caudry,,,,115,Rue de Bruxelles,,59540
+115 Rue de Bruxelles 59540,,,,115,Rue de Bruxelles,Caudry,
+115 Rue de Bruxelles,3.410777,50.131644,,115,Rue de Bruxelles,,59540
+17 Rue Stephenson Caudry,,,,17,Rue Stephenson,,59540
+17 Rue Stephenson 59540,,,,17,Rue Stephenson,Caudry,
+17 Rue Stephenson,3.420761,50.126288,,17,Rue Stephenson,,59540
+34 Rue du Bon Passage Chéreng,,,,34,Rue du Bon Passage,,59152
+34 Rue du Bon Passage 59152,,,,34,Rue du Bon Passage,Chéreng,
+34 Rue du Bon Passage,3.20485,50.608204,,34,Rue du Bon Passage,,59152
+58 Rue Martha Desrumeaux Comines,,,,58,Rue Martha Desrumaux,,59560
+58 Rue Martha Desrumeaux 59560,,,,58,Rue Martha Desrumaux,Comines,
+58 Rue Martha Desrumeaux,3.020017,50.7665,,58,Rue Martha Desrumaux,,59560
+21 Rue du Quesnoy Condé-sur-l'Escaut,,,,21,Rue du Quesnoy,,59163
+21 Rue du Quesnoy 59163,,,,21,Rue du Quesnoy,Condé-sur-l'Escaut,
+21 Rue du Quesnoy,3.594722,50.445786,2,21,Rue du Quesnoy,,59163
+69 Boulevard Jean Jaurès Coudekerque-Branche,,,,69,Boulevard Jean Jaurès,,59210
+69 Boulevard Jean Jaurès 59210,,,,69,Boulevard Jean Jaurès,Coudekerque-Branche,
+69 Boulevard Jean Jaurès,2.379438,51.021507,,69,Boulevard Jean Jaurès,,59210
+2 Rue Pierre de Coubertin Courchelettes,,,,2,Rue Pierre de Coubertin,,59552
+2 Rue Pierre de Coubertin 59552,,,,2,Rue Pierre de Coubertin,Courchelettes,
+2 Rue Pierre de Coubertin,3.057501,50.348526,,2,Rue Pierre de Coubertin,,59552
+73 Rue Anatole France Croix,,,,73,Rue Anatole France,,59170
+73 Rue Anatole France 59170,,,,73,Rue Anatole France,Croix,
+73 Rue Anatole France,3.156332,50.684844,5,73,Rue Anatole France,,59170
+43 Rue Paul Lafargue Croix,,,,43,Rue Paul Lafargue,,59170
+43 Rue Paul Lafargue 59170,,,,43,Rue Paul Lafargue,Croix,
+43 Rue Paul Lafargue,3.155249,50.686021,,43,Rue Paul Lafargue,,59170
+20E Rue du Général de Gaulle Cysoing,,,,20,Rue du Général de Gaulle,,59830
+20E Rue du Général de Gaulle 59830,,,,20,Rue du Général de Gaulle,Cysoing,
+20E Rue du Général de Gaulle,3.218773,50.57048,,20,Rue du Général de Gaulle,,59830
+240 Rue Charles Bourseul Douai,,,,240,Rue Charles Bourseul,,59500
+240 Rue Charles Bourseul 59500,,,,240,Rue Charles Bourseul,Douai,
+240 Rue Charles Bourseul,3.074509,50.379867,,240,Rue Charles Bourseul,,59500
+89 Rue Léo Delibes Douai,,,,89,Rue Léo Delibes,,59500
+89 Rue Léo Delibes 59500,,,,89,Rue Léo Delibes,Douai,
+89 Rue Léo Delibes,3.098754,50.378096,,89,Rue Léo Delibes,,59500
+32 Rue Victor Pecqueur Douai,,,,32,Rue Victor Pecqueur,,59500
+32 Rue Victor Pecqueur 59500,,,,32,Rue Victor Pecqueur,Douai,
+32 Rue Victor Pecqueur,3.084533,50.391887,,32,Rue Victor Pecqueur,,59500
+30 Rue Alfred Dumont Dunkerque,,,,30,Rue Alfred Dumont,,59140
+30 Rue Alfred Dumont 59140,,,,30,Rue Alfred Dumont,Dunkerque,
+30 Rue Alfred Dumont,2.377278,51.030606,,30,Rue Alfred Dumont,,59140
+543 Rue Arago Dunkerque,,,,543,Rue Arago,,59240
+543 Rue Arago 59240,,,,543,Rue Arago,Dunkerque,
+543 Rue Arago,2.403552,51.044322,,543,Rue Arago,,59240
+52 Rue des Fusiliers Marins Dunkerque,,,,52,Rue des Fusiliers Marins,,59430
+52 Rue des Fusiliers Marins 59430,,,,52,Rue des Fusiliers Marins,Dunkerque,
+52 Rue des Fusiliers Marins,2.345248,51.034846,,52,Rue des Fusiliers Marins,,59430
+133 Rue de la Moissonnière Dunkerque,,,,133,Rue de la Moissonnière,,59640
+133 Rue de la Moissonnière 59640,,,,133,Rue de la Moissonnière,Dunkerque,
+133 Rue de la Moissonnière,2.315725,51.025215,,133,Rue de la Moissonnière,,59640
+635 Rue de Zuydcoote Dunkerque,,,,635,Rue de Zuydcoote,,59240
+635 Rue de Zuydcoote 59240,,,,635,Rue de Zuydcoote,Dunkerque,
+635 Rue de Zuydcoote,2.427879,51.047466,,635,Rue de Zuydcoote,,59240
+56 Rue Gambetta Dunkerque,,,,56,Rue Gambetta,,59430
+56 Rue Gambetta 59430,,,,56,Rue Gambetta,Dunkerque,
+56 Rue Gambetta,2.350174,51.02621,,56,Rue Gambetta,,59430
+93 Rue de l'Hazewinde Eecke,,,,93,Rue de l'Hazewinde,,59114
+93 Rue de l'Hazewinde 59114,,,,93,Rue de l'Hazewinde,Eecke,
+93 Rue de l'Hazewinde,2.593041,50.780304,,93,Rue de l'Hazewinde,,59114
+404 Avenue Jules Guesde Escaudain,,,,404,Avenue Jules Guesde,,59124
+404 Avenue Jules Guesde 59124,,,,404,Avenue Jules Guesde,Escaudain,
+404 Avenue Jules Guesde,3.330919,50.329008,,404,Avenue Jules Guesde,,59124
+4 Allée des Peupliers Escobecques,,,,4,Allée des Peupliers,,59320
+4 Allée des Peupliers 59320,,,2,4,Allée des Peupliers,Escobecques,
+4 Allée des Peupliers,2.937156,50.618826,3,4,Allée des Peupliers,,59320
+19 Rue de Thun l'Eveque Eswars,,,,19,Rue de Thun l'Eveque,,59161
+19 Rue de Thun l'Eveque 59161,,,,19,Rue de Thun l'Eveque,Eswars,
+19 Rue de Thun l'Eveque,3.272098,50.22217,,19,Rue de Thun l'Eveque,,59161
+228 Rue Jean Jaurès Faches-Thumesnil,,,,228,Rue Jean Jaurès,,59155
+228 Rue Jean Jaurès 59155,,,,228,Rue Jean Jaurès,Faches-Thumesnil,
+228 Rue Jean Jaurès,3.074016,50.604837,2,228,Rue Jean Jaurès,,59155
+2 Rue Alfred-Derkenne Feignies,,,,2,Rue Alfred-Derkenne,,59750
+2 Rue Alfred-Derkenne 59750,,,,2,Rue Alfred-Derkenne,Feignies,
+2 Rue Alfred-Derkenne,3.917436,50.298104,,2,Rue Alfred-Derkenne,,59750
+75 Rue Suzanne Lanoy Fenain,,,,75,Rue Suzanne Lanoy,,59179
+75 Rue Suzanne Lanoy 59179,,,,75,Rue Suzanne Lanoy,Fenain,
+75 Rue Suzanne Lanoy,3.29585,50.366135,,75,Rue Suzanne Lanoy,,59179
+79BIS Rue Marceau Martin Flers-en-Escrebieux,,,,79,Rue Marceau Martin,,59128
+79BIS Rue Marceau Martin 59128,,,,79,Rue Marceau Martin,Flers-en-Escrebieux,
+79BIS Rue Marceau Martin,3.091407,50.399575,,79,Rue Marceau Martin,,59128
+41 Rue Lamartine Fontaine-au-Pire,,,,41,Rue Lamartine,,59157
+41 Rue Lamartine 59157,,,,41,Rue Lamartine,Fontaine-au-Pire,
+41 Rue Lamartine,3.374668,50.133814,,41,Rue Lamartine,,59157
+4 Impasse Marcy Fourmies,,,,4,Impasse Marcy,,59610
+4 Impasse Marcy 59610,,,,4,Impasse Marcy,Fourmies,
+4 Impasse Marcy,4.040814,50.013599,,4,Impasse Marcy,,59610
+84 Rue Jacques Renard Fresnes-sur-Escaut,,,,84,Rue Jacques Renard,,59970
+84 Rue Jacques Renard 59970,,,,84,Rue Jacques Renard,Fresnes-sur-Escaut,
+84 Rue Jacques Renard,3.555527,50.438435,,84,Rue Jacques Renard,,59970
+22A Rue des Écoles Ghyvelde,,,,22,Rue des Écoles,,59254
+22A Rue des Écoles 59254,,,,22,Rue des Écoles,Ghyvelde,
+22A Rue des Écoles,2.524502,51.0501,2,22,Rue des Écoles,,59254
+10 Rue Gustave Mélantois Gondecourt,,,,10,Rue Gustave Mélantois,,59147
+10 Rue Gustave Mélantois 59147,,,,10,Rue Gustave Mélantois,Gondecourt,
+10 Rue Gustave Mélantois,2.981813,50.541273,,10,Rue Gustave Mélantois,,59147
+77 Rue de Gravelines Grand-Fort-Philippe,,,,77,Rue de Gravelines,,59153
+77 Rue de Gravelines 59153,,,,77,Rue de Gravelines,Grand-Fort-Philippe,
+77 Rue de Gravelines,2.105327,50.998279,,77,Rue de Gravelines,,59153
+14 Rue de la Plage Gravelines,,,,14,Rue de la Plage,,59820
+14 Rue de la Plage 59820,,,,14,Rue de la Plage,Gravelines,
+14 Rue de la Plage,2.132981,50.991071,2,14,Rue de la Plage,,59820
+12 Rue Arthur Houte Halluin,,,,12,Rue Arthur Houte,,59250
+12 Rue Arthur Houte 59250,,,,12,Rue Arthur Houte,Halluin,
+12 Rue Arthur Houte,3.127454,50.779975,,12,Rue Arthur Houte,,59250
+81 Rue Maurice Simono Halluin,,,,81,Rue Maurice Simono,,59250
+81 Rue Maurice Simono 59250,,,,81,Rue Maurice Simono,Halluin,
+81 Rue Maurice Simono,3.120149,50.785824,,81,Rue Maurice Simono,,59250
+1 BIS Rue d'Avesnes Le Sec Haspres,,,,1,Rue d'Avesnes Le Sec,,59198
+1 BIS Rue d'Avesnes Le Sec 59198,,,,1,Rue d'Avesnes Le Sec,Haspres,
+1 BIS Rue d'Avesnes Le Sec,3.411783,50.256013,,1,Rue d'Avesnes Le Sec,,59198
+69 Avenue de la Pépinière Haubourdin,,,,69,Avenue de la Pépinière,,59320
+69 Avenue de la Pépinière 59320,,,,69,Avenue de la Pépinière,Haubourdin,
+69 Avenue de la Pépinière,2.970606,50.609344,,69,Avenue de la Pépinière,,59320
+183 Avenue du Général Leclerc Hautmont,,,,183,Avenue du Général Leclerc,,59330
+183 Avenue du Général Leclerc 59330,,,,183,Avenue du Général Leclerc,Hautmont,
+183 Avenue du Général Leclerc,3.910328,50.24328,,183,Avenue du Général Leclerc,,59330
+138 Rue de la Croix Haynecourt,,,,138,Rue de la Croix,,59268
+138 Rue de la Croix 59268,,,,138,Rue de la Croix,Haynecourt,
+138 Rue de la Croix,3.162923,50.212839,,138,Rue de la Croix,,59268
+34 Avenue Masson Beau Hazebrouck,,,,34,Avenue Masson Beau,,59190
+34 Avenue Masson Beau 59190,,,,34,Avenue Masson Beau,Hazebrouck,
+34 Avenue Masson Beau,2.537314,50.727763,,34,Avenue Masson Beau,,59190
+35T Rue Briet Hem,,,,35,Rue Briet,,59510
+35T Rue Briet 59510,,,,35,Rue Briet,Hem,
+35T Rue Briet,3.190776,50.669223,,35,Rue Briet,,59510
+35T Rue du Trié Hem,,,,35T,Rue du Trié,,59510
+35T Rue du Trié 59510,,,,35T,Rue du Trié,Hem,
+35T Rue du Trié,3.170736,50.662216,,35T,Rue du Trié,,59510
+435 Rue de la Rosière Herrin,,,,435,Rue de la Rosière,,59147
+435 Rue de la Rosière 59147,,,,435,Rue de la Rosière,Herrin,
+435 Rue de la Rosière,2.965071,50.546279,,435,Rue de la Rosière,,59147
+60 Rue Paul Lafargue Hornaing,,,,60,Rue Paul Lafargue,,59171
+60 Rue Paul Lafargue 59171,,,,60,Rue Paul Lafargue,Hornaing,
+60 Rue Paul Lafargue,3.340594,50.368279,,60,Rue Paul Lafargue,,59171
+6 Allée des Tilleuls Houplines,,,,6,Allée des Tilleuls,,59116
+6 Allée des Tilleuls 59116,,,,6,Allée des Tilleuls,Houplines,
+6 Allée des Tilleuls,2.915761,50.699086,,6,Allée des Tilleuls,,59116
+184 Rue Auguste-Marchal Jeumont,,,,184,Rue Auguste-Marchal,,59460
+184 Rue Auguste-Marchal 59460,,,,184,Rue Auguste-Marchal,Jeumont,
+184 Rue Auguste-Marchal,4.089842,50.294301,,184,Rue Auguste-Marchal,,59460
+60 Rue des Clématites Lallaing,,,,60,Rue des Clématites,,59167
+60 Rue des Clématites 59167,,,,60,Rue des Clématites,Lallaing,
+60 Rue des Clématites,3.158504,50.385744,,60,Rue des Clématites,,59167
+58 Rue Georges Boidin Lambersart,,,,58,Rue Georges Boidin,,59130
+58 Rue Georges Boidin 59130,,,,58,Rue Georges Boidin,Lambersart,
+58 Rue Georges Boidin,3.025622,50.641394,,58,Rue Georges Boidin,,59130
+1T Rue de Verlinghem Lambersart,,,,1,ter Rue de Verlinghem,,59130
+1T Rue de Verlinghem 59130,,,,1,ter Rue de Verlinghem,Lambersart,
+1T Rue de Verlinghem,3.02441,50.653979,,1,ter Rue de Verlinghem,,59130
+4 Rue de Tournai Lannoy,,,,4,Rue de Tournai,,59390
+4 Rue de Tournai 59390,,,,4,Rue de Tournai,Lannoy,
+4 Rue de Tournai,3.211316,50.666924,2,4,Rue de Tournai,,59390
+105 Rue du Maréchal Leclerc Leers,,,,105,Rue du Maréchal Leclerc,,59115
+105 Rue du Maréchal Leclerc 59115,,,,105,Rue du Maréchal Leclerc,Leers,
+105 Rue du Maréchal Leclerc,3.224415,50.685248,,105,Rue du Maréchal Leclerc,,59115
+22 Rue d'Iena Lesquin,,,,22,Rue d'Iena,,59810
+22 Rue d'Iena 59810,,,,22,Rue d'Iena,Lesquin,
+22 Rue d'Iena,3.110028,50.587426,3,22,Rue d'Iena,,59810
+41 Rue de Beaux-Monts Liessies,,,,41,Rue des Beaux-Monts,,59740
+41 Rue de Beaux-Monts 59740,,,,41,Rue des Beaux-Monts,Liessies,
+41 Rue de Beaux-Monts,4.082586,50.124005,,41,Rue des Beaux-Monts,,59740
+119 Rue Barthélémy Delespaul Lille,,,,119,Rue Barthélémy Delespaul,,59000
+119 Rue Barthélémy Delespaul 59000,,,,119,Rue Barthélémy Delespaul,Lille,
+119 Rue Barthélémy Delespaul,3.065487,50.624199,,119,Rue Barthélémy Delespaul,,59000
+27 Rue du Chaufour Lille,,,,27,Rue du Chaufour,,59000
+27 Rue du Chaufour 59000,,,,27,Rue du Chaufour,Lille,
+27 Rue du Chaufour,3.048511,50.625807,,27,Rue du Chaufour,,59000
+54 Boulevard de l'Épine Lille,,,,54,Boulevard de l'Épine,,59260
+54 Boulevard de l'Épine 59260,,,,54,Boulevard de l'Épine,Lille,
+54 Boulevard de l'Épine,3.106904,50.620387,,54,Boulevard de l'Épine,,59260
+15 Rue Gustave Nadaud Lille,,,,15,Rue Gustave Nadaud,,59000
+15 Rue Gustave Nadaud 59000,,,,15,Rue Gustave Nadaud,Lille,
+15 Rue Gustave Nadaud,3.045269,50.61348,,15,Rue Gustave Nadaud,,59000
+37 Rue de Lens Lille,,,,37,Rue de Lens,,59000
+37 Rue de Lens 59000,,,,37,Rue de Lens,Lille,
+37 Rue de Lens,3.06242,50.624967,,37,Rue de Lens,,59000
+14 Rue des Modeleurs Lille,,,,14,Rue des Modeleurs,,59260
+14 Rue des Modeleurs 59260,,,,14,Rue des Modeleurs,Lille,
+14 Rue des Modeleurs,3.103481,50.626239,,14,Rue des Modeleurs,,59260
+41 Rue du Professeur Langevin Lille,,,,41,Rue du Professeur Langevin,,59000
+41 Rue du Professeur Langevin 59000,,,,41,Rue du Professeur Langevin,Lille,
+41 Rue du Professeur Langevin,3.087164,50.617687,,41,Rue du Professeur Langevin,,59000
+25 Rue de Tourville Lille,,,,25,Rue de Tourville,,59000
+25 Rue de Tourville 59000,,,,25,Rue de Tourville,Lille,
+25 Rue de Tourville,3.02686,50.631026,,25,Rue de Tourville,,59000
+5 Rue François J Deroullers Lille,,,,5,Rue François Joseph Deroullers,,59160
+5 Rue François J Deroullers 59160,,,,5,Rue François Joseph Deroullers,Lille,
+5 Rue François J Deroullers,2.981528,50.647078,,5,Rue François Joseph Deroullers,,59160
+57 Cité Bacquet Lille,,,,57,Cité Bacquet,,59260
+57 Cité Bacquet 59260,,,,57,Cité Bacquet,Lille,
+57 Cité Bacquet,3.102247,50.634071,,57,Cité Bacquet,,59260
+40 Rue de Pont-sur-Sambre La Longueville,,,,40,Rue de Pont-sur-Sambre,,59570
+40 Rue de Pont-sur-Sambre 59570,,,,40,Rue de Pont-sur-Sambre,La Longueville,
+40 Rue de Pont-sur-Sambre,3.855835,50.279,,40,Rue de Pont-sur-Sambre,,59570
+157 Rue Georges Clemenceau Loos,,,,157,Rue Georges Clemenceau,,59120
+157 Rue Georges Clemenceau 59120,,,,157,Rue Georges Clemenceau,Loos,
+157 Rue Georges Clemenceau,3.010221,50.615663,,157,Rue Georges Clemenceau,,59120
+14BIS Ruelle de la Frête Louvignies-Quesnoy,,,,14,Ruelle de la Frête,,59530
+14BIS Ruelle de la Frête 59530,,,,14,Ruelle de la Frête,Louvignies-Quesnoy,
+14BIS Ruelle de la Frête,3.638996,50.222443,,14,Ruelle de la Frête,,59530
+54 Rue Henri Ghesquière Lys-lez-Lannoy,,,,54,Rue Henri Ghesquière,,59390
+54 Rue Henri Ghesquière 59390,,,,54,Rue Henri Ghesquière,Lys-lez-Lannoy,
+54 Rue Henri Ghesquière,3.20761,50.672364,2,54,Rue Henri Ghesquière,,59390
+35 Rue Jeanne d'Arc La Madeleine,,,,35,Rue Jeanne d'Arc,,59110
+35 Rue Jeanne d'Arc 59110,,,,35,Rue Jeanne d'Arc,La Madeleine,
+35 Rue Jeanne d'Arc,3.0672,50.659361,5,35,Rue Jeanne d'Arc,,59110
+2 Rue de Beaurevoir Malincourt,,,,2,Rue de Beaurevoir,,59127
+2 Rue de Beaurevoir 59127,,,,2,Rue de Beaurevoir,Malincourt,
+2 Rue de Beaurevoir,3.326748,50.045848,,2,Rue de Beaurevoir,,59127
+17 Rue des Châtaigniers Marcq-en-Barœul,,,,17,Rue des Châtaigniers,,59700
+17 Rue des Châtaigniers 59700,,,,17,Rue des Châtaigniers,Marcq-en-Barœul,
+17 Rue des Châtaigniers,3.099402,50.683486,,17,Rue des Châtaigniers,,59700
+16 Rue Marc Sangnier Marcq-en-Barœul,,,,16,Rue Marc Sangnier,,59700
+16 Rue Marc Sangnier 59700,,,,16,Rue Marc Sangnier,Marcq-en-Barœul,
+16 Rue Marc Sangnier,3.098585,50.673768,3,16,Rue Marc Sangnier,,59700
+3 Rue d'Artres Maresches,,,,3,Rue d'Artres,,59990
+3 Rue d'Artres 59990,,,,3,Rue d'Artres,Maresches,
+3 Rue d'Artres,3.574746,50.293586,2,3,Rue d'Artres,,59990
+6 Rue des Tulipes Marly,,,,6,Rue des Tulipes,,59770
+6 Rue des Tulipes 59770,,,,6,Rue des Tulipes,Marly,
+6 Rue des Tulipes,3.546305,50.343249,,6,Rue des Tulipes,,59770
+19 Rue Saint-Venant Marquette-lez-Lille,,,,19,Rue Saint-Venant,,59520
+19 Rue Saint-Venant 59520,,,,19,Rue Saint-Venant,Marquette-lez-Lille,
+19 Rue Saint-Venant,3.05313,50.67061,,19,Rue Saint-Venant,,59520
+12 Rue Charles Grivilers Mastaing,,,,12,Rue Charles Grivilers,,59172
+12 Rue Charles Grivilers 59172,,,,12,Rue Charles Grivilers,Mastaing,
+12 Rue Charles Grivilers,3.309081,50.305725,,12,Rue Charles Grivilers,,59172
+141 Boulevard Jean-de-la-Fontaine Maubeuge,,,,141,Boulevard Jean-de-la-Fontaine,,59600
+141 Boulevard Jean-de-la-Fontaine 59600,,,,141,Boulevard Jean-de-la-Fontaine,Maubeuge,
+141 Boulevard Jean-de-la-Fontaine,3.965613,50.294906,,141,Boulevard Jean-de-la-Fontaine,,59600
+4 Rue d'Honnechy Maurois,,,,4,Rue d'Honnechy,,59980
+4 Rue d'Honnechy 59980,,,,4,Rue d'Honnechy,Maurois,
+4 Rue d'Honnechy,3.468269,50.073082,,4,Rue d'Honnechy,,59980
+19 Allée des Peupliers Merville,,,,19,Allée des Peupliers,,59660
+19 Allée des Peupliers 59660,,,,19,Allée des Peupliers,Merville,
+19 Allée des Peupliers,2.63294,50.639541,,19,Allée des Peupliers,,59660
+160 Rue du Becquerel Mons-en-Barœul,,,,160,Rue du Becquerel,,59370
+160 Rue du Becquerel 59370,,,,160,Rue du Becquerel,Mons-en-Barœul,
+160 Rue du Becquerel,3.099317,50.635803,,160,Rue du Becquerel,,59370
+1 Rue de la Feuillée Montay,,,,1,Rue de la Feuillée,,59360
+1 Rue de la Feuillée 59360,,,,1,Rue de la Feuillée,Montay,
+1 Rue de la Feuillée,3.539689,50.118812,,1,Rue de la Feuillée,,59360
+361 Rue du Congo Mouvaux,,,,361,Rue du Congo,,59420
+361 Rue du Congo 59420,,,,361,Rue du Congo,Mouvaux,
+361 Rue du Congo,3.153066,50.703059,,361,Rue du Congo,,59420
+16 Rue Montigny Neuf-Berquin,,,,16,Rue Montigny,,59940
+16 Rue Montigny 59940,,,,16,Rue Montigny,Neuf-Berquin,
+16 Rue Montigny,2.677298,50.660866,,16,Rue Montigny,,59940
+96 Rue du Général de Gaulle La Neuville,,,,96,Rue du Général de Gaulle,,59239
+96 Rue du Général de Gaulle 59239,,,,96,Rue du Général de Gaulle,La Neuville,
+96 Rue du Général de Gaulle,3.04797,50.491887,2,96,Rue du Général de Gaulle,,59239
+94 Avenue des Lilas Nieppe,,,,94,Avenue des Lilas,,59850
+94 Avenue des Lilas 59850,,,,94,Avenue des Lilas,Nieppe,
+94 Avenue des Lilas,2.845615,50.700406,,94,Avenue des Lilas,,59850
+185 Rue de la Haute Ville Odomez,,,,185,Rue de la Haute Ville,,59970
+185 Rue de la Haute Ville 59970,,,,185,Rue de la Haute Ville,Odomez,
+185 Rue de la Haute Ville,3.525402,50.450805,,185,Rue de la Haute Ville,,59970
+104 Rue Claude Jean Orchies,,,,104,Rue Claude Jean,,59310
+104 Rue Claude Jean 59310,,,,104,Rue Claude Jean,Orchies,
+104 Rue Claude Jean,3.251419,50.468616,,104,Rue Claude Jean,,59310
+609 Route de Wormhout Oudezeele,,,,609,Route de Wormhout,,59670
+609 Route de Wormhout 59670,,,,609,Route de Wormhout,Oudezeele,
+609 Route de Wormhout,2.50648,50.85165,,609,Route de Wormhout,,59670
+18 Rue Pasteur Pérenchies,,,,18,Rue Pasteur,,59840
+18 Rue Pasteur 59840,,,,18,Rue Pasteur,Pérenchies,
+18 Rue Pasteur,2.970613,50.667235,2,18,Rue Pasteur,,59840
+1 Chemin des Moulins Vc 2 Pitgam,,,,1,Chemin des Moulins Vc 2,,59284
+1 Chemin des Moulins Vc 2 59284,,,,1,Chemin des Moulins Vc 2,Pitgam,
+1 Chemin des Moulins Vc 2,2.3367,50.933208,,1,Chemin des Moulins Vc 2,,59284
+13 Clos des Pommiers Préseau,,,,13,Clos des Pommiers,,59990
+13 Clos des Pommiers 59990,,,,13,Clos des Pommiers,Préseau,
+13 Clos des Pommiers,3.57157,50.309031,,13,Clos des Pommiers,,59990
+36 Route de Wylder Quaëdypre,,,,36,Route de Wylder,,59380
+36 Route de Wylder 59380,,,,36,Route de Wylder,Quaëdypre,
+36 Route de Wylder,2.456855,50.933267,,36,Route de Wylder,,59380
+45 Rue du Maréchal Foch Quesnoy-sur-Deûle,,,,45,Rue du Maréchal Foch,,59890
+45 Rue du Maréchal Foch 59890,,,,45,Rue du Maréchal Foch,Quesnoy-sur-Deûle,
+45 Rue du Maréchal Foch,3.003627,50.711636,2,45,Rue du Maréchal Foch,,59890
+56B Ruelle Patelette Râches,,,,56,Ruelle Patelette,,59194
+56B Ruelle Patelette 59194,,,,56,Ruelle Patelette,Râches,
+56B Ruelle Patelette,3.13318,50.411388,,56,Ruelle Patelette,,59194
+37 Rue Henri Barbusse Raismes,,,,37,Rue Henri Barbusse,,59590
+37 Rue Henri Barbusse 59590,,,,37,Rue Henri Barbusse,Raismes,
+37 Rue Henri Barbusse,3.496558,50.384737,,37,Rue Henri Barbusse,,59590
+12 Rue du Château Renescure,,,,12,Rue du Château,,59173
+12 Rue du Château 59173,,,,12,Rue du Château,Renescure,
+12 Rue du Château,2.367303,50.728072,,12,Rue du Château,,59173
+14 Rue André Malraux Ronchin,,,,14,Rue André Malraux,,59790
+14 Rue André Malraux 59790,,,,14,Rue André Malraux,Ronchin,
+14 Rue André Malraux,3.085307,50.6068,,14,Rue André Malraux,,59790
+6 Rue de l'Abbé Lemire Roncq,,,,6,Rue de l'Abbé Lemire,,59223
+6 Rue de l'Abbé Lemire 59223,,,,6,Rue de l'Abbé Lemire,Roncq,
+6 Rue de l'Abbé Lemire,3.130111,50.734933,2,6,Rue de l'Abbé Lemire,,59223
+10 Rue Arthur Rimbaud Roost-Warendin,,,,10,Rue Arthur Rimbaud,,59286
+10 Rue Arthur Rimbaud 59286,,,,10,Rue Arthur Rimbaud,Roost-Warendin,
+10 Rue Arthur Rimbaud,3.113307,50.418723,2,10,Rue Arthur Rimbaud,,59286
+16 Boulevard de Beaurepaire Roubaix,,,,16,Boulevard de Beaurepaire,,59100
+16 Boulevard de Beaurepaire 59100,,,,16,Boulevard de Beaurepaire,Roubaix,
+16 Boulevard de Beaurepaire,3.191057,50.691005,,16,Boulevard de Beaurepaire,,59100
+9 Rue Desaix Roubaix,,,,9,Rue Desaix,,59100
+9 Rue Desaix 59100,,,,9,Rue Desaix,Roubaix,
+9 Rue Desaix,3.192618,50.688999,,9,Rue Desaix,,59100
+294 Rue Ingres Roubaix,,,,294,Rue Ingres,,59100
+294 Rue Ingres 59100,,,,294,Rue Ingres,Roubaix,
+294 Rue Ingres,3.186472,50.674927,,294,Rue Ingres,,59100
+16 Rue Marengo Roubaix,,,,16,Rue Marengo,,59100
+16 Rue Marengo 59100,,,,16,Rue Marengo,Roubaix,
+16 Rue Marengo,3.174831,50.704305,,16,Rue Marengo,,59100
+38 Boulevard de la République Roubaix,,,,38,Boulevard de la République,,59100
+38 Boulevard de la République 59100,,,,38,Boulevard de la République,Roubaix,
+38 Boulevard de la République,3.161079,50.701551,,38,Boulevard de la République,,59100
+46 Rue du Grand-Fort Rousies,,,,46,Rue du Grand-Fort,,59131
+46 Rue du Grand-Fort 59131,,,,46,Rue du Grand-Fort,Rousies,
+46 Rue du Grand-Fort,3.977902,50.266603,,46,Rue du Grand-Fort,,59131
+28 Rue Pasteur Sainghin-en-Mélantois,,,,28,Rue Pasteur,,59262
+28 Rue Pasteur 59262,,,,28,Rue Pasteur,Sainghin-en-Mélantois,
+28 Rue Pasteur,3.177454,50.589714,,28,Rue Pasteur,,59262
+158 Rue de la Collinière Saint-Amand-les-Eaux,,,,158,Rue de la Collinière,,59230
+158 Rue de la Collinière 59230,,,,158,Rue de la Collinière,Saint-Amand-les-Eaux,
+158 Rue de la Collinière,3.430691,50.436078,,158,Rue de la Collinière,,59230
+25 Rue de Thumelart Saint-Amand-les-Eaux,,,,25,Rue de Thumelart,,59230
+25 Rue de Thumelart 59230,,,,25,Rue de Thumelart,Saint-Amand-les-Eaux,
+25 Rue de Thumelart,3.442172,50.446925,,25,Rue de Thumelart,,59230
+9 Rue Victor Hugo Saint-Aubert,,,,9,Rue Victor Hugo,,59188
+9 Rue Victor Hugo 59188,,,,9,Rue Victor Hugo,Saint-Aubert,
+9 Rue Victor Hugo,3.420311,50.206752,,9,Rue Victor Hugo,,59188
+32A Rue Charles Giraud Saint-Saulve,,,,32A,Rue Charles Giraud,,59880
+32A Rue Charles Giraud 59880,,,,32A,Rue Charles Giraud,Saint-Saulve,
+32A Rue Charles Giraud,3.557418,50.373649,,32A,Rue Charles Giraud,,59880
+12 Rue Emile Dubois Salomé,,,,12,Rue Emile Dubois,,59496
+12 Rue Emile Dubois 59496,,,,12,Rue Emile Dubois,Salomé,
+12 Rue Emile Dubois,2.848427,50.534044,,12,Rue Emile Dubois,,59496
+38 Rue Arthur Breucq Saultain,,,,38,Rue Arthur Breucq,,59990
+38 Rue Arthur Breucq 59990,,,,38,Rue Arthur Breucq,Saultain,
+38 Rue Arthur Breucq,3.572094,50.333981,,38,Rue Arthur Breucq,,59990
+32 Rue de la Naviette Seclin,,,,32,Rue de la Naviette,,59113
+32 Rue de la Naviette 59113,,,,32,Rue de la Naviette,Seclin,
+32 Rue de la Naviette,3.013429,50.541161,,32,Rue de la Naviette,,59113
+40 Rue Alcide Moché Sin-le-Noble,,,,40,Rue Alcide Moché,,59450
+40 Rue Alcide Moché 59450,,,,40,Rue Alcide Moché,Sin-le-Noble,
+40 Rue Alcide Moché,3.114885,50.366988,,40,Rue Alcide Moché,,59450
+12 Résidence Alexia Iv Sin-le-Noble,,,,12,Résidence Alexia Iv,,59450
+12 Résidence Alexia Iv 59450,,,,12,Résidence Alexia Iv,Sin-le-Noble,
+12 Résidence Alexia Iv,3.099176,50.345457,,12,Résidence Alexia Iv,,59450
+19 Rue de Fayence Somain,,,,19,Rue de Fayence,,59490
+19 Rue de Fayence 59490,,,,19,Rue de Fayence,Somain,
+19 Rue de Fayence,3.268381,50.372871,,19,Rue de Fayence,,59490
+7 Chemin de Champs Steene,,,,7,Chemin de Champs,,59380
+7 Chemin de Champs 59380,,,,7,Chemin de Champs,Steene,
+7 Chemin de Champs,2.371346,50.950241,,7,Chemin de Champs,,59380
+7 Rue Jean Jaurès Templemars,,,,7,Rue Jean Jaurès,,59175
+7 Rue Jean Jaurès 59175,,,,7,Rue Jean Jaurès,Templemars,
+7 Rue Jean Jaurès,3.055701,50.568724,,7,Rue Jean Jaurès,,59175
+188 Rue des Pierres Téteghem,,,,188,Rue des Pierres,,59229
+188 Rue des Pierres 59229,,,,188,Rue des Pierres,Téteghem-Coudekerque-Village,
+188 Rue des Pierres,2.454387,51.007269,,188,Rue des Pierres,,59229
+16 Rue des Azalées Toufflers,,,,16,Rue des Azalées,,59390
+16 Rue des Azalées 59390,,,,16,Rue des Azalées,Toufflers,
+16 Rue des Azalées,3.22537,50.664541,,16,Rue des Azalées,,59390
+379 Rue du Blanc Seau Tourcoing,,,,379,Rue du Blanc Seau,,59200
+379 Rue du Blanc Seau 59200,,,,379,Rue du Blanc Seau,Tourcoing,
+379 Rue du Blanc Seau,3.152676,50.700555,,379,Rue du Blanc Seau,,59200
+20 Rue de Creil Tourcoing,,,,20,Rue de Creil,,59200
+20 Rue de Creil 59200,,,,20,Rue de Creil,Tourcoing,
+20 Rue de Creil,3.17699,50.725963,,20,Rue de Creil,,59200
+37 Rue du Général Douay Tourcoing,,,,37,Rue du Général Douay,,59200
+37 Rue du Général Douay 59200,,,,37,Rue du Général Douay,Tourcoing,
+37 Rue du Général Douay,3.144455,50.727136,,37,Rue du Général Douay,,59200
+103 Rue de Magenta Tourcoing,,,,103,Rue de Magenta,,59200
+103 Rue de Magenta 59200,,,,103,Rue de Magenta,Tourcoing,
+103 Rue de Magenta,3.160952,50.708694,,103,Rue de Magenta,,59200
+143 Chaussée Pierre Curie Tourcoing,,,,143,Chaussée Pierre Curie,,59200
+143 Chaussée Pierre Curie 59200,,,,143,Chaussée Pierre Curie,Tourcoing,
+143 Chaussée Pierre Curie,3.179949,50.734156,,143,Chaussée Pierre Curie,,59200
+7 Place de la Victoire Tourcoing,,,,7,Place de la Victoire,,59200
+7 Place de la Victoire 59200,,,,7,Place de la Victoire,Tourcoing,
+7 Place de la Victoire,3.157999,50.718157,,7,Place de la Victoire,,59200
+8 Résidence J Dupont R d'Peupliers Trith-Saint-Léger,,,,8,Résidence J Dupont R d'Peupliers,,59125
+8 Résidence J Dupont R d'Peupliers 59125,,,,8,Résidence J Dupont R d'Peupliers,Trith-Saint-Léger,
+8 Résidence J Dupont R d'Peupliers,3.508119,50.338944,,8,Résidence J Dupont R d'Peupliers,,59125
+5 Avenue de Denain Valenciennes,,,,5,Avenue de Denain,,59300
+5 Avenue de Denain 59300,,,,5,Avenue de Denain,Valenciennes,
+5 Avenue de Denain,3.50393,50.356503,,5,Avenue de Denain,,59300
+11 Avenue du Maréchal Leclerc Valenciennes,,,,11,Avenue du Maréchal Leclerc,,59300
+11 Avenue du Maréchal Leclerc 59300,,,,11,Avenue du Maréchal Leclerc,Valenciennes,
+11 Avenue du Maréchal Leclerc,3.519411,50.363943,,11,Avenue du Maréchal Leclerc,,59300
+47 Clos des Tonneliers Le Vignoble Valenciennes,,,,47,Clos des Tonneliers Le Vignoble,,59300
+47 Clos des Tonneliers Le Vignoble 59300,,,,47,Clos des Tonneliers Le Vignoble,Valenciennes,
+47 Clos des Tonneliers Le Vignoble,3.503491,50.350439,,47,Clos des Tonneliers Le Vignoble,,59300
+289 Rue du Pain Sec Vieux-Berquin,,,,289,Rue du Pain Sec,,59232
+289 Rue du Pain Sec 59232,,,,289,Rue du Pain Sec,Vieux-Berquin,
+289 Rue du Pain Sec,2.591522,50.709381,,289,Rue du Pain Sec,,59232
+2 Rue Aimable Liénard Vieux-Reng,,,,2,Rue Aimable Liénard,,59600
+2 Rue Aimable Liénard 59600,,,,2,Rue Aimable Liénard,Vieux-Reng,
+2 Rue Aimable Liénard,4.066714,50.326416,,2,Rue Aimable Liénard,,59600
+21 Voie Communale Groupement du Montsorel Wahagnies,,,,21,Voie Communale Groupement du Montsorel,,59261
+21 Voie Communale Groupement du Montsorel 59261,,,,21,Voie Communale Groupement du Montsorel,Wahagnies,
+21 Voie Communale Groupement du Montsorel,3.037608,50.47989,,21,Voie Communale Groupement du Montsorel,,59261
+169 Rue de l'Agrippin Wambrechies,,,,169,Rue de l'Agrippin,,59118
+169 Rue de l'Agrippin 59118,,,,169,Rue de l'Agrippin,Wambrechies,
+169 Rue de l'Agrippin,3.045818,50.686316,,169,Rue de l'Agrippin,,59118
+38 Rue Firmaine Warlaing,,,,38,Rue Firmaine,,59870
+38 Rue Firmaine 59870,,,,38,Rue Firmaine,Warlaing,
+38 Rue Firmaine,3.31539,50.411146,,38,Rue Firmaine,,59870
+54 Avenue de la Marne Wasquehal,,,,54,Avenue de la Marne,,59290
+54 Avenue de la Marne 59290,,,,54,Avenue de la Marne,Wasquehal,
+54 Avenue de la Marne,3.126854,50.688405,,54,Avenue de la Marne,,59290
+2 Rue Marcel Fertein Wattignies,,,,2,Rue Marcel Fertein,,59139
+2 Rue Marcel Fertein 59139,,,,2,Rue Marcel Fertein,Wattignies,
+2 Rue Marcel Fertein,3.050171,50.600171,,2,Rue Marcel Fertein,,59139
+39 Rue Couteau Wattrelos,,,,39,Rue Couteau,,59150
+39 Rue Couteau 59150,,,,39,Rue Couteau,Wattrelos,
+39 Rue Couteau,3.201617,50.697077,,39,Rue Couteau,,59150
+16 Square Léon Marlot Wattrelos,,,,16,Square Léon Marlot,,59150
+16 Square Léon Marlot 59150,,,,16,Square Léon Marlot,Wattrelos,
+16 Square Léon Marlot,3.205423,50.699003,,16,Square Léon Marlot,,59150
+432BIS Rue du Sapin Vert Wattrelos,,,,432BIS,Rue du Sapin Vert,,59150
+432BIS Rue du Sapin Vert 59150,,,,432BIS,Rue du Sapin Vert,Wattrelos,
+432BIS Rue du Sapin Vert,3.184997,50.713501,,432BIS,Rue du Sapin Vert,,59150
+55 Rue Raymond Poincaré Wavrin,,,,55,Rue Raymond Poincaré,,59136
+55 Rue Raymond Poincaré 59136,,,,55,Rue Raymond Poincaré,Wavrin,
+55 Rue Raymond Poincaré,2.946462,50.571316,,55,Rue Raymond Poincaré,,59136
+54 Rue Théodore Brasme Wicres,,,,54,Rue Théodore Brasme,,59134
+54 Rue Théodore Brasme 59134,,,,54,Rue Théodore Brasme,Wicres,
+54 Rue Théodore Brasme,2.865642,50.570858,,54,Rue Théodore Brasme,,59134
+434 Route de Steenvoorde Wormhout,,,,434,Route de Steenvoorde,,59470
+434 Route de Steenvoorde 59470,,,,434,Route de Steenvoorde,Wormhout,
+434 Route de Steenvoorde,2.473476,50.879144,,434,Route de Steenvoorde,,59470
+300 Rue d'Avesnes Agnez-lès-Duisans,,,,300,Rue d'Avesnes,,62161
+300 Rue d'Avesnes 62161,,,,300,Rue d'Avesnes,Agnez-lès-Duisans,
+300 Rue d'Avesnes,2.650494,50.313989,,300,Rue d'Avesnes,,62161
+74 Rue Henri Béthouart Airon-Saint-Vaast,,,,74,Rue Henri Béthouart,,62180
+74 Rue Henri Béthouart 62180,,,,74,Rue Henri Béthouart,Airon-Saint-Vaast,
+74 Rue Henri Béthouart,1.660878,50.432106,,74,Rue Henri Béthouart,,62180
+6 Chaussée Brunehaut Amettes,,,,6,Chaussée Brunehaut,,62260
+6 Chaussée Brunehaut 62260,,,,6,Chaussée Brunehaut,Amettes,
+6 Chaussée Brunehaut,2.406646,50.532101,,6,Chaussée Brunehaut,,62260
+9 Rue des Hortensias Annezin,,,,9,Rue des Hortensias,,62232
+9 Rue des Hortensias 62232,,,,9,Rue des Hortensias,Annezin,
+9 Rue des Hortensias,2.613845,50.537138,,9,Rue des Hortensias,,62232
+32 Rue d'Oppy Arleux-en-Gohelle,,,,32,Rue d'Oppy,,62580
+32 Rue d'Oppy 62580,,,,32,Rue d'Oppy,Arleux-en-Gohelle,
+32 Rue d'Oppy,2.873808,50.361775,,32,Rue d'Oppy,,62580
+9 Rue du Bloc Arras,,,,9,Rue du Bloc,,62000
+9 Rue du Bloc 62000,,,,9,Rue du Bloc,Arras,
+9 Rue du Bloc,2.772323,50.293568,,9,Rue du Bloc,,62000
+26 Avenue Jean Jaurès Arras,,,,26,Avenue Jean Jaurès,,62000
+26 Avenue Jean Jaurès 62000,,,,26,Avenue Jean Jaurès,Arras,
+26 Avenue Jean Jaurès,2.77946,50.27949,,26,Avenue Jean Jaurès,,62000
+4 Impasse Zéphyr Thomas Arras,,,,4,Impasse Zéphyr Thomas,,62000
+4 Impasse Zéphyr Thomas 62000,,,,4,Impasse Zéphyr Thomas,Arras,
+4 Impasse Zéphyr Thomas,2.748897,50.292704,,4,Impasse Zéphyr Thomas,,62000
+22 Rue du Paradis Auchel,,,,22,Rue du Paradis,,62260
+22 Rue du Paradis 62260,,,,22,Rue du Paradis,Auchel,
+22 Rue du Paradis,2.482407,50.512785,,22,Rue du Paradis,,62260
+15 Rue Accary Audresselles,,,,15,Rue Accary,,62164
+15 Rue Accary 62164,,,,15,Rue Accary,Audresselles,
+15 Rue Accary,1.592125,50.822883,,15,Rue Accary,,62164
+14 Rue Boussingault Avion,,,,14,Rue Boussingault,,62210
+14 Rue Boussingault 62210,,,,14,Rue Boussingault,Avion,
+14 Rue Boussingault,2.835133,50.408002,,14,Rue Boussingault,,62210
+3BIS Rue de Moyenneville Ayette,,,,3BIS,Rue de Moyenneville,,62116
+3BIS Rue de Moyenneville 62116,,,,3BIS,Rue de Moyenneville,Ayette,
+3BIS Rue de Moyenneville,2.736687,50.176547,,3BIS,Rue de Moyenneville,,62116
+45 Rue d'Houdain Barlin,,,,45,Rue d'Houdain,,62620
+45 Rue d'Houdain 62620,,,,45,Rue d'Houdain,Barlin,
+45 Rue d'Houdain,2.610775,50.459324,,45,Rue d'Houdain,,62620
+15 Rue Simone Jagu Beaurains,,,,15,Rue Simone Jagu,,62217
+15 Rue Simone Jagu 62217,,,,15,Rue Simone Jagu,Beaurains,
+15 Rue Simone Jagu,2.782739,50.267254,,15,Rue Simone Jagu,,62217
+4 Rue de la Marine Berck,,,,4,Rue de la Marine,,62600
+4 Rue de la Marine 62600,,,,4,Rue de la Marine,Berck,
+4 Rue de la Marine,1.583967,50.40739,,4,Rue de la Marine,,62600
+307 RUE DU BEAU MARAIS Béthune,,,,307,MARAIS,,62400
+307 RUE DU BEAU MARAIS 62400,,,,307,MARAIS,Béthune,
+307 RUE DU BEAU MARAIS,2.649996,50.532409,,307,MARAIS,,62400
+2 Rue Parmentier Béthune,,,,2,Rue Parmentier,,62400
+2 Rue Parmentier 62400,,,,2,Rue Parmentier,Béthune,
+2 Rue Parmentier,2.626935,50.527897,,2,Rue Parmentier,,62400
+155 Rue Germon Beuvry,,,,155,Rue Germon,,62660
+155 Rue Germon 62660,,,,155,Rue Germon,Beuvry,
+155 Rue Germon,2.691955,50.532343,,155,Rue Germon,,62660
+4 Rue Lamartine Billy-Berclau,,,,4,Rue Lamartine,,62138
+4 Rue Lamartine 62138,,,,4,Rue Lamartine,Billy-Berclau,
+4 Rue Lamartine,2.877387,50.523379,,4,Rue Lamartine,,62138
+31 Rue de l'Hermitage Blendecques,,,,31,Rue de l'Hermitage,,62575
+31 Rue de l'Hermitage 62575,,,,31,Rue de l'Hermitage,Blendecques,
+31 Rue de l'Hermitage,2.266427,50.712505,,31,Rue de l'Hermitage,,62575
+44 Rue de l'Amiral Bruix Boulogne-sur-Mer,,,,44,Rue de l'Amiral Bruix,,62200
+44 Rue de l'Amiral Bruix 62200,,,,44,Rue de l'Amiral Bruix,Boulogne-sur-Mer,
+44 Rue de l'Amiral Bruix,1.60358,50.723069,,44,Rue de l'Amiral Bruix,,62200
+89 Rue Faidherbe Boulogne-sur-Mer,,,,89,Rue Faidherbe,,62200
+89 Rue Faidherbe 62200,,,,89,Rue Faidherbe,Boulogne-sur-Mer,
+89 Rue Faidherbe,1.606249,50.725833,,89,Rue Faidherbe,,62200
+318 Boulevard Sainte-Beuve Boulogne-sur-Mer,,,,318,Boulevard Sainte-Beuve,,62200
+318 Boulevard Sainte-Beuve 62200,,,,318,Boulevard Sainte-Beuve,Boulogne-sur-Mer,
+318 Boulevard Sainte-Beuve,1.594486,50.73566,,318,Boulevard Sainte-Beuve,,62200
+26 Rue de Corbehem Brebières,,,,26,Rue de Corbehem,,62117
+26 Rue de Corbehem 62117,,,,26,Rue de Corbehem,Brebières,
+26 Rue de Corbehem,3.025246,50.337436,,26,Rue de Corbehem,,62117
+126 Rue Coquel Bruay-la-Buissière,,,,126,Rue Coquel,,62700
+126 Rue Coquel 62700,,,,126,Rue Coquel,Bruay-la-Buissière,
+126 Rue Coquel,2.54346,50.490531,,126,Rue Coquel,,62700
+12 Rue de Pologne Bruay-la-Buissière,,,,12,Rue de Pologne,,62700
+12 Rue de Pologne 62700,,,,12,Rue de Pologne,Bruay-la-Buissière,
+12 Rue de Pologne,2.530334,50.491633,,12,Rue de Pologne,,62700
+1 Rue d'Enghien Bully-les-Mines,,,,1,Rue d'Enghien,,62160
+1 Rue d'Enghien 62160,,,,1,Rue d'Enghien,Bully-les-Mines,
+1 Rue d'Enghien,2.740679,50.441568,,1,Rue d'Enghien,,62160
+2 Rue des Planchettes Busnes,,,,2,Rue des Planchettes,,62350
+2 Rue des Planchettes 62350,,,,2,Rue des Planchettes,Busnes,
+2 Rue des Planchettes,2.51654,50.588893,,2,Rue des Planchettes,,62350
+24 Rue du Château D'Eau Calais,,,,24,Rue du Château D'Eau,,62100
+24 Rue du Château D'Eau 62100,,,,24,Rue du Château D'Eau,Calais,
+24 Rue du Château D'Eau,1.85184,50.945275,,24,Rue du Château D'Eau,,62100
+1 Quai de la Gendarmerie Calais,,,,1,Quai de la Gendarmerie,,62100
+1 Quai de la Gendarmerie 62100,,,,1,Quai de la Gendarmerie,Calais,
+1 Quai de la Gendarmerie,1.858472,50.952986,,1,Quai de la Gendarmerie,,62100
+40 Rue de Malaga Calais,,,,40,Rue de Malaga,,62100
+40 Rue de Malaga 62100,,,,40,Rue de Malaga,Calais,
+40 Rue de Malaga,1.834182,50.945823,,40,Rue de Malaga,,62100
+34BIS Chemin de Régniers Calais,,,,34BIS,Chemin de Régniers,,62100
+34BIS Chemin de Régniers 62100,,,,34BIS,Chemin de Régniers,Calais,
+34BIS Chemin de Régniers,1.853723,50.93483,,34BIS,Chemin de Régniers,,62100
+115 Rue de Camblain Calonne-Ricouart,,,,115,Rue de Camblain,,62470
+115 Rue de Camblain 62470,,,,115,Rue de Camblain,Calonne-Ricouart,
+115 Rue de Camblain,2.467224,50.497597,,115,Rue de Camblain,,62470
+50 Allée des Milouins Camiers,,,,50,Allée des Milouins,,62176
+50 Allée des Milouins 62176,,,,50,Allée des Milouins,Camiers,
+50 Allée des Milouins,1.598317,50.571714,,50,Allée des Milouins,,62176
+76 Rue Émile Zola Carvin,,,,76,Rue Émile Zola,,62220
+76 Rue Émile Zola 62220,,,,76,Rue Émile Zola,Carvin,
+76 Rue Émile Zola,2.953786,50.494631,,76,Rue Émile Zola,,62220
+15 Rue Laure Marelle Cauchy-à-la-Tour,,,,15,Rue Laure Marelle,,62260
+15 Rue Laure Marelle 62260,,,,15,Rue Laure Marelle,Cauchy-à-la-Tour,
+15 Rue Laure Marelle,2.456806,50.504145,,15,Rue Laure Marelle,,62260
+2BIS Rue de l'Église Condette,,,,2BIS,Rue de l'Église,,62360
+2BIS Rue de l'Église 62360,,,,2BIS,Rue de l'Église,Condette,
+2BIS Rue de l'Église,1.639961,50.653854,,2BIS,Rue de l'Église,,62360
+118BIS Rue Principale Coulomby,,,,118BIS,Rue Principale,,62380
+118BIS Rue Principale 62380,,,,118BIS,Rue Principale,Coulomby,
+118BIS Rue Principale,2.011533,50.706109,,118BIS,Rue Principale,,62380
+3 Rue des Martinets Courrières,,,,3,Rue des Martinets,,62710
+3 Rue des Martinets 62710,,,,3,Rue des Martinets,Courrières,
+3 Rue des Martinets,2.95755,50.455963,,3,Rue des Martinets,,62710
+496 Rue Emile Grevet Cucq,,,,496,Rue Emile Grevet,,62780
+496 Rue Emile Grevet 62780,,,,496,Rue Emile Grevet,Cucq,
+496 Rue Emile Grevet,1.626047,50.501951,,496,Rue Emile Grevet,,62780
+25 Rue de Verdun Dainville,,,,25,Rue de Verdun,,62000
+25 Rue de Verdun 62000,,,,25,Rue de Verdun,Dainville,
+25 Rue de Verdun,2.730205,50.280899,,25,Rue de Verdun,,62000
+13 Rue Ionesco Divion,,,,13,Rue Ionesco,,62460
+13 Rue Ionesco 62460,,,,13,Rue Ionesco,Divion,
+13 Rue Ionesco,2.491434,50.473712,,13,Rue Ionesco,,62460
+30 Rue Cuvillier Douvrin,,,,30,Rue Cuvillier,,62138
+30 Rue Cuvillier 62138,,,,30,Rue Cuvillier,Douvrin,
+30 Rue Cuvillier,2.82962,50.510804,,30,Rue Cuvillier,,62138
+1410 Rue de Cassel Ecques,,,,1410,Rue de Cassel,,62129
+1410 Rue de Cassel 62129,,,,1410,Rue de Cassel,Ecques,
+1410 Rue de Cassel,2.295753,50.661206,,1410,Rue de Cassel,,62129
+59 Rue de la Courtille Équihen-Plage,,,,59,Rue de la Courtille,,62224
+59 Rue de la Courtille 62224,,,,59,Rue de la Courtille,Équihen-Plage,
+59 Rue de la Courtille,1.575372,50.681205,,59,Rue de la Courtille,,62224
+1 Rue du Château d'Eau Étaples,,,,1,Rue du Château d'Eau,,62630
+1 Rue du Château d'Eau 62630,,,,1,Rue du Château d'Eau,Étaples,
+1 Rue du Château d'Eau,1.652837,50.518803,,1,Rue du Château d'Eau,,62630
+65 Rue d'Arras Fampoux,,,,65,Rue d'Arras,,62118
+65 Rue d'Arras 62118,,,,65,Rue d'Arras,Fampoux,
+65 Rue d'Arras,2.863444,50.301568,,65,Rue d'Arras,,62118
+29 Rue de la Malassise Fleurbaix,,,,29,Rue de la Malassise,,62840
+29 Rue de la Malassise 62840,,,,29,Rue de la Malassise,Fleurbaix,
+29 Rue de la Malassise,2.836445,50.652153,,29,Rue de la Malassise,,62840
+17 Rue Léo Lagrange Fresnicourt-le-Dolmen,,,,17,Rue Léo Lagrange,,62150
+17 Rue Léo Lagrange 62150,,,,17,Rue Léo Lagrange,Fresnicourt-le-Dolmen,
+17 Rue Léo Lagrange,2.586904,50.423836,,17,Rue Léo Lagrange,,62150
+33 Rue Marcel Sembat Givenchy-en-Gohelle,,,,33,Rue Marcel Sembat,,62580
+33 Rue Marcel Sembat 62580,,,,33,Rue Marcel Sembat,Givenchy-en-Gohelle,
+33 Rue Marcel Sembat,2.768739,50.394576,,33,Rue Marcel Sembat,,62580
+6 Rue Louis Legay Grenay,,,,6,Rue Louis Legay,,62160
+6 Rue Louis Legay 62160,,,,6,Rue Louis Legay,Grenay,
+6 Rue Louis Legay,2.743214,50.446963,,6,Rue Louis Legay,,62160
+14 Avenue de Verdun Guînes,,,,14,Avenue de Verdun,,62340
+14 Avenue de Verdun 62340,,,,14,Avenue de Verdun,Guînes,
+14 Avenue de Verdun,1.863325,50.865374,,14,Avenue de Verdun,,62340
+16 Rue de l'Église Ham-en-Artois,,,,16,Rue de l'Église,,62190
+16 Rue de l'Église 62190,,,,16,Rue de l'Église,Ham-en-Artois,
+16 Rue de l'Église,2.453457,50.589796,,16,Rue de l'Église,,62190
+20 Rue de Saint-Claude Harnes,,,,20,Rue de Saint-Claude,,62440
+20 Rue de Saint-Claude 62440,,,,20,Rue de Saint-Claude,Harnes,
+20 Rue de Saint-Claude,2.885522,50.443679,,20,Rue de Saint-Claude,,62440
+67 Rue du Docteur Laennec Hénin-Beaumont,,,,67,Rue du Docteur Laennec,,62110
+67 Rue du Docteur Laennec 62110,,,,67,Rue du Docteur Laennec,Hénin-Beaumont,
+67 Rue du Docteur Laennec,2.946247,50.430665,,67,Rue du Docteur Laennec,,62110
+133 Rue Mirabeau Hénin-Beaumont,,,,133,Rue Mirabeau,,62110
+133 Rue Mirabeau 62110,,,,133,Rue Mirabeau,Hénin-Beaumont,
+133 Rue Mirabeau,2.943184,50.426527,,133,Rue Mirabeau,,62110
+16 Rue Berthelot Hersin-Coupigny,,,,16,Rue Berthelot,,62530
+16 Rue Berthelot 62530,,,,16,Rue Berthelot,Hersin-Coupigny,
+16 Rue Berthelot,2.651906,50.454255,,16,Rue Berthelot,,62530
+67 Rue d'Aire Heuchin,,,,67,Rue d'Aire,,62134
+67 Rue d'Aire 62134,,,,67,Rue d'Aire,Heuchin,
+67 Rue d'Aire,2.273693,50.480533,,67,Rue d'Aire,,62134
+73 Rue de Vincq Houlle,,,,73,Rue de Vincq,,62910
+73 Rue de Vincq 62910,,,,73,Rue de Vincq,Houlle,
+73 Rue de Vincq,2.196549,50.809475,,73,Rue de Vincq,,62910
+15 Rue de la Roupie Isbergues,,,,15,Rue de la Roupie,,62330
+15 Rue de la Roupie 62330,,,,15,Rue de la Roupie,Isbergues,
+15 Rue de la Roupie,2.436322,50.63029,,15,Rue de la Roupie,,62330
+12 Rue de Prédefin Laires,,,,12,Rue de Prédefin,,62960
+12 Rue de Prédefin 62960,,,,12,Rue de Prédefin,Laires,
+12 Rue de Prédefin,2.257489,50.537882,,12,Rue de Prédefin,,62960
+29 Rue de Doullens Leforest,,,,29,Rue de Doullens,,62790
+29 Rue de Doullens 62790,,,,29,Rue de Doullens,Leforest,
+29 Rue de Doullens,3.057061,50.442445,,29,Rue de Doullens,,62790
+6 Rue du 19 Mars 1962 Lens,,,,6,Rue du 19 Mars 1962,,62300
+6 Rue du 19 Mars 1962 62300,,,,6,Rue du 19 Mars 1962,Lens,
+6 Rue du 19 Mars 1962,2.840617,50.431926,,6,Rue du 19 Mars 1962,,62300
+209 Rue Molière Lens,,,,209,Rue Molière,,62300
+209 Rue Molière 62300,,,,209,Rue Molière,Lens,
+209 Rue Molière,2.796306,50.437101,,209,Rue Molière,,62300
+2132 Rue Delflie Lestrem,,,,2132,Rue Delflie,,62136
+2132 Rue Delflie 62136,,,,2132,Rue Delflie,Lestrem,
+2132 Rue Delflie,2.653285,50.600295,,2132,Rue Delflie,,62136
+5 Rue Denfert Rochereau Liévin,,,,5,Rue Denfert Rochereau,,62800
+5 Rue Denfert Rochereau 62800,,,,5,Rue Denfert Rochereau,Liévin,
+5 Rue Denfert Rochereau,2.773937,50.414615,,5,Rue Denfert Rochereau,,62800
+4 Rue Mozart Liévin,,,,4,Rue Wolfgang Mozart,,62800
+4 Rue Mozart 62800,,,,4,Rue Wolfgang Mozart,Liévin,
+4 Rue Mozart,2.764032,50.420897,,4,Rue Wolfgang Mozart,,62800
+135 Rue de la Haye Lillers,,,,135,Rue de la Haye,,62190
+135 Rue de la Haye 62190,,,,135,Rue de la Haye,Lillers,
+135 Rue de la Haye,2.458961,50.564003,,135,Rue de la Haye,,62190
+53 Rue Léon Blum Loison-sous-Lens,,,,53,Rue Léon Blum,,62218
+53 Rue Léon Blum 62218,,,,53,Rue Léon Blum,Loison-sous-Lens,
+53 Rue Léon Blum,2.862614,50.43852,,53,Rue Léon Blum,,62218
+20 Rue Decrombecque Loos-en-Gohelle,,,,20,Rue Decrombecque,,62750
+20 Rue Decrombecque 62750,,,,20,Rue Decrombecque,Loos-en-Gohelle,
+20 Rue Decrombecque,2.799763,50.457953,,20,Rue Decrombecque,,62750
+5 Rue des Charbonniers Magnicourt-en-Comte,,,,5,Rue des Charbonniers,,62127
+5 Rue des Charbonniers 62127,,,,5,Rue des Charbonniers,Magnicourt-en-Comte,
+5 Rue des Charbonniers,2.485575,50.40396,,5,Rue des Charbonniers,,62127
+630 Avenue de Verdun Marck,,,,630,Avenue de Verdun,,62730
+630 Avenue de Verdun 62730,,,,630,Avenue de Verdun,Marck,
+630 Avenue de Verdun,1.939797,50.953148,,630,Avenue de Verdun,,62730
+48 Rue d'Etrun Marœuil,,,,48,Rue d'Etrun,,62161
+48 Rue d'Etrun 62161,,,,48,Rue d'Etrun,Marœuil,
+48 Rue d'Etrun,2.70561,50.321447,,48,Rue d'Etrun,,62161
+5 Ruelle Monniez Mazingarbe,,,,5,Ruelle Monniez,,62670
+5 Ruelle Monniez 62670,,,,5,Ruelle Monniez,Mazingarbe,
+5 Ruelle Monniez,2.72009,50.474622,,5,Ruelle Monniez,,62670
+119B Rue Pierre Simon Méricourt,,,,119B,Rue Pierre Simon,,62680
+119B Rue Pierre Simon 62680,,,,119B,Rue Pierre Simon,Méricourt,
+119B Rue Pierre Simon,2.882195,50.41139,,119B,Rue Pierre Simon,,62680
+21 Rue Thomas Meurchin,,,,21,Rue Thomas,,62410
+21 Rue Thomas 62410,,,,21,Rue Thomas,Meurchin,
+21 Rue Thomas,2.881511,50.497457,,21,Rue Thomas,,62410
+25 Rue de Sartène Montigny-en-Gohelle,,,,25,Rue de Sartène,,62640
+25 Rue de Sartène 62640,,,,25,Rue de Sartène,Montigny-en-Gohelle,
+25 Rue de Sartène,2.939533,50.430042,,25,Rue de Sartène,,62640
+2 Allée des Geais Neufchâtel-Hardelot,,,,2,Allée des Geais,,62152
+2 Allée des Geais 62152,,,,2,Allée des Geais,Neufchâtel-Hardelot,
+2 Allée des Geais,1.601782,50.630593,,2,Allée des Geais,,62152
+8022 Rue Fleming Nœux-les-Mines,,,,8022,Rue Fleming,,62290
+8022 Rue Fleming 62290,,,,8022,Rue Fleming,Nœux-les-Mines,
+8022 Rue Fleming,2.656455,50.47724,,8022,Rue Fleming,,62290
+63 Rue Arthur Lamendin Noyelles-Godault,,,,63,Rue Arthur Lamendin,,62950
+63 Rue Arthur Lamendin 62950,,,,63,Rue Arthur Lamendin,Noyelles-Godault,
+63 Rue Arthur Lamendin,2.998968,50.416686,,63,Rue Arthur Lamendin,,62950
+91 Rue du 11 Novembre Noyelles-sous-Lens,,,,91,Rue du 11 Novembre,,62221
+91 Rue du 11 Novembre 62221,,,,91,Rue du 11 Novembre,Noyelles-sous-Lens,
+91 Rue du 11 Novembre,2.875325,50.433573,,91,Rue du 11 Novembre,,62221
+4 Impasse Savary Bouquet Oignies,,,,4,Impasse Savary Bouquet,,62590
+4 Impasse Savary Bouquet 62590,,,,4,Impasse Savary Bouquet,Oignies,
+4 Impasse Savary Bouquet,3.011311,50.467954,,4,Impasse Savary Bouquet,,62590
+2 Square Musset Outreau,,,,2,Square Musset,,62230
+2 Square Musset 62230,,,,2,Square Musset,Outreau,
+2 Square Musset,1.586048,50.702582,,2,Square Musset,,62230
+37 Rue de Verdun Pas-en-Artois,,,,37,Rue de Verdun,,62760
+37 Rue de Verdun 62760,,,,37,Rue de Verdun,Pas-en-Artois,
+37 Rue de Verdun,2.484169,50.16029,,37,Rue de Verdun,,62760
+195 Rue Carnot Le Portel,,,,195,Rue Carnot,,62480
+195 Rue Carnot 62480,,,,195,Rue Carnot,Le Portel,
+195 Rue Carnot,1.581045,50.710159,,195,Rue Carnot,,62480
+42 Rue du Marais Quiestède,,,,42,Rue du Marais,,62120
+42 Rue du Marais 62120,,,,42,Rue du Marais,Quiestède,
+42 Rue du Marais,2.33994,50.680402,,42,Rue du Marais,,62120
+33 Rue de la Moulière Remilly-Wirquin,,,,33,Rue de la Moulière,,62380
+33 Rue de la Moulière 62380,,,,33,Rue de la Moulière,Remilly-Wirquin,
+33 Rue de la Moulière,2.157895,50.663168,,33,Rue de la Moulière,,62380
+300 Rue du Moulin de Landrethun Rodelinghem,,,,300,Rue du Moulin de Landrethun,,62610
+300 Rue du Moulin de Landrethun 62610,,,,300,Rue du Moulin de Landrethun,Rodelinghem,
+300 Rue du Moulin de Landrethun,1.945174,50.83003,,300,Rue du Moulin de Landrethun,,62610
+10 Ruelle de l'Hôpital Ruitz,,,,10,Ruelle de l'Hôpital,,62620
+10 Ruelle de l'Hôpital 62620,,,,10,Ruelle de l'Hôpital,Ruitz,
+10 Ruelle de l'Hôpital,2.593997,50.466773,,10,Ruelle de l'Hôpital,,62620
+40 Rue Jean Jacques Rousseau Sains-en-Gohelle,,,,40,Rue Jean Jacques Rousseau,,62114
+40 Rue Jean Jacques Rousseau 62114,,,,40,Rue Jean Jacques Rousseau,Sains-en-Gohelle,
+40 Rue Jean Jacques Rousseau,2.681755,50.450067,,40,Rue Jean Jacques Rousseau,,62114
+81 Rue de Calais Saint-Folquin,,,,81,Rue de Calais,,62370
+81 Rue de Calais 62370,,,,81,Rue de Calais,Saint-Folquin,
+81 Rue de Calais,2.123362,50.945957,,81,Rue de Calais,,62370
+47 Avenue du Moulin Saint-Léonard,,,,47,Avenue du Moulin,,62360
+47 Avenue du Moulin 62360,,,,47,Avenue du Moulin,Saint-Léonard,
+47 Avenue du Moulin,1.629806,50.687663,,47,Avenue du Moulin,,62360
+54 Rue Marteau Saint-Martin-Boulogne,,,,54,Rue Marteau,,62280
+54 Rue Marteau 62280,,,,54,Rue Marteau,Saint-Martin-Boulogne,
+54 Rue Marteau,1.636167,50.726677,,54,Rue Marteau,,62280
+23B Rue du Doulac Saint-Omer,,,,23B,Rue du Doulac,,62500
+23B Rue du Doulac 62500,,,,23B,Rue du Doulac,Saint-Omer,
+23B Rue du Doulac,2.268552,50.767091,,23B,Rue du Doulac,,62500
+3 Rue Lamartine Saint-Pol-sur-Ternoise,,,,3,Rue Lamartine,,62130
+3 Rue Lamartine 62130,,,,3,Rue Lamartine,Saint-Pol-sur-Ternoise,
+3 Rue Lamartine,2.335829,50.385229,,3,Rue Lamartine,,62130
+11 Rue de Ronchin Sallaumines,,,,11,Rue de Ronchin,,62430
+11 Rue de Ronchin 62430,,,,11,Rue de Ronchin,Sallaumines,
+11 Rue de Ronchin,2.860679,50.417529,,11,Rue de Ronchin,,62430
+39 Rue du Marais Savy-Berlette,,,,39,Rue du Marais,,62690
+39 Rue du Marais 62690,,,,39,Rue du Marais,Savy-Berlette,
+39 Rue du Marais,2.571683,50.356247,,39,Rue du Marais,,62690
+5 Ruellette La Ruellette Teneur,,,,5,Ruellette La Ruellette,,62134
+5 Ruellette La Ruellette 62134,,,,5,Ruellette La Ruellette,Teneur,
+5 Ruellette La Ruellette,2.233334,50.453258,,5,Ruellette La Ruellette,,62134
+85 Rue de Londres Le Touquet-Paris-Plage,,,,85,Rue de Londres,,62520
+85 Rue de Londres 62520,,,,85,Rue de Londres,Le Touquet-Paris-Plage,
+85 Rue de Londres,1.583615,50.522788,,85,Rue de Londres,,62520
+4 Rue Courbet Vendin-le-Vieil,,,,4,Rue Courbet,,62880
+4 Rue Courbet 62880,,,,4,Rue Courbet,Vendin-le-Vieil,
+4 Rue Courbet,2.840093,50.449185,,4,Rue Courbet,,62880
+27 Rue Constant Martin Verquin,,,,27,Rue Constant Martin,,62131
+27 Rue Constant Martin 62131,,,,27,Rue Constant Martin,Verquin,
+27 Rue Constant Martin,2.641294,50.501418,,27,Rue Constant Martin,,62131
+15 Rue Roger Salengro Vimy,,,,15,Rue Roger Salengro,,62580
+15 Rue Roger Salengro 62580,,,,15,Rue Roger Salengro,Vimy,
+15 Rue Roger Salengro,2.801865,50.370954,,15,Rue Roger Salengro,,62580
+8 Rue du Haut Wamin,,,,8,Rue du Haut,,62770
+8 Rue du Haut 62770,,,,8,Rue du Haut,Wamin,
+8 Rue du Haut,2.055461,50.415592,,8,Rue du Haut,,62770
+20 Rue Jean Moulin Wimereux,,,,20,Rue Jean Moulin,,62930
+20 Rue Jean Moulin 62930,,,,20,Rue Jean Moulin,Wimereux,
+20 Rue Jean Moulin,1.614382,50.775737,,20,Rue Jean Moulin,,62930
+7 Avenue de la Verrerie Wingles,,,,7,Avenue de la Verrerie,,62410
+7 Avenue de la Verrerie 62410,,,,7,Avenue de la Verrerie,Wingles,
+7 Avenue de la Verrerie,2.870264,50.493851,,7,Avenue de la Verrerie,,62410
+1596 Rue de la Montoire Zutkerque,,,,1596,Rue de la Montoire,,62370
+1596 Rue de la Montoire 62370,,,,1596,Rue de la Montoire,Zutkerque,
+1596 Rue de la Montoire,2.028339,50.851355,,1596,Rue de la Montoire,,62370
+augustines arras,,,2,Petit,Petit Chemin des Augustines,Arras,
+augustines arras,,,,Rue,Rue des Augustines,Arras,
+rue jean jaures Helemmes,,,,Rue,Rue Jean Jaurès,,59491
+rue charles saint venant lomme,,,,Rue,Rue Charles Saint-Venant,Lille,59160

--- a/geocoder_tester/world/france/paysdelaloire/test_addresses.csv
+++ b/geocoder_tester/world/france/paysdelaloire/test_addresses.csv
@@ -1,705 +1,705 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-12A Impasse de la Forge Arthon-en-Retz,,,,12A Impasse de la Forge,,,,44320
-12A Impasse de la Forge 44320,,,,12A Impasse de la Forge,,,Arthon-en-Retz,
-12A Impasse de la Forge,-1.946713,47.117975,,12A Impasse de la Forge,,,,44320
-2 Impasse Paul Claudel Basse-Goulaine,,,,2 Impasse Paul Claudel,,,,44115
-2 Impasse Paul Claudel 44115,,,,2 Impasse Paul Claudel,,,Basse-Goulaine,
-2 Impasse Paul Claudel,-1.464937,47.207470,,2 Impasse Paul Claudel,,,,44115
-3 Avenue des Jonquilles La Bernerie-en-Retz,,,,3 Avenue des Jonquilles,,,,44760
-3 Avenue des Jonquilles 44760,,,,3 Avenue des Jonquilles,,,La Bernerie-en-Retz,
-3 Avenue des Jonquilles,-2.045256,47.096511,,3 Avenue des Jonquilles,,,,44760
-4 Place Saint-Omer Blain,,,,4 Place Saint-Omer,,,,44130
-4 Place Saint-Omer 44130,,,,4 Place Saint-Omer,,,Blain,
-4 Place Saint-Omer,-1.857482,47.474340,,4 Place Saint-Omer,,,,44130
-1 Rue de la Chabossière Bouguenais,,,,1 Rue de la Chabossière,,,,44340
-1 Rue de la Chabossière 44340,,,,1 Rue de la Chabossière,,,Bouguenais,
-1 Rue de la Chabossière,-1.587273,47.186506,,1 Rue de la Chabossière,,,,44340
-1 Square René Clair Bouguenais,,,,1 Square René Clair,,,,44340
-1 Square René Clair 44340,,,,1 Square René Clair,,,Bouguenais,
-1 Square René Clair,-1.587448,47.182124,,1 Square René Clair,,,,44340
-12 Allée des Tilleuls Campbon,,,,12 Allée des Tilleuls,,,,44750
-12 Allée des Tilleuls 44750,,,,12 Allée des Tilleuls,,,Campbon,
-12 Allée des Tilleuls,-1.967584,47.409289,,12 Allée des Tilleuls,,,,44750
-2T Avenue du Professeur Jean Rouxel Carquefou,,,,2T Avenue du Professeur Jean Rouxel,,,,44470
-2T Avenue du Professeur Jean Rouxel 44470,,,,2T Avenue du Professeur Jean Rouxel,,,Carquefou,
-2T Avenue du Professeur Jean Rouxel,-1.500784,47.298647,,2T Avenue du Professeur Jean Rouxel,,,,44470
-29 Rue de la Jô La Chapelle-des-Marais,,,,29 Rue de la Jô,,,,44410
-29 Rue de la Jô 44410,,,,29 Rue de la Jô,,,La Chapelle-des-Marais,
-29 Rue de la Jô,-2.229013,47.454799,,29 Rue de la Jô,,,,44410
-7 Rue François Truffaut La Chapelle-sur-Erdre,,,,7 Rue François Truffaut,,,,44240
-7 Rue François Truffaut 44240,,,,7 Rue François Truffaut,,,La Chapelle-sur-Erdre,
-7 Rue François Truffaut,-1.550099,47.310998,,7 Rue François Truffaut,,,,44240
-14 Rue du Béarn Châteaubriant,,,,14 Rue du Béarn,,,,44110
-14 Rue du Béarn 44110,,,,14 Rue du Béarn,,,Châteaubriant,
-14 Rue du Béarn,-1.376947,47.709993,,14 Rue du Béarn,,,,44110
-26 Rue des Mimosas Chauvé,,,,26 Rue des Mimosas,,,,44320
-26 Rue des Mimosas 44320,,,,26 Rue des Mimosas,,,Chauvé,
-26 Rue des Mimosas,-1.989472,47.153648,,26 Rue des Mimosas,,,,44320
-1 Place des Mimosas Clisson,,,,1 Place des Mimosas,,,,44190
-1 Place des Mimosas 44190,,,,1 Place des Mimosas,,,Clisson,
-1 Place des Mimosas,-1.289697,47.084777,,1 Place des Mimosas,,,,44190
-17 Rue de la Gare Couëron,,,,17 Rue de la Gare,,,,44220
-17 Rue de la Gare 44220,,,,17 Rue de la Gare,,,Couëron,
-17 Rue de la Gare,-1.725642,47.222301,,17 Rue de la Gare,,,,44220
-13 Rue Bretonnie Le Croisic,,,,13 Rue Bretonnie,,,,44490
-13 Rue Bretonnie 44490,,,,13 Rue Bretonnie,,,Le Croisic,
-13 Rue Bretonnie,-2.514335,47.294146,,13 Rue Bretonnie,,,,44490
-45 Rue Évariste Boulay Paty Donges,,,,45 Rue Évariste Boulay Paty,,,,44480
-45 Rue Évariste Boulay Paty 44480,,,,45 Rue Évariste Boulay Paty,,,Donges,
-45 Rue Évariste Boulay Paty,-2.076523,47.320523,,45 Rue Évariste Boulay Paty,,,,44480
-3 Avenue de l'Église La Baule-Escoublac,,,,3 Avenue de l'Église,,,,44500
-3 Avenue de l'Église 44500,,,,3 Avenue de l'Église,,,La Baule-Escoublac,
-3 Avenue de l'Église,-2.371919,47.284189,,3 Avenue de l'Église,,,,44500
-20 Avenue des Ondines La Baule-Escoublac,,,,20 Avenue des Ondines,,,,44500
-20 Avenue des Ondines 44500,,,,20 Avenue des Ondines,,,La Baule-Escoublac,
-20 Avenue des Ondines,-2.402307,47.285353,,20 Avenue des Ondines,,,,44500
-9 Route de Bellevue Frossay,,,,9 Route de Bellevue,,,,44320
-9 Route de Bellevue 44320,,,,9 Route de Bellevue,,,Frossay,
-9 Route de Bellevue,-1.941915,47.247923,,9 Route de Bellevue,,,,44320
-23 Rue de la Houssine Guémené-Penfao,,,,23 Rue de la Houssine,,,,44290
-23 Rue de la Houssine 44290,,,,23 Rue de la Houssine,,,Guémené-Penfao,
-23 Rue de la Houssine,-1.844559,47.630252,,23 Rue de la Houssine,,,,44290
-35 Rue du Moulin de la Place Guérande,,,,35 Rue du Moulin de la Place,,,,44350
-35 Rue du Moulin de la Place 44350,,,,35 Rue du Moulin de la Place,,,Guérande,
-35 Rue du Moulin de la Place,-2.424566,47.322314,,35 Rue du Moulin de la Place,,,,44350
-3 Rue de Préneau Haute-Goulaine,,,,3 Rue de Préneau,,,,44115
-3 Rue de Préneau 44115,,,,3 Rue de Préneau,,,Haute-Goulaine,
-3 Rue de Préneau,-1.395011,47.187436,,3 Rue de Préneau,,,,44115
-27 Rue Joseph Tahet Indre,,,,27 Rue Joseph Tahet,,,,44610
-27 Rue Joseph Tahet 44610,,,,27 Rue Joseph Tahet,,,Indre,
-27 Rue Joseph Tahet,-1.648197,47.193676,,27 Rue Joseph Tahet,,,,44610
-534 Rue Louis Aragon Ligné,,,,534 Rue Louis Aragon,,,,44850
-534 Rue Louis Aragon 44850,,,,534 Rue Louis Aragon,,,Ligné,
-534 Rue Louis Aragon,-1.374487,47.402490,,534 Rue Louis Aragon,,,,44850
-24 Route de Saint-Même Machecoul,,,,24 Route de Saint-Même,,,,44270
-24 Route de Saint-Même 44270,,,,24 Route de Saint-Même,,,Machecoul,
-24 Route de Saint-Même,-1.819886,47.004106,,24 Route de Saint-Même,,,,44270
-200 Rue des Platanes Mésanger,,,,200 Rue des Platanes,,,,44522
-200 Rue des Platanes 44522,,,,200 Rue des Platanes,,,Mésanger,
-200 Rue des Platanes,-1.226522,47.434121,,200 Rue des Platanes,,,,44522
-14 Rue de Bel-Air La Montagne,,,,14 Rue de Bel-Air,,,,44620
-14 Rue de Bel-Air 44620,,,,14 Rue de Bel-Air,,,La Montagne,
-14 Rue de Bel-Air,-1.693059,47.192465,,14 Rue de Bel-Air,,,,44620
-143 Rue Parmentier Montoir-de-Bretagne,,,,143 Rue Parmentier,,,,44550
-143 Rue Parmentier 44550,,,,143 Rue Parmentier,,,Montoir-de-Bretagne,
-143 Rue Parmentier,-2.127400,47.322413,,143 Rue Parmentier,,,,44550
-15 Rue Amiral Duchaffault Nantes,,,,15 Rue Amiral Duchaffault,,,,44100
-15 Rue Amiral Duchaffault 44100,,,,15 Rue Amiral Duchaffault,,,Nantes,
-15 Rue Amiral Duchaffault,-1.580268,47.209380,,15 Rue Amiral Duchaffault,,,,44100
-11 Avenue Botha Nantes,,,,11 Avenue Botha,,,,44100
-11 Avenue Botha 44100,,,,11 Avenue Botha,,,Nantes,
-11 Avenue Botha,-1.593097,47.202538,,11 Avenue Botha,,,,44100
-49 Rue des Clématites Nantes,,,,49 Rue des Clématites,,,,44100
-49 Rue des Clématites 44100,,,,49 Rue des Clématites,,,Nantes,
-49 Rue des Clématites,-1.523468,47.234130,,49 Rue des Clématites,,,,44100
-7 Rue Émile Loubet Nantes,,,,7 Rue Émile Loubet,,,,44100
-7 Rue Émile Loubet 44100,,,,7 Rue Émile Loubet,,,Nantes,
-7 Rue Émile Loubet,-1.569020,47.232213,,7 Rue Émile Loubet,,,,44100
-2 Place Gabriel Trarieux Nantes,,,,2 Place Gabriel Trarieux,,,,44100
-2 Place Gabriel Trarieux 44100,,,,2 Place Gabriel Trarieux,,,Nantes,
-2 Place Gabriel Trarieux,-1.522254,47.225914,,2 Place Gabriel Trarieux,,,,44100
-3 Rue Hectot Nantes,,,,3 Rue Hectot,,,,44100
-3 Rue Hectot 44100,,,,3 Rue Hectot,,,Nantes,
-3 Rue Hectot,-1.530976,47.235641,,3 Rue Hectot,,,,44100
-29 Rue Lamoricière Nantes,,,,29 Rue Lamoricière,,,,44100
-29 Rue Lamoricière 44100,,,,29 Rue Lamoricière,,,Nantes,
-29 Rue Lamoricière,-1.571949,47.213409,,29 Rue Lamoricière,,,,44100
-11B Rue Mellier Nantes,,,,11B Rue Mellier,,,,44100
-11B Rue Mellier 44100,,,,11B Rue Mellier,,,Nantes,
-11B Rue Mellier,-1.578521,47.210715,,11B Rue Mellier,,,,44100
-9 Avenue Père de Foucauld Nantes,,,,9 Avenue Père de Foucauld,,,,44100
-9 Avenue Père de Foucauld 44100,,,,9 Avenue Père de Foucauld,,,Nantes,
-9 Avenue Père de Foucauld,-1.576092,47.216529,,9 Avenue Père de Foucauld,,,,44100
-162 Route de Rennes Nantes,,,,162 Route de Rennes,,,,44100
-162 Route de Rennes 44100,,,,162 Route de Rennes,,,Nantes,
-162 Route de Rennes,-1.579779,47.258487,,162 Route de Rennes,,,,44100
-35 Boulevard du Tertre Nantes,,,,35 Boulevard du Tertre,,,,44100
-35 Boulevard du Tertre 44100,,,,35 Boulevard du Tertre,,,Nantes,
-35 Boulevard du Tertre,-1.604462,47.216499,,35 Boulevard du Tertre,,,,44100
-9 Rue de la Croix Perroche Notre-Dame-des-Landes,,,,9 Rue de la Croix Perroche,,,,44130
-9 Rue de la Croix Perroche 44130,,,,9 Rue de la Croix Perroche,,,Notre-Dame-des-Landes,
-9 Rue de la Croix Perroche,-1.705697,47.377936,,9 Rue de la Croix Perroche,,,,44130
-9 Rue Frédéric Chopin Orvault,,,,9 Rue Frédéric Chopin,,,,44700
-9 Rue Frédéric Chopin 44700,,,,9 Rue Frédéric Chopin,,,Orvault,
-9 Rue Frédéric Chopin,-1.583730,47.254271,,9 Rue Frédéric Chopin,,,,44700
-37 Impasse des Jardins de Belle-Vue Oudon,,,,37 Impasse des Jardins de Belle-Vue,,,,44521
-37 Impasse des Jardins de Belle-Vue 44521,,,,37 Impasse des Jardins de Belle-Vue,,,Oudon,
-37 Impasse des Jardins de Belle-Vue,-1.284644,47.351280,,37 Impasse des Jardins de Belle-Vue,,,,44521
-400 Rue du Lindron Petit-Mars,,,,400 Rue du Lindron,,,,44390
-400 Rue du Lindron 44390,,,,400 Rue du Lindron,,,Petit-Mars,
-400 Rue du Lindron,-1.431071,47.387314,,400 Rue du Lindron,,,,44390
-13 Rue Jean Moulin La Plaine-sur-Mer,,,,13 Rue Jean Moulin,,,,44770
-13 Rue Jean Moulin 44770,,,,13 Rue Jean Moulin,,,La Plaine-sur-Mer,
-13 Rue Jean Moulin,-2.176222,47.153645,,13 Rue Jean Moulin,,,,44770
-10 Rue du Chardonnet Pontchâteau,,,,10 Rue du Chardonnet,,,,44160
-10 Rue du Chardonnet 44160,,,,10 Rue du Chardonnet,,,Pontchâteau,
-10 Rue du Chardonnet,-2.081026,47.424722,,10 Rue du Chardonnet,,,,44160
-125 Rue de la Bernerie Pornic,,,,125 Rue de la Bernerie,,,,44210
-125 Rue de la Bernerie 44210,,,,125 Rue de la Bernerie,,,Pornic,
-125 Rue de la Bernerie,-2.077415,47.107100,,125 Rue de la Bernerie,,,,44210
-6 Rue des Ormes Pornic,,,,6 Rue des Ormes,,,,44210
-6 Rue des Ormes 44210,,,,6 Rue des Ormes,,,Pornic,
-6 Rue des Ormes,-2.085849,47.109944,,6 Rue des Ormes,,,,44210
-20BIS Avenue des Lavandes Pornichet,,,,20BIS Avenue des Lavandes,,,,44380
-20BIS Avenue des Lavandes 44380,,,,20BIS Avenue des Lavandes,,,Pornichet,
-20BIS Avenue des Lavandes,-2.313842,47.249407,,20BIS Avenue des Lavandes,,,,44380
-14 Rue Georges Gralpois Le Pouliguen,,,,14 Rue Georges Gralpois,,,,44510
-14 Rue Georges Gralpois 44510,,,,14 Rue Georges Gralpois,,,Le Pouliguen,
-14 Rue Georges Gralpois,-2.438216,47.264914,,14 Rue Georges Gralpois,,,,44510
-1 Impasse du Tonnelier Puceul,,,,1 Impasse du Tonnelier,,,,44390
-1 Impasse du Tonnelier 44390,,,,1 Impasse du Tonnelier,,,Puceul,
-1 Impasse du Tonnelier,-1.616572,47.520386,,1 Impasse du Tonnelier,,,,44390
-4 Impasse des Couteaux Rezé,,,,4 Impasse des Couteaux,,,,44400
-4 Impasse des Couteaux 44400,,,,4 Impasse des Couteaux,,,Rezé,
-4 Impasse des Couteaux,-1.538270,47.187590,,4 Impasse des Couteaux,,,,44400
-10 Rue Maurice Jouaud Rezé,,,,10 Rue Maurice Jouaud,,,,44400
-10 Rue Maurice Jouaud 44400,,,,10 Rue Maurice Jouaud,,,Rezé,
-10 Rue Maurice Jouaud,-1.558130,47.179171,,10 Rue Maurice Jouaud,,,,44400
-12 Rue de la Sevreniere Gd Rigné Rougé,,,,12 Rue de la Sevreniere Gd Rigné,,,,44660
-12 Rue de la Sevreniere Gd Rigné 44660,,,,12 Rue de la Sevreniere Gd Rigné,,,Rougé,
-12 Rue de la Sevreniere Gd Rigné,-1.407284,47.749852,,12 Rue de la Sevreniere Gd Rigné,,,,44660
-39 Allée des Acacias Saint-Brevin-les-Pins,,,,39 Allée des Acacias,,,,44250
-39 Allée des Acacias 44250,,,,39 Allée des Acacias,,,Saint-Brevin-les-Pins,
-39 Allée des Acacias,-2.164335,47.228467,,39 Allée des Acacias,,,,44250
-228 Avenue de Mindin Saint-Brevin-les-Pins,,,,228 Avenue de Mindin,,,,44250
-228 Avenue de Mindin 44250,,,,228 Avenue de Mindin,,,Saint-Brevin-les-Pins,
-228 Avenue de Mindin,-2.165547,47.250165,,228 Avenue de Mindin,,,,44250
-74 Rue de La Chezine Saint-Étienne-de-Montluc,,,,74 Rue de La Chezine,,,,44360
-74 Rue de La Chezine 44360,,,,74 Rue de La Chezine,,,Saint-Étienne-de-Montluc,
-74 Rue de La Chezine,-1.772332,47.274230,,74 Rue de La Chezine,,,,44360
-15 Rue de la Brétinais Saint-Herblain,,,,15 Rue de la Brétinais,,,,44800
-15 Rue de la Brétinais 44800,,,,15 Rue de la Brétinais,,,Saint-Herblain,
-15 Rue de la Brétinais,-1.664860,47.224707,,15 Rue de la Brétinais,,,,44800
-8 Rue Louis Boutin Saint-Herblain,,,,8 Rue Louis Boutin,,,,44800
-8 Rue Louis Boutin 44800,,,,8 Rue Louis Boutin,,,Saint-Herblain,
-8 Rue Louis Boutin,-1.655437,47.211563,,8 Rue Louis Boutin,,,,44800
-24 Rue de la Gare Saint-Hilaire-de-Chaléons,,,,24 Rue de la Gare,,,,44680
-24 Rue de la Gare 44680,,,,24 Rue de la Gare,,,Saint-Hilaire-de-Chaléons,
-24 Rue de la Gare,-1.863331,47.105098,,24 Rue de la Gare,,,,44680
-55 Rue de Ménac Saint-Joachim,,,,55 Rue de Ménac,,,,44720
-55 Rue de Ménac 44720,,,,55 Rue de Ménac,,,Saint-Joachim,
-55 Rue de Ménac,-2.187261,47.374170,,55 Rue de Ménac,,,,44720
-12 Avenue des Frênes Sainte-Luce-sur-Loire,,,,12 Avenue des Frênes,,,,44980
-12 Avenue des Frênes 44980,,,,12 Avenue des Frênes,,,Sainte-Luce-sur-Loire,
-12 Avenue des Frênes,-1.489056,47.252299,,12 Avenue des Frênes,,,,44980
-11 Rue des Roseaux Saint-Lyphard,,,,11 Rue des Roseaux,,,,44410
-11 Rue des Roseaux 44410,,,,11 Rue des Roseaux,,,Saint-Lyphard,
-11 Rue des Roseaux,-2.312695,47.397740,,11 Rue des Roseaux,,,,44410
-4 Rue des Écoles Saint-Michel-Chef-Chef,,,,4 Rue des Écoles,,,,44730
-4 Rue des Écoles 44730,,,,4 Rue des Écoles,,,Saint-Michel-Chef-Chef,
-4 Rue des Écoles,-2.148796,47.181655,,4 Rue des Écoles,,,,44730
-13 Allée André Malraux Saint-Nazaire,,,,13 Allée André Malraux,,,,44600
-13 Allée André Malraux 44600,,,,13 Allée André Malraux,,,Saint-Nazaire,
-13 Allée André Malraux,-2.258431,47.285266,,13 Allée André Malraux,,,,44600
-16 Allée Edward Jenner Saint-Nazaire,,,,16 Allée Edward Jenner,,,,44600
-16 Allée Edward Jenner 44600,,,,16 Allée Edward Jenner,,,Saint-Nazaire,
-16 Allée Edward Jenner,-2.244289,47.277744,,16 Allée Edward Jenner,,,,44600
-6 Rue Jean-Pierre Dufrexou Saint-Nazaire,,,,6 Rue Jean-Pierre Dufrexou,,,,44600
-6 Rue Jean-Pierre Dufrexou 44600,,,,6 Rue Jean-Pierre Dufrexou,,,Saint-Nazaire,
-6 Rue Jean-Pierre Dufrexou,-2.205834,47.272325,,6 Rue Jean-Pierre Dufrexou,,,,44600
-54TER Route des Québrais Saint-Nazaire,,,,54TER Route des Québrais,,,,44600
-54TER Route des Québrais 44600,,,,54TER Route des Québrais,,,Saint-Nazaire,
-54TER Route des Québrais,-2.246485,47.283719,,54TER Route des Québrais,,,,44600
-6 Rue de la Châtaigneraie Sainte-Pazanne,,,,6 Rue de la Châtaigneraie,,,,44680
-6 Rue de la Châtaigneraie 44680,,,,6 Rue de la Châtaigneraie,,,Sainte-Pazanne,
-6 Rue de la Châtaigneraie,-1.806360,47.099608,,6 Rue de la Châtaigneraie,,,,44680
-5 Rue George Sand Sainte-Reine-de-Bretagne,,,,5 Rue George Sand,,,,44160
-5 Rue George Sand 44160,,,,5 Rue George Sand,,,Sainte-Reine-de-Bretagne,
-5 Rue George Sand,-2.189322,47.441669,,5 Rue George Sand,,,,44160
-5 Avenue Jean Jaurès Saint-Sébastien-sur-Loire,,,,5 Avenue Jean Jaurès,,,,44230
-5 Avenue Jean Jaurès 44230,,,,5 Avenue Jean Jaurès,,,Saint-Sébastien-sur-Loire,
-5 Avenue Jean Jaurès,-1.488975,47.206083,,5 Avenue Jean Jaurès,,,,44230
-4 Rue de l'Allouée Sautron,,,,4 Rue de l'Allouée,,,,44880
-4 Rue de l'Allouée 44880,,,,4 Rue de l'Allouée,,,Sautron,
-4 Rue de l'Allouée,-1.678651,47.260428,,4 Rue de l'Allouée,,,,44880
-51 Route du Chêne Sévérac,,,,51 Route du Chêne,,,,44530
-51 Route du Chêne 44530,,,,51 Route du Chêne,,,Sévérac,
-51 Route du Chêne,-2.043178,47.560304,,51 Route du Chêne,,,,44530
-115 Route de la Gamoterie Sucé-sur-Erdre,,,,115 Route de la Gamoterie,,,,44240
-115 Route de la Gamoterie 44240,,,,115 Route de la Gamoterie,,,Sucé-sur-Erdre,
-115 Route de la Gamoterie,-1.506215,47.376569,,115 Route de la Gamoterie,,,,44240
-1 Impasse de la Blançonnerie Thouaré-sur-Loire,,,,1 Impasse de la Blançonnerie,,,,44470
-1 Impasse de la Blançonnerie 44470,,,,1 Impasse de la Blançonnerie,,,Thouaré-sur-Loire,
-1 Impasse de la Blançonnerie,-1.440792,47.268258,,1 Impasse de la Blançonnerie,,,,44470
-12 Rue Edgar Degas Trignac,,,,12 Rue Edgar Degas,,,,44570
-12 Rue Edgar Degas 44570,,,,12 Rue Edgar Degas,,,Trignac,
-12 Rue Edgar Degas,-2.184467,47.316857,,12 Rue Edgar Degas,,,,44570
-31 Rue du Maréchal de Lattre de Tassigny La Turballe,,,,31 Rue du Maréchal de Lattre de Tassigny,,,,44420
-31 Rue du Maréchal de Lattre de Tassigny 44420,,,,31 Rue du Maréchal de Lattre de Tassigny,,,La Turballe,
-31 Rue du Maréchal de Lattre de Tassigny,-2.506815,47.347345,,31 Rue du Maréchal de Lattre de Tassigny,,,,44420
-11 Chemin des Baillorges Vertou,,,,11 Chemin des Baillorges,,,,44120
-11 Chemin des Baillorges 44120,,,,11 Chemin des Baillorges,,,Vertou,
-11 Chemin des Baillorges,-1.478400,47.167084,,11 Chemin des Baillorges,,,,44120
-5 Avenue de la Juillerie Vertou,,,,5 Avenue de la Juillerie,,,,44120
-5 Avenue de la Juillerie 44120,,,,5 Avenue de la Juillerie,,,Vertou,
-5 Avenue de la Juillerie,-1.448851,47.175661,,5 Avenue de la Juillerie,,,,44120
-10 Rue du Pressoir Vieillevigne,,,,10 Rue du Pressoir,,,,44116
-10 Rue du Pressoir 44116,,,,10 Rue du Pressoir,,,Vieillevigne,
-10 Rue du Pressoir,-1.440420,46.965299,,10 Rue du Pressoir,,,,44116
-41 Rue Bernier Angers,,,,41 Rue Bernier,,,,49000
-41 Rue Bernier 49000,,,,41 Rue Bernier,,,Angers,
-41 Rue Bernier,-0.543830,47.462038,,41 Rue Bernier,,,,49000
-8 Rue du Docteur Michel Gruet Angers,,,,8 Rue du Docteur Michel Gruet,,,,49000
-8 Rue du Docteur Michel Gruet 49000,,,,8 Rue du Docteur Michel Gruet,,,Angers,
-8 Rue du Docteur Michel Gruet,-0.510907,47.489724,,8 Rue du Docteur Michel Gruet,,,,49000
-12 Rue Henri Fruchaud Angers,,,,12 Rue Henri Fruchaud,,,,49000
-12 Rue Henri Fruchaud 49000,,,,12 Rue Henri Fruchaud,,,Angers,
-12 Rue Henri Fruchaud,-0.578647,47.481391,,12 Rue Henri Fruchaud,,,,49000
-68 Rue Maurice Geslin Angers,,,,68 Rue Maurice Geslin,,,,49000
-68 Rue Maurice Geslin 49000,,,,68 Rue Maurice Geslin,,,Angers,
-68 Rue Maurice Geslin,-0.514235,47.479930,,68 Rue Maurice Geslin,,,,49000
-4 Rue Roger Chauviré Angers,,,,4 Rue Roger Chauviré,,,,49000
-4 Rue Roger Chauviré 49000,,,,4 Rue Roger Chauviré,,,Angers,
-4 Rue Roger Chauviré,-0.569845,47.472860,,4 Rue Roger Chauviré,,,,49000
-49 Rue André Malraux Avrillé,,,,49 Rue André Malraux,,,,49240
-49 Rue André Malraux 49240,,,,49 Rue André Malraux,,,Avrillé,
-49 Rue André Malraux,-0.591068,47.509567,,49 Rue André Malraux,,,,49240
-60 Rue de Milngavie Baugé-en-Anjou,,,,60 Rue de Milngavie,,,,49150
-60 Rue de Milngavie 49150,,,,60 Rue de Milngavie,,,Baugé-en-Anjou,
-60 Rue de Milngavie,-0.100197,47.546727,,60 Rue de Milngavie,,,,49150
-16 Impasse Richelieu Beaufort-en-Vallée,,,,16 Impasse Richelieu,,,,49250
-16 Impasse Richelieu 49250,,,,16 Impasse Richelieu,,,Beaufort-en-Vallée,
-16 Impasse Richelieu,-0.219054,47.436017,,16 Impasse Richelieu,,,,49250
-2 Square de la Roseraie Bégrolles-en-Mauges,,,,2 Square de la Roseraie,,,,49122
-2 Square de la Roseraie 49122,,,,2 Square de la Roseraie,,,Bégrolles-en-Mauges,
-2 Square de la Roseraie,-0.940641,47.141094,,2 Square de la Roseraie,,,,49122
-10 Impasse de la Fuye Bouzillé,,,,10 Impasse de la Fuye,,,,49530
-10 Impasse de la Fuye 49530,,,,10 Impasse de la Fuye,,,Bouzillé,
-10 Impasse de la Fuye,-1.116254,47.357275,,10 Impasse de la Fuye,,,,49530
-17 Rue du Maréchal Joffre Brissac-Quincé,,,,17 Rue du Maréchal Joffre,,,,49320
-17 Rue du Maréchal Joffre 49320,,,,17 Rue du Maréchal Joffre,,,Brissac-Quincé,
-17 Rue du Maréchal Joffre,-0.448169,47.358061,,17 Rue du Maréchal Joffre,,,,49320
-9 Avenue Gayot Chalonnes-sur-Loire,,,,9 Avenue Gayot,,,,49290
-9 Avenue Gayot 49290,,,,9 Avenue Gayot,,,Chalonnes-sur-Loire,
-9 Avenue Gayot,-0.766173,47.350430,,9 Avenue Gayot,,,,49290
-2 Rue de Pimodan La Chapelle-sur-Oudon,,,,2 Rue de Pimodan,,,,49500
-2 Rue de Pimodan 49500,,,,2 Rue de Pimodan,,,La Chapelle-sur-Oudon,
-2 Rue de Pimodan,-0.830559,47.676215,,2 Rue de Pimodan,,,,49500
-1 Rue du Mail Chemillé-Melay,,,,1 Rue du Mail,,,,49120
-1 Rue du Mail 49120,,,,1 Rue du Mail,,,Chemillé-Melay,
-1 Rue du Mail,-0.727086,47.219184,,1 Rue du Mail,,,,49120
-21 Rue des Bourgniers Cholet,,,,21 Rue des Bourgniers,,,,49300
-21 Rue des Bourgniers 49300,,,,21 Rue des Bourgniers,,,Cholet,
-21 Rue des Bourgniers,-0.887265,47.063354,,21 Rue des Bourgniers,,,,49300
-13 Square d'Imola Cholet,,,,13 Square d'Imola,,,,49300
-13 Square d'Imola 49300,,,,13 Square d'Imola,,,Cholet,
-13 Square d'Imola,-0.873579,47.043590,,13 Square d'Imola,,,,49300
-35 Rue du Paradis Cholet,,,,35 Rue du Paradis,,,,49300
-35 Rue du Paradis 49300,,,,35 Rue du Paradis,,,Cholet,
-35 Rue du Paradis,-0.872798,47.061839,,35 Rue du Paradis,,,,49300
-39 Boulevard Victor Hugo Cholet,,,,39 Boulevard Victor Hugo,,,,49300
-39 Boulevard Victor Hugo 49300,,,,39 Boulevard Victor Hugo,,,Cholet,
-39 Boulevard Victor Hugo,-0.878228,47.066551,,39 Boulevard Victor Hugo,,,,49300
-1 Rue de l'Église Le Coudray-Macouard,,,,1 Rue de l'Église,,,,49260
-1 Rue de l'Église 49260,,,,1 Rue de l'Église,,,Le Coudray-Macouard,
-1 Rue de l'Église,-0.118443,47.193488,,1 Rue de l'Église,,,,49260
-5 Rue du Pré du Camp Doué-la-Fontaine,,,,5 Rue du Pré du Camp,,,,49700
-5 Rue du Pré du Camp 49700,,,,5 Rue du Pré du Camp,,,Doué-la-Fontaine,
-5 Rue du Pré du Camp,-0.274544,47.191634,,5 Rue du Pré du Camp,,,,49700
-4 Rue des Coteaux du Layon Faye-d'Anjou,,,,4 Rue des Coteaux du Layon,,,,49380
-4 Rue des Coteaux du Layon 49380,,,,4 Rue des Coteaux du Layon,,,Faye-d'Anjou,
-4 Rue des Coteaux du Layon,-0.523499,47.292973,,4 Rue des Coteaux du Layon,,,,49380
-28 Rue des Mésanges Gesté,,,,28 Rue des Mésanges,,,,49600
-28 Rue des Mésanges 49600,,,,28 Rue des Mésanges,,,Gesté,
-28 Rue des Mésanges,-1.107495,47.183954,,28 Rue des Mésanges,,,,49600
-29 Chemin du Haut Plessis Juigné-sur-Loire,,,,29 Chemin du Haut Plessis,,,,49610
-29 Chemin du Haut Plessis 49610,,,,29 Chemin du Haut Plessis,,,Juigné-sur-Loire,
-29 Chemin du Haut Plessis,-0.500230,47.385852,,29 Chemin du Haut Plessis,,,,49610
-12 Place du Bourg Neuf Longué-Jumelles,,,,12 Place du Bourg Neuf,,,,49160
-12 Place du Bourg Neuf 49160,,,,12 Place du Bourg Neuf,,,Longué-Jumelles,
-12 Place du Bourg Neuf,-0.105638,47.376055,,12 Place du Bourg Neuf,,,,49160
-11 Rue Baguenier-Desormeaux Maulévrier,,,,11 Rue Baguenier-Desormeaux,,,,49360
-11 Rue Baguenier-Desormeaux 49360,,,,11 Rue Baguenier-Desormeaux,,,Maulévrier,
-11 Rue Baguenier-Desormeaux,-0.738757,47.011938,,11 Rue Baguenier-Desormeaux,,,,49360
-39 Rue Jean Le Francois La Membrolle-sur-Longuenée,,,,39 Rue Jean Le Francois,,,,49770
-39 Rue Jean Le Francois 49770,,,,39 Rue Jean Le Francois,,,La Membrolle-sur-Longuenée,
-39 Rue Jean Le Francois,-0.669329,47.559405,,39 Rue Jean Le Francois,,,,49770
-6 Impasse du Pressoir Montreuil-Juigné,,,,6 Impasse du Pressoir,,,,49460
-6 Impasse du Pressoir 49460,,,,6 Impasse du Pressoir,,,Montreuil-Juigné,
-6 Impasse du Pressoir,-0.598407,47.528210,,6 Impasse du Pressoir,,,,49460
-35 Route de Brissac Mûrs-Erigné,,,,35 Route de Brissac,,,,49610
-35 Route de Brissac 49610,,,,35 Route de Brissac,,,Mûrs-Erigné,
-35 Route de Brissac,-0.521015,47.403884,,35 Route de Brissac,,,,49610
-25 Allée des Chênes Pellouailles-les-Vignes,,,,25 Allée des Chênes,,,,49112
-25 Allée des Chênes 49112,,,,25 Allée des Chênes,,,Pellouailles-les-Vignes,
-25 Allée des Chênes,-0.442702,47.525732,,25 Allée des Chênes,,,,49112
-4 Avenue Galliéni Les Ponts-de-Cé,,,,4 Avenue Galliéni,,,,49130
-4 Avenue Galliéni 49130,,,,4 Avenue Galliéni,,,Les Ponts-de-Cé,
-4 Avenue Galliéni,-0.528803,47.433649,,4 Avenue Galliéni,,,,49130
-22 Rue de la Villenière La Pouëze,,,,22 Rue de la Villenière,,,,49370
-22 Rue de la Villenière 49370,,,,22 Rue de la Villenière,,,La Pouëze,
-22 Rue de la Villenière,-0.811699,47.556209,,22 Rue de la Villenière,,,,49370
-5 Rue des Charmes Saint-André-de-la-Marche,,,,5 Rue des Charmes,,,,49450
-5 Rue des Charmes 49450,,,,5 Rue des Charmes,,,Saint-André-de-la-Marche,
-5 Rue des Charmes,-0.993764,47.106475,,5 Rue des Charmes,,,,49450
-8 Rue Saint-Maurille Saint-Christophe-du-Bois,,,,8 Rue Saint-Maurille,,,,49280
-8 Rue Saint-Maurille 49280,,,,8 Rue Saint-Maurille,,,Saint-Christophe-du-Bois,
-8 Rue Saint-Maurille,-0.942141,47.030194,,8 Rue Saint-Maurille,,,,49280
-32 Rue Pierre Lepoureau Saint-Georges-des-Gardes,,,,32 Rue Pierre Lepoureau,,,,49120
-32 Rue Pierre Lepoureau 49120,,,,32 Rue Pierre Lepoureau,,,Saint-Georges-des-Gardes,
-32 Rue Pierre Lepoureau,-0.757283,47.146712,,32 Rue Pierre Lepoureau,,,,49120
-4 Rue Paul Gauguin Saint-Lambert-la-Potherie,,,,4 Rue Paul Gauguin,,,,49070
-4 Rue Paul Gauguin 49070,,,,4 Rue Paul Gauguin,,,Saint-Lambert-la-Potherie,
-4 Rue Paul Gauguin,-0.681096,47.483530,,4 Rue Paul Gauguin,,,,49070
-28 Rue du Poirier Saint-Macaire-en-Mauges,,,,28 Rue du Poirier,,,,49450
-28 Rue du Poirier 49450,,,,28 Rue du Poirier,,,Saint-Macaire-en-Mauges,
-28 Rue du Poirier,-1.001958,47.124507,,28 Rue du Poirier,,,,49450
-23 Allée du tumulus Saint-Pierre-Montlimart,,,,23 Allée du tumulus,,,,49110
-23 Allée du tumulus 49110,,,,23 Allée du tumulus,,,Saint-Pierre-Montlimart,
-23 Allée du tumulus,-1.038533,47.264940,,23 Allée du tumulus,,,,49110
-15 Rue des Bouvreuils Saumur,,,,15 Rue des Bouvreuils,,,,49400
-15 Rue des Bouvreuils 49400,,,,15 Rue des Bouvreuils,,,Saumur,
-15 Rue des Bouvreuils,-0.071626,47.272718,,15 Rue des Bouvreuils,,,,49400
-6 Cité André Penot Saumur,,,,6 Cité André Penot,,,,49400
-6 Cité André Penot 49400,,,,6 Cité André Penot,,,Saumur,
-6 Cité André Penot,-0.092506,47.246292,,6 Cité André Penot,,,,49400
-5 Impasse des Haveurs Segré,,,,5 Impasse des Haveurs,,,,49500
-5 Impasse des Haveurs 49500,,,,5 Impasse des Haveurs,,,Segré,
-5 Impasse des Haveurs,-0.863685,47.682341,,5 Impasse des Haveurs,,,,49500
-2 Rue Saint-Pierre Soulaines-sur-Aubance,,,,2 Rue Saint-Pierre,,,,49610
-2 Rue Saint-Pierre 49610,,,,2 Rue Saint-Pierre,,,Soulaines-sur-Aubance,
-2 Rue Saint-Pierre,-0.521654,47.363947,,2 Rue Saint-Pierre,,,,49610
-3 Rue Charles Foyer Torfou,,,,3 Rue Charles Foyer,,,,49660
-3 Rue Charles Foyer 49660,,,,3 Rue Charles Foyer,,,Torfou,
-3 Rue Charles Foyer,-1.116083,47.036905,,3 Rue Charles Foyer,,,,49660
-15BIS Rue des Toises Trélazé,,,,15BIS Rue des Toises,,,,49800
-15BIS Rue des Toises 49800,,,,15BIS Rue des Toises,,,Trélazé,
-15BIS Rue des Toises,-0.466646,47.445031,,15BIS Rue des Toises,,,,49800
-9 Rue du 11 Novembre Vern-d'Anjou,,,,9 Rue du 11 Novembre,,,,49220
-9 Rue du 11 Novembre 49220,,,,9 Rue du 11 Novembre,,,Vern-d'Anjou,
-9 Rue du 11 Novembre,-0.834454,47.601598,,9 Rue du 11 Novembre,,,,49220
-4 Rue des Écoles Villevêque,,,,4 Rue des Écoles,,,,49140
-4 Rue des Écoles 49140,,,,4 Rue des Écoles,,,Villevêque,
-4 Rue des Écoles,-0.422940,47.559646,,4 Rue des Écoles,,,,49140
-5 Route de Laval Azé,,,,5 Route de Laval,,,,53200
-5 Route de Laval 53200,,,,5 Route de Laval,,,Azé,
-5 Route de Laval,-0.700041,47.836286,,5 Route de Laval,,,,53200
-6 Rue des Ormes Bonchamp-lès-Laval,,,,6 Rue des Ormes,,,,53960
-6 Rue des Ormes 53960,,,,6 Rue des Ormes,,,Bonchamp-lès-Laval,
-6 Rue des Ormes,-0.706817,48.074814,,6 Rue des Ormes,,,,53960
-8 Rue de la Bergerie Chantrigné,,,,8 Rue de la Bergerie,,,,53300
-8 Rue de la Bergerie 53300,,,,8 Rue de la Bergerie,,,Chantrigné,
-8 Rue de la Bergerie,-0.568959,48.416928,,8 Rue de la Bergerie,,,,53300
-26 Boulevard Victor Hugo Château-Gontier,,,,26 Boulevard Victor Hugo,,,,53200
-26 Boulevard Victor Hugo 53200,,,,26 Boulevard Victor Hugo,,,Château-Gontier,
-26 Boulevard Victor Hugo,-0.712805,47.826162,,26 Boulevard Victor Hugo,,,,53200
-62 Route de Château Gontier Craon,,,,62 Route de Château Gontier,,,,53400
-62 Route de Château Gontier 53400,,,,62 Route de Château Gontier,,,Craon,
-62 Route de Château Gontier,-0.944215,47.846931,,62 Route de Château Gontier,,,,53400
-19 Rue des Mimosas Ernée,,,,19 Rue des Mimosas,,,,53500
-19 Rue des Mimosas 53500,,,,19 Rue des Mimosas,,,Ernée,
-19 Rue des Mimosas,-0.933801,48.304762,,19 Rue des Mimosas,,,,53500
-24 Rue des Noisetiers Le Genest-Saint-Isle,,,,24 Rue des Noisetiers,,,,53940
-24 Rue des Noisetiers 53940,,,,24 Rue des Noisetiers,,,Le Genest-Saint-Isle,
-24 Rue des Noisetiers,-0.894480,48.098622,,24 Rue des Noisetiers,,,,53940
-13 Rue du Temple Jublains,,,,13 Rue du Temple,,,,53160
-13 Rue du Temple 53160,,,,13 Rue du Temple,,,Jublains,
-13 Rue du Temple,-0.496803,48.256702,,13 Rue du Temple,,,,53160
-37BIS Rue du 124Ieme Régiment I Laval,,,,37BIS Rue du 124Ieme Régiment I,,,,53000
-37BIS Rue du 124Ieme Régiment I 53000,,,,37BIS Rue du 124Ieme Régiment I,,,Laval,
-37BIS Rue du 124Ieme Régiment I,-0.778598,48.073295,,37BIS Rue du 124Ieme Régiment I,,,,53000
-23 Rue Lemercier de Neuville Laval,,,,23 Rue Lemercier de Neuville,,,,53000
-23 Rue Lemercier de Neuville 53000,,,,23 Rue Lemercier de Neuville,,,Laval,
-23 Rue Lemercier de Neuville,-0.778088,48.065088,,23 Rue Lemercier de Neuville,,,,53000
-33 Rue Thomas Naudet Laval,,,,33 Rue Thomas Naudet,,,,53000
-33 Rue Thomas Naudet 53000,,,,33 Rue Thomas Naudet,,,Laval,
-33 Rue Thomas Naudet,-0.790594,48.071767,,33 Rue Thomas Naudet,,,,53000
-28 Lotissement des Gandonnières Martigné-sur-Mayenne,,,,28 Lotissement des Gandonnières,,,,53470
-28 Lotissement des Gandonnières 53470,,,,28 Lotissement des Gandonnières,,,Martigné-sur-Mayenne,
-28 Lotissement des Gandonnières,-0.659245,48.194923,,28 Lotissement des Gandonnières,,,,53470
-5 Résidence de Plein Mer Mayenne,,,,5 Résidence de Plein Mer,,,,53100
-5 Résidence de Plein Mer 53100,,,,5 Résidence de Plein Mer,,,Mayenne,
-5 Résidence de Plein Mer,-0.617575,48.293500,,5 Résidence de Plein Mer,,,,53100
-2BIS Route de la Selle Craonnaise Niafles,,,,2BIS Route de la Selle Craonnaise,,,,53400
-2BIS Route de la Selle Craonnaise 53400,,,,2BIS Route de la Selle Craonnaise,,,Niafles,
-2BIS Route de la Selle Craonnaise,-1.002331,47.846002,,2BIS Route de la Selle Craonnaise,,,,53400
-11 Rue de Kirchheim Renazé,,,,11 Rue de Kirchheim,,,,53800
-11 Rue de Kirchheim 53800,,,,11 Rue de Kirchheim,,,Renazé,
-11 Rue de Kirchheim,-1.058142,47.789834,,11 Rue de Kirchheim,,,,53800
-3 Rue de la Chapelle Anthenaise Saint-Céneré,,,,3 Rue de la Chapelle Anthenaise,,,,53150
-3 Rue de la Chapelle Anthenaise 53150,,,,3 Rue de la Chapelle Anthenaise,,,Saint-Céneré,
-3 Rue de la Chapelle Anthenaise,-0.595741,48.121904,,3 Rue de la Chapelle Anthenaise,,,,53150
-3 Chemin de la Basse Vigne Saint-Martin-de-Connée,,,,3 Chemin de la Basse Vigne,,,,53160
-3 Chemin de la Basse Vigne 53160,,,,3 Chemin de la Basse Vigne,,,Saint-Martin-de-Connée,
-3 Chemin de la Basse Vigne,-0.217400,48.214986,,3 Chemin de la Basse Vigne,,,,53160
-22 Rue de Fromentin Villaines-la-Juhel,,,,22 Rue de Fromentin,,,,53700
-22 Rue de Fromentin 53700,,,,22 Rue de Fromentin,,,Villaines-la-Juhel,
-22 Rue de Fromentin,-0.290272,48.343552,,22 Rue de Fromentin,,,,53700
-3 Rue des Lilas Arnage,,,,3 Rue des Lilas,,,,72230
-3 Rue des Lilas 72230,,,,3 Rue des Lilas,,,Arnage,
-3 Rue des Lilas,0.184668,47.945060,,3 Rue des Lilas,,,,72230
-68 Avenue Nationale La Bazoge,,,,68 Avenue Nationale,,,,72650
-68 Avenue Nationale 72650,,,,68 Avenue Nationale,,,La Bazoge,
-68 Avenue Nationale,0.154360,48.099874,,68 Avenue Nationale,,,,72650
-11 Rue du Professeur Calmette Bonnétable,,,,11 Rue du Professeur Calmette,,,,72110
-11 Rue du Professeur Calmette 72110,,,,11 Rue du Professeur Calmette,,,Bonnétable,
-11 Rue du Professeur Calmette,0.435273,48.175760,,11 Rue du Professeur Calmette,,,,72110
-1 Rue de la Fontaine Saint-Jean Chahaignes,,,,1 Rue de la Fontaine Saint-Jean,,,,72340
-1 Rue de la Fontaine Saint-Jean 72340,,,,1 Rue de la Fontaine Saint-Jean,,,Chahaignes,
-1 Rue de la Fontaine Saint-Jean,0.516881,47.741490,,1 Rue de la Fontaine Saint-Jean,,,,72340
-1 Rue Victor Hugo La Chapelle-Huon,,,,1 Rue Victor Hugo,,,,72310
-1 Rue Victor Hugo 72310,,,,1 Rue Victor Hugo,,,La Chapelle-Huon,
-1 Rue Victor Hugo,0.744765,47.859052,,1 Rue Victor Hugo,,,,72310
-4 Rue Bollée Cherré,,,,4 Rue Bollée,,,,72400
-4 Rue Bollée 72400,,,,4 Rue Bollée,,,Cherré,
-4 Rue Bollée,0.668979,48.170775,,4 Rue Bollée,,,,72400
-11 Rue Jean Moulin Coulaines,,,,11 Rue Jean Moulin,,,,72190
-11 Rue Jean Moulin 72190,,,,11 Rue Jean Moulin,,,Coulaines,
-11 Rue Jean Moulin,0.203743,48.030574,,11 Rue Jean Moulin,,,,72190
-29A Rue du Luart Duneau,,,,29A Rue du Luart,,,,72160
-29A Rue du Luart 72160,,,,29A Rue du Luart,,,Duneau,
-29A Rue du Luart,0.502663,48.060074,,29A Rue du Luart,,,,72160
-5 Cour du Pavillon La Ferté-Bernard,,,,5 Cour du Pavillon,,,,72400
-5 Cour du Pavillon 72400,,,,5 Cour du Pavillon,,,La Ferté-Bernard,
-5 Cour du Pavillon,0.652441,48.185177,,5 Cour du Pavillon,,,,72400
-3 Chemin des Minières Guécélard,,,,3 Chemin des Minières,,,,72230
-3 Chemin des Minières 72230,,,,3 Chemin des Minières,,,Guécélard,
-3 Chemin des Minières,0.142678,47.879196,,3 Chemin des Minières,,,,72230
-37 Rue Léo Delibes La Flèche,,,,37 Rue Léo Delibes,,,,72200
-37 Rue Léo Delibes 72200,,,,37 Rue Léo Delibes,,,La Flèche,
-37 Rue Léo Delibes,-0.064474,47.711546,,37 Rue Léo Delibes,,,,72200
-1598 Route de Gaigner Lombron,,,,1598 Route de Gaigner,,,,72450
-1598 Route de Gaigner 72450,,,,1598 Route de Gaigner,,,Lombron,
-1598 Route de Gaigner,0.380472,48.092463,,1598 Route de Gaigner,,,,72450
-35 Rue Bernard Palissy Malicorne-sur-Sarthe,,,,35 Rue Bernard Palissy,,,,72270
-35 Rue Bernard Palissy 72270,,,,35 Rue Bernard Palissy,,,Malicorne-sur-Sarthe,
-35 Rue Bernard Palissy,-0.074195,47.816103,,35 Rue Bernard Palissy,,,,72270
-15 Rue André Gabelle Le Mans,,,,15 Rue André Gabelle,,,,72000
-15 Rue André Gabelle 72000,,,,15 Rue André Gabelle,,,Le Mans,
-15 Rue André Gabelle,0.212339,47.977122,,15 Rue André Gabelle,,,,72000
-33 Rue de la Briqueterie Le Mans,,,,33 Rue de la Briqueterie,,,,72000
-33 Rue de la Briqueterie 72000,,,,33 Rue de la Briqueterie,,,Le Mans,
-33 Rue de la Briqueterie,0.167214,47.992340,,33 Rue de la Briqueterie,,,,72000
-23 Rue Desaix Le Mans,,,,23 Rue Desaix,,,,72000
-23 Rue Desaix 72000,,,,23 Rue Desaix,,,Le Mans,
-23 Rue Desaix,0.182775,48.011719,,23 Rue Desaix,,,,72000
-93 Rue Gambetta Le Mans,,,,93 Rue Gambetta,,,,72000
-93 Rue Gambetta 72000,,,,93 Rue Gambetta,,,Le Mans,
-93 Rue Gambetta,0.189523,48.007066,,93 Rue Gambetta,,,,72000
-20 Rue Jean Cocteau Le Mans,,,,20 Rue Jean Cocteau,,,,72000
-20 Rue Jean Cocteau 72000,,,,20 Rue Jean Cocteau,,,Le Mans,
-20 Rue Jean Cocteau,0.225887,48.013282,,20 Rue Jean Cocteau,,,,72000
-29 Rue du Maine Le Mans,,,,29 Rue du Maine,,,,72000
-29 Rue du Maine 72000,,,,29 Rue du Maine,,,Le Mans,
-29 Rue du Maine,0.199364,47.970830,,29 Rue du Maine,,,,72000
-62 Rue Paul Éluard Le Mans,,,,62 Rue Paul Éluard,,,,72000
-62 Rue Paul Éluard 72000,,,,62 Rue Paul Éluard,,,Le Mans,
-62 Rue Paul Éluard,0.232122,48.003491,,62 Rue Paul Éluard,,,,72000
-57 Rue Rodolphe Diesel Le Mans,,,,57 Rue Rodolphe Diesel,,,,72000
-57 Rue Rodolphe Diesel 72000,,,,57 Rue Rodolphe Diesel,,,Le Mans,
-57 Rue Rodolphe Diesel,0.225340,47.984681,,57 Rue Rodolphe Diesel,,,,72000
-64 Rue de Valence Le Mans,,,,64 Rue de Valence,,,,72000
-64 Rue de Valence 72000,,,,64 Rue de Valence,,,Le Mans,
-64 Rue de Valence,0.224589,48.016576,,64 Rue de Valence,,,,72000
-43 Route de Sarcé Mayet,,,,43 Route de Sarcé,,,,72360
-43 Route de Sarcé 72360,,,,43 Route de Sarcé,,,Mayet,
-43 Route de Sarcé,0.266716,47.750441,,43 Route de Sarcé,,,,72360
-11 Impasse de la Butte Mulsanne,,,,11 Impasse de la Butte,,,,72230
-11 Impasse de la Butte 72230,,,,11 Impasse de la Butte,,,Mulsanne,
-11 Impasse de la Butte,0.254178,47.915242,,11 Impasse de la Butte,,,,72230
-26 Allée du Stade Parcé-sur-Sarthe,,,,26 Allée du Stade,,,,72300
-26 Allée du Stade 72300,,,,26 Allée du Stade,,,Parcé-sur-Sarthe,
-26 Allée du Stade,-0.205098,47.845927,,26 Allée du Stade,,,,72300
-9 Rue du Levant Pruillé-le-Chétif,,,,9 Rue du Levant,,,,72700
-9 Rue du Levant 72700,,,,9 Rue du Levant,,,Pruillé-le-Chétif,
-9 Rue du Levant,0.102413,47.995602,,9 Rue du Levant,,,,72700
-12 Boulevard de la Gare Sablé-sur-Sarthe,,,,12 Boulevard de la Gare,,,,72300
-12 Boulevard de la Gare 72300,,,,12 Boulevard de la Gare,,,Sablé-sur-Sarthe,
-12 Boulevard de la Gare,-0.340541,47.839455,,12 Boulevard de la Gare,,,,72300
-19 Rue Pasteur Sainte-Cérotte,,,,19 Rue Pasteur,,,,72120
-19 Rue Pasteur 72120,,,,19 Rue Pasteur,,,Sainte-Cérotte,
-19 Rue Pasteur,0.688937,47.900524,,19 Rue Pasteur,,,,72120
-67 Rue Principale Saint-Jean-d'Assé,,,,67 Rue Principale,,,,72380
-67 Rue Principale 72380,,,,67 Rue Principale,,,Saint-Jean-d'Assé,
-67 Rue Principale,0.131408,48.149428,,67 Rue Principale,,,,72380
-2 Rue du Soleil Levant Saint-Pierre-de-Chevillé,,,,2 Rue du Soleil Levant,,,,72500
-2 Rue du Soleil Levant 72500,,,,2 Rue du Soleil Levant,,,Saint-Pierre-de-Chevillé,
-2 Rue du Soleil Levant,0.439346,47.645856,,2 Rue du Soleil Levant,,,,72500
-18BIS Place de l'Église Savigné-l'Évêque,,,,18BIS Place de l'Église,,,,72460
-18BIS Place de l'Église 72460,,,,18BIS Place de l'Église,,,Savigné-l'Évêque,
-18BIS Place de l'Église,0.296642,48.077027,,18BIS Place de l'Église,,,,72460
-1 Rue des Roses Spay,,,,1 Rue des Roses,,,,72700
-1 Rue des Roses 72700,,,,1 Rue des Roses,,,Spay,
-1 Rue des Roses,0.147953,47.926834,,1 Rue des Roses,,,,72700
-17 Rue du Stade Torcé-en-Vallée,,,,17 Rue du Stade,,,,72110
-17 Rue du Stade 72110,,,,17 Rue du Stade,,,Torcé-en-Vallée,
-17 Rue du Stade,0.400757,48.134544,,17 Rue du Stade,,,,72110
-41B Route de Saint-Mars-de-Locquenay Volnay,,,,41B Route de Saint-Mars-de-Locquenay,,,,72440
-41B Route de Saint-Mars-de-Locquenay 72440,,,,41B Route de Saint-Mars-de-Locquenay,,,Volnay,
-41B Route de Saint-Mars-de-Locquenay,0.477404,47.931001,,41B Route de Saint-Mars-de-Locquenay,,,,72440
-2 Rue des Néfliers Aizenay,,,,2 Rue des Néfliers,,,,85190
-2 Rue des Néfliers 85190,,,,2 Rue des Néfliers,,,Aizenay,
-2 Rue des Néfliers,-1.612453,46.750890,,2 Rue des Néfliers,,,,85190
-2 Allée Emile Ruchaud Aubigny,,,,2 Allée Emile Ruchaud,,,,85430
-2 Allée Emile Ruchaud 85430,,,,2 Allée Emile Ruchaud,,,Aubigny,
-2 Allée Emile Ruchaud,-1.448445,46.600254,,2 Allée Emile Ruchaud,,,,85430
-10 Esplanade de la Mer La Barre-de-Monts,,,,10 Esplanade de la Mer,,,,85550
-10 Esplanade de la Mer 85550,,,,10 Esplanade de la Mer,,,La Barre-de-Monts,
-10 Esplanade de la Mer,-2.140608,46.891552,,10 Esplanade de la Mer,,,,85550
-12 Boulevard André Malraux Belleville-sur-Vie,,,,12 Boulevard André Malraux,,,,85170
-12 Boulevard André Malraux 85170,,,,12 Boulevard André Malraux,,,Belleville-sur-Vie,
-12 Boulevard André Malraux,-1.421664,46.780359,,12 Boulevard André Malraux,,,,85170
-3 Allée de la Rochette La Boissière-des-Landes,,,,3 Allée de la Rochette,,,,85430
-3 Allée de la Rochette 85430,,,,3 Allée de la Rochette,,,La Boissière-des-Landes,
-3 Allée de la Rochette,-1.458436,46.564232,,3 Allée de la Rochette,,,,85430
-5 Rue de la Boutinière Bretignolles-sur-Mer,,,,5 Rue de la Boutinière,,,,85470
-5 Rue de la Boutinière 85470,,,,5 Rue de la Boutinière,,,Bretignolles-sur-Mer,
-5 Rue de la Boutinière,-1.844072,46.629009,,5 Rue de la Boutinière,,,,85470
-3 Place de l'Église La Bretonnière-la-Claye,,,,3 Place de l'Église,,,,85320
-3 Place de l'Église 85320,,,,3 Place de l'Église,,,La Bretonnière-la-Claye,
-3 Place de l'Église,-1.254924,46.482316,,3 Place de l'Église,,,,85320
-2 Rue de la Pierre Plate La Chaize-le-Vicomte,,,,2 Rue de la Pierre Plate,,,,85310
-2 Rue de la Pierre Plate 85310,,,,2 Rue de la Pierre Plate,,,La Chaize-le-Vicomte,
-2 Rue de la Pierre Plate,-1.292395,46.673324,,2 Rue de la Pierre Plate,,,,85310
-44 Rue du Maréchal Foch Challans,,,,44 Rue du Maréchal Foch,,,,85300
-44 Rue du Maréchal Foch 85300,,,,44 Rue du Maréchal Foch,,,Challans,
-44 Rue du Maréchal Foch,-1.868567,46.835055,,44 Rue du Maréchal Foch,,,,85300
-4 Rue du Stade Le Champ-Saint-Père,,,,4 Rue du Stade,,,,85540
-4 Rue du Stade 85540,,,,4 Rue du Stade,,,Le Champ-Saint-Père,
-4 Rue du Stade,-1.346287,46.506865,,4 Rue du Stade,,,,85540
-7BIS Rue du Bossard Chasnais,,,,7BIS Rue du Bossard,,,,85400
-7BIS Rue du Bossard 85400,,,,7BIS Rue du Bossard,,,Chasnais,
-7BIS Rue du Bossard,-1.224799,46.462383,,7BIS Rue du Bossard,,,,85400
-26 Rue Jacquard Château-d'Olonne,,,,26 Rue Jacquard,,,,85180
-26 Rue Jacquard 85180,,,,26 Rue Jacquard,,,Château-d'Olonne,
-26 Rue Jacquard,-1.734248,46.490831,,26 Rue Jacquard,,,,85180
-3BIS Rue du Centre Chauché,,,,3BIS Rue du Centre,,,,85140
-3BIS Rue du Centre 85140,,,,3BIS Rue du Centre,,,Chauché,
-3BIS Rue du Centre,-1.271029,46.828715,,3BIS Rue du Centre,,,,85140
-38BIS Rue de la Frise Corpe,,,,38BIS Rue de la Frise,,,,85320
-38BIS Rue de la Frise 85320,,,,38BIS Rue de la Frise,,,Corpe,
-38BIS Rue de la Frise,-1.186704,46.503122,,38BIS Rue de la Frise,,,,85320
-2BIS Rue du Moulin Rompu L'Épine,,,,2BIS Rue du Moulin Rompu,,,,85740
-2BIS Rue du Moulin Rompu 85740,,,,2BIS Rue du Moulin Rompu,,,L'Épine,
-2BIS Rue du Moulin Rompu,-2.265415,46.978017,,2BIS Rue du Moulin Rompu,,,,85740
-5 Impasse du Sextant Le Fenouiller,,,,5 Impasse du Sextant,,,,85800
-5 Impasse du Sextant 85800,,,,5 Impasse du Sextant,,,Le Fenouiller,
-5 Impasse du Sextant,-1.920543,46.700406,,5 Impasse du Sextant,,,,85800
-3 Rue de la Fuie Champanaie Fontenay-le-Comte,,,,3 Rue de la Fuie Champanaie,,,,85200
-3 Rue de la Fuie Champanaie 85200,,,,3 Rue de la Fuie Champanaie,,,Fontenay-le-Comte,
-3 Rue de la Fuie Champanaie,-0.797354,46.466950,,3 Rue de la Fuie Champanaie,,,,85200
-3 Rue des Genêts Fougeré,,,,3 Rue des Genêts,,,,85480
-3 Rue des Genêts 85480,,,,3 Rue des Genêts,,,Fougeré,
-3 Rue des Genêts,-1.235600,46.659260,,3 Rue des Genêts,,,,85480
-3 Rue de l'Église Grand'Landes,,,,3 Rue de l'Église,,,,85670
-3 Rue de l'Église 85670,,,,3 Rue de l'Église,,,Grand'Landes,
-3 Rue de l'Église,-1.650527,46.821338,,3 Rue de l'Église,,,,85670
-11 Rue Claude Debussy L'Herbergement,,,,11 Rue Claude Debussy,,,,85260
-11 Rue Claude Debussy 85260,,,,11 Rue Claude Debussy,,,L'Herbergement,
-11 Rue Claude Debussy,-1.373464,46.915988,,11 Rue Claude Debussy,,,,85260
-8 Rue des Petrels Les Herbiers,,,,8 Rue des Petrels,,,,85500
-8 Rue des Petrels 85500,,,,8 Rue des Petrels,,,Les Herbiers,
-8 Rue des Petrels,-1.012870,46.855887,,8 Rue des Petrels,,,,85500
-34 Rue de la Croix de Ker Chalon L'Île-d'Yeu,,,,34 Rue de la Croix de Ker Chalon,,,,85350
-34 Rue de la Croix de Ker Chalon 85350,,,,34 Rue de la Croix de Ker Chalon,,,L'Île-d'Yeu,
-34 Rue de la Croix de Ker Chalon,-2.337617,46.716345,,34 Rue de la Croix de Ker Chalon,,,,85350
-8 Chemin de la Conche A Marais Jard-sur-Mer,,,,8 Chemin de la Conche A Marais,,,,85520
-8 Chemin de la Conche A Marais 85520,,,,8 Chemin de la Conche A Marais,,,Jard-sur-Mer,
-8 Chemin de la Conche A Marais,-1.586628,46.415337,,8 Chemin de la Conche A Marais,,,,85520
-3 Rue du Moulin Les Landes-Genusson,,,,3 Rue du Moulin,,,,85130
-3 Rue du Moulin 85130,,,,3 Rue du Moulin,,,Les Landes-Genusson,
-3 Rue du Moulin,-1.116880,46.968099,,3 Rue du Moulin,,,,85130
-8 Rue des Bleuets Luçon,,,,8 Rue des Bleuets,,,,85400
-8 Rue des Bleuets 85400,,,,8 Rue des Bleuets,,,Luçon,
-8 Rue des Bleuets,-1.154475,46.452875,,8 Rue des Bleuets,,,,85400
-2 Rue des Primevères Maché,,,,2 Rue des Primevères,,,,85190
-2 Rue des Primevères 85190,,,,2 Rue des Primevères,,,Maché,
-2 Rue des Primevères,-1.689473,46.754276,,2 Rue des Primevères,,,,85190
-14 Rue du Prieuré Mervent,,,,14 Rue du Prieuré,,,,85200
-14 Rue du Prieuré 85200,,,,14 Rue du Prieuré,,,Mervent,
-14 Rue du Prieuré,-0.757475,46.522454,,14 Rue du Prieuré,,,,85200
-1 Place de la Liberté Mortagne-sur-Sèvre,,,,1 Place de la Liberté,,,,85290
-1 Place de la Liberté 85290,,,,1 Place de la Liberté,,,Mortagne-sur-Sèvre,
-1 Place de la Liberté,-0.956046,46.992697,,1 Place de la Liberté,,,,85290
-1 Impasse des Hérons Mouilleron-le-Captif,,,,1 Impasse des Hérons,,,,85000
-1 Impasse des Hérons 85000,,,,1 Impasse des Hérons,,,Mouilleron-le-Captif,
-1 Impasse des Hérons,-1.461033,46.719850,,1 Impasse des Hérons,,,,85000
-42 Basse Rue Noirmoutier-en-l'Île,,,,42 Basse Rue,,,,85330
-42 Basse Rue 85330,,,,42 Basse Rue,,,Noirmoutier-en-l'Île,
-42 Basse Rue,-2.254555,47.006150,,42 Basse Rue,,,,85330
-25 Résidence des Longues Pièces Noirmoutier-en-l'Île,,,,25 Résidence des Longues Pièces,,,,85330
-25 Résidence des Longues Pièces 85330,,,,25 Résidence des Longues Pièces,,,Noirmoutier-en-l'Île,
-25 Résidence des Longues Pièces,-2.251874,47.009588,,25 Résidence des Longues Pièces,,,,85330
-4 Rue des Cordeliers Olonne-sur-Mer,,,,4 Rue des Cordeliers,,,,85340
-4 Rue des Cordeliers 85340,,,,4 Rue des Cordeliers,,,Olonne-sur-Mer,
-4 Rue des Cordeliers,-1.780272,46.536713,,4 Rue des Cordeliers,,,,85340
-25 Rue des Agates Olonne-sur-Mer,,,,25 Rue des Agates,,,,85340
-25 Rue des Agates 85340,,,,25 Rue des Agates,,,Olonne-sur-Mer,
-25 Rue des Agates,-1.756648,46.508859,,25 Rue des Agates,,,,85340
-11 Rue de la Gâte Bourse Le Poiré-sur-Vie,,,,11 Rue de la Gâte Bourse,,,,85170
-11 Rue de la Gâte Bourse 85170,,,,11 Rue de la Gâte Bourse,,,Le Poiré-sur-Vie,
-11 Rue de la Gâte Bourse,-1.503435,46.765317,,11 Rue de la Gâte Bourse,,,,85170
-96 Route de la Bouillée La Réorthe,,,,96 Route de la Bouillée,,,,85210
-96 Route de la Bouillée 85210,,,,96 Route de la Bouillée,,,La Réorthe,
-96 Route de la Bouillée,-1.042911,46.603146,,96 Route de la Bouillée,,,,85210
-17 Impasse de Bougainville La Roche-sur-Yon,,,,17 Impasse de Bougainville,,,,85000
-17 Impasse de Bougainville 85000,,,,17 Impasse de Bougainville,,,La Roche-sur-Yon,
-17 Impasse de Bougainville,-1.440972,46.677363,,17 Impasse de Bougainville,,,,85000
-35BIS Rue Hoche La Roche-sur-Yon,,,,35BIS Rue Hoche,,,,85000
-35BIS Rue Hoche 85000,,,,35BIS Rue Hoche,,,La Roche-sur-Yon,
-35BIS Rue Hoche,-1.433899,46.670546,,35BIS Rue Hoche,,,,85000
-17 Impasse du Petit Luc La Roche-sur-Yon,,,,17 Impasse du Petit Luc,,,,85000
-17 Impasse du Petit Luc 85000,,,,17 Impasse du Petit Luc,,,La Roche-sur-Yon,
-17 Impasse du Petit Luc,-1.443349,46.649930,,17 Impasse du Petit Luc,,,,85000
-12 Rue de l'Ancienne Comédie Les Sables-d'Olonne,,,,12 Rue de l'Ancienne Comédie,,,,85100
-12 Rue de l'Ancienne Comédie 85100,,,,12 Rue de l'Ancienne Comédie,,,Les Sables-d'Olonne,
-12 Rue de l'Ancienne Comédie,-1.790952,46.495400,,12 Rue de l'Ancienne Comédie,,,,85100
-52 Rue des Frères Rochier Les Sables-d'Olonne,,,,52 Rue des Frères Rochier,,,,85100
-52 Rue des Frères Rochier 85100,,,,52 Rue des Frères Rochier,,,Les Sables-d'Olonne,
-52 Rue des Frères Rochier,-1.769113,46.497069,,52 Rue des Frères Rochier,,,,85100
-44 Impasse Renoleau Les Sables-d'Olonne,,,,44 Impasse Renoleau,,,,85100
-44 Impasse Renoleau 85100,,,,44 Impasse Renoleau,,,Les Sables-d'Olonne,
-44 Impasse Renoleau,-1.771144,46.497662,,44 Impasse Renoleau,,,,85100
-112 Rue Georges Clémenceau Saint-Denis-la-Chevasse,,,,112 Rue Georges Clémenceau,,,,85170
-112 Rue Georges Clémenceau 85170,,,,112 Rue Georges Clémenceau,,,Saint-Denis-la-Chevasse,
-112 Rue Georges Clémenceau,-1.370356,46.824997,,112 Rue Georges Clémenceau,,,,85170
-2A Rue de la Paquette Sainte-Gemme-la-Plaine,,,,2A Rue de la Paquette,,,,85400
-2A Rue de la Paquette 85400,,,,2A Rue de la Paquette,,,Sainte-Gemme-la-Plaine,
-2A Rue de la Paquette,-1.111175,46.482733,,2A Rue de la Paquette,,,,85400
-22 Rue de la Cour Rouge Saint-Gilles-Croix-de-Vie,,,,22 Rue de la Cour Rouge,,,,85800
-22 Rue de la Cour Rouge 85800,,,,22 Rue de la Cour Rouge,,,Saint-Gilles-Croix-de-Vie,
-22 Rue de la Cour Rouge,-1.923046,46.697724,,22 Rue de la Cour Rouge,,,,85800
-32 Rue de la Cosse Sainte-Hermine,,,,32 Rue de la Cosse,,,,85210
-32 Rue de la Cosse 85210,,,,32 Rue de la Cosse,,,Sainte-Hermine,
-32 Rue de la Cosse,-1.066614,46.547860,,32 Rue de la Cosse,,,,85210
-21 Avenue du Docteur Lindemann Saint-Hilaire-de-Riez,,,,21 Avenue du Docteur Lindemann,,,,85270
-21 Avenue du Docteur Lindemann 85270,,,,21 Avenue du Docteur Lindemann,,,Saint-Hilaire-de-Riez,
-21 Avenue du Docteur Lindemann,-1.972026,46.711524,,21 Avenue du Docteur Lindemann,,,,85270
-26 Rue de la Petite Tenue Saint-Hilaire-de-Riez,,,,26 Rue de la Petite Tenue,,,,85270
-26 Rue de la Petite Tenue 85270,,,,26 Rue de la Petite Tenue,,,Saint-Hilaire-de-Riez,
-26 Rue de la Petite Tenue,-1.960658,46.701620,,26 Rue de la Petite Tenue,,,,85270
-21 Rue des Armoises Saint-Jean-de-Monts,,,,21 Rue des Armoises,,,,85160
-21 Rue des Armoises 85160,,,,21 Rue des Armoises,,,Saint-Jean-de-Monts,
-21 Rue des Armoises,-1.983023,46.762007,,21 Rue des Armoises,,,,85160
-11 Allée des Portes Vertes Saint-Jean-de-Monts,,,,11 Allée des Portes Vertes,,,,85160
-11 Allée des Portes Vertes 85160,,,,11 Allée des Portes Vertes,,,Saint-Jean-de-Monts,
-11 Allée des Portes Vertes,-2.033043,46.793795,,11 Allée des Portes Vertes,,,,85160
-23 Rue du Chaponnet Brem-sur-Mer,,,,23 Rue du Chaponnet,,,,85470
-23 Rue du Chaponnet 85470,,,,23 Rue du Chaponnet,,,Brem-sur-Mer,
-23 Rue du Chaponnet,-1.830844,46.604558,,23 Rue du Chaponnet,,,,85470
-30 Rue Alexander Fleming Saint-Michel-en-l'Herm,,,,30 Rue Alexander Fleming,,,,85580
-30 Rue Alexander Fleming 85580,,,,30 Rue Alexander Fleming,,,Saint-Michel-en-l'Herm,
-30 Rue Alexander Fleming,-1.259513,46.352129,,30 Rue Alexander Fleming,,,,85580
-2 Rue du Temple Saint-Prouant,,,,2 Rue du Temple,,,,85110
-2 Rue du Temple 85110,,,,2 Rue du Temple,,,Saint-Prouant,
-2 Rue du Temple,-0.957903,46.759390,,2 Rue du Temple,,,,85110
-24BIS Rue de Beauvoir Sallertaine,,,,24BIS Rue de Beauvoir,,,,85300
-24BIS Rue de Beauvoir 85300,,,,24BIS Rue de Beauvoir,,,Sallertaine,
-24BIS Rue de Beauvoir,-1.898802,46.856718,,24BIS Rue de Beauvoir,,,,85300
-54 Impasse Éole Talmont-Saint-Hilaire,,,,54 Impasse Éole,,,,85440
-54 Impasse Éole 85440,,,,54 Impasse Éole,,,Talmont-Saint-Hilaire,
-54 Impasse Éole,-1.701311,46.453894,,54 Impasse Éole,,,,85440
-48 Rue des Bars La Tranche-sur-Mer,,,,48 Rue des Bars,,,,85360
-48 Rue des Bars 85360,,,,48 Rue des Bars,,,La Tranche-sur-Mer,
-48 Rue des Bars,-1.457383,46.345871,,48 Rue des Bars,,,,85360
-1 Rue des Prairies La Tranche-sur-Mer,,,,1 Rue des Prairies,,,,85360
-1 Rue des Prairies 85360,,,,1 Rue des Prairies,,,La Tranche-sur-Mer,
-1 Rue des Prairies,-1.454323,46.360697,,1 Rue des Prairies,,,,85360
-14 Impasse des Landes Venansault,,,,14 Impasse des Landes,,,,85190
-14 Impasse des Landes 85190,,,,14 Impasse des Landes,,,Venansault,
-14 Impasse des Landes,-1.521961,46.689133,,14 Impasse des Landes,,,,85190
-53 Route de la Pointe d'Arçay La Faute-sur-Mer,,,,53 Route de la Pointe d'Arçay,,,,85460
-53 Route de la Pointe d'Arçay 85460,,,,53 Route de la Pointe d'Arçay,,,La Faute-sur-Mer,
-53 Route de la Pointe d'Arçay,-1.319468,46.329066,,53 Route de la Pointe d'Arçay,,,,85460
-rue de la loire Saint-Sébastien,-1.5528,47.2011,,Rue de la Loire,,,Saint-Sébastien-sur-Loire,
-rue de la loire Saint-Sébastien sur loire,,,,Rue de la Loire,,,Saint-Sébastien-sur-Loire,
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+12A Impasse de la Forge Arthon-en-Retz,,,,12A,Impasse de la Forge,,44320
+12A Impasse de la Forge 44320,,,,12A,Impasse de la Forge,Arthon-en-Retz,
+12A Impasse de la Forge,-1.946713,47.117975,,12A,Impasse de la Forge,,44320
+2 Impasse Paul Claudel Basse-Goulaine,,,,2,Impasse Paul Claudel,,44115
+2 Impasse Paul Claudel 44115,,,,2,Impasse Paul Claudel,Basse-Goulaine,
+2 Impasse Paul Claudel,-1.464937,47.20747,,2,Impasse Paul Claudel,,44115
+3 Avenue des Jonquilles La Bernerie-en-Retz,,,,3,Avenue des Jonquilles,,44760
+3 Avenue des Jonquilles 44760,,,,3,Avenue des Jonquilles,La Bernerie-en-Retz,
+3 Avenue des Jonquilles,-2.045256,47.096511,,3,Avenue des Jonquilles,,44760
+4 Place Saint-Omer Blain,,,,4,Place Saint-Omer,,44130
+4 Place Saint-Omer 44130,,,,4,Place Saint-Omer,Blain,
+4 Place Saint-Omer,-1.857482,47.47434,,4,Place Saint-Omer,,44130
+1 Rue de la Chabossière Bouguenais,,,,1,Rue de la Chabossière,,44340
+1 Rue de la Chabossière 44340,,,,1,Rue de la Chabossière,Bouguenais,
+1 Rue de la Chabossière,-1.587273,47.186506,,1,Rue de la Chabossière,,44340
+1 Square René Clair Bouguenais,,,,1,Square René Clair,,44340
+1 Square René Clair 44340,,,,1,Square René Clair,Bouguenais,
+1 Square René Clair,-1.587448,47.182124,,1,Square René Clair,,44340
+12 Allée des Tilleuls Campbon,,,,12,Allée des Tilleuls,,44750
+12 Allée des Tilleuls 44750,,,,12,Allée des Tilleuls,Campbon,
+12 Allée des Tilleuls,-1.967584,47.409289,,12,Allée des Tilleuls,,44750
+2T Avenue du Professeur Jean Rouxel Carquefou,,,,2T,Avenue du Professeur Jean Rouxel,,44470
+2T Avenue du Professeur Jean Rouxel 44470,,,,2T,Avenue du Professeur Jean Rouxel,Carquefou,
+2T Avenue du Professeur Jean Rouxel,-1.500784,47.298647,,2T,Avenue du Professeur Jean Rouxel,,44470
+29 Rue de la Jô La Chapelle-des-Marais,,,,29,Rue de la Jô,,44410
+29 Rue de la Jô 44410,,,,29,Rue de la Jô,La Chapelle-des-Marais,
+29 Rue de la Jô,-2.229013,47.454799,,29,Rue de la Jô,,44410
+7 Rue François Truffaut La Chapelle-sur-Erdre,,,,7,Rue François Truffaut,,44240
+7 Rue François Truffaut 44240,,,,7,Rue François Truffaut,La Chapelle-sur-Erdre,
+7 Rue François Truffaut,-1.550099,47.310998,,7,Rue François Truffaut,,44240
+14 Rue du Béarn Châteaubriant,,,,14,Rue du Béarn,,44110
+14 Rue du Béarn 44110,,,,14,Rue du Béarn,Châteaubriant,
+14 Rue du Béarn,-1.376947,47.709993,,14,Rue du Béarn,,44110
+26 Rue des Mimosas Chauvé,,,,26,Rue des Mimosas,,44320
+26 Rue des Mimosas 44320,,,,26,Rue des Mimosas,Chauvé,
+26 Rue des Mimosas,-1.989472,47.153648,,26,Rue des Mimosas,,44320
+1 Place des Mimosas Clisson,,,,1,Place des Mimosas,,44190
+1 Place des Mimosas 44190,,,,1,Place des Mimosas,Clisson,
+1 Place des Mimosas,-1.289697,47.084777,,1,Place des Mimosas,,44190
+17 Rue de la Gare Couëron,,,,17,Rue de la Gare,,44220
+17 Rue de la Gare 44220,,,,17,Rue de la Gare,Couëron,
+17 Rue de la Gare,-1.725642,47.222301,,17,Rue de la Gare,,44220
+13 Rue Bretonnie Le Croisic,,,,13,Rue Bretonnie,,44490
+13 Rue Bretonnie 44490,,,,13,Rue Bretonnie,Le Croisic,
+13 Rue Bretonnie,-2.514335,47.294146,,13,Rue Bretonnie,,44490
+45 Rue Évariste Boulay Paty Donges,,,,45,Rue Évariste Boulay Paty,,44480
+45 Rue Évariste Boulay Paty 44480,,,,45,Rue Évariste Boulay Paty,Donges,
+45 Rue Évariste Boulay Paty,-2.076523,47.320523,,45,Rue Évariste Boulay Paty,,44480
+3 Avenue de l'Église La Baule-Escoublac,,,,3,Avenue de l'Église,,44500
+3 Avenue de l'Église 44500,,,,3,Avenue de l'Église,La Baule-Escoublac,
+3 Avenue de l'Église,-2.371919,47.284189,,3,Avenue de l'Église,,44500
+20 Avenue des Ondines La Baule-Escoublac,,,,20,Avenue des Ondines,,44500
+20 Avenue des Ondines 44500,,,,20,Avenue des Ondines,La Baule-Escoublac,
+20 Avenue des Ondines,-2.402307,47.285353,,20,Avenue des Ondines,,44500
+9 Route de Bellevue Frossay,,,,9,Route de Bellevue,,44320
+9 Route de Bellevue 44320,,,,9,Route de Bellevue,Frossay,
+9 Route de Bellevue,-1.941915,47.247923,,9,Route de Bellevue,,44320
+23 Rue de la Houssine Guémené-Penfao,,,,23,Rue de la Houssine,,44290
+23 Rue de la Houssine 44290,,,,23,Rue de la Houssine,Guémené-Penfao,
+23 Rue de la Houssine,-1.844559,47.630252,,23,Rue de la Houssine,,44290
+35 Rue du Moulin de la Place Guérande,,,,35,Rue du Moulin de la Place,,44350
+35 Rue du Moulin de la Place 44350,,,,35,Rue du Moulin de la Place,Guérande,
+35 Rue du Moulin de la Place,-2.424566,47.322314,,35,Rue du Moulin de la Place,,44350
+3 Rue de Préneau Haute-Goulaine,,,,3,Rue de Préneau,,44115
+3 Rue de Préneau 44115,,,,3,Rue de Préneau,Haute-Goulaine,
+3 Rue de Préneau,-1.395011,47.187436,,3,Rue de Préneau,,44115
+27 Rue Joseph Tahet Indre,,,,27,Rue Joseph Tahet,,44610
+27 Rue Joseph Tahet 44610,,,,27,Rue Joseph Tahet,Indre,
+27 Rue Joseph Tahet,-1.648197,47.193676,,27,Rue Joseph Tahet,,44610
+534 Rue Louis Aragon Ligné,,,,534,Rue Louis Aragon,,44850
+534 Rue Louis Aragon 44850,,,,534,Rue Louis Aragon,Ligné,
+534 Rue Louis Aragon,-1.374487,47.40249,,534,Rue Louis Aragon,,44850
+24 Route de Saint-Même Machecoul,,,,24,Route de Saint-Même,,44270
+24 Route de Saint-Même 44270,,,,24,Route de Saint-Même,Machecoul,
+24 Route de Saint-Même,-1.819886,47.004106,,24,Route de Saint-Même,,44270
+200 Rue des Platanes Mésanger,,,,200,Rue des Platanes,,44522
+200 Rue des Platanes 44522,,,,200,Rue des Platanes,Mésanger,
+200 Rue des Platanes,-1.226522,47.434121,,200,Rue des Platanes,,44522
+14 Rue de Bel-Air La Montagne,,,,14,Rue de Bel-Air,,44620
+14 Rue de Bel-Air 44620,,,,14,Rue de Bel-Air,La Montagne,
+14 Rue de Bel-Air,-1.693059,47.192465,,14,Rue de Bel-Air,,44620
+143 Rue Parmentier Montoir-de-Bretagne,,,,143,Rue Parmentier,,44550
+143 Rue Parmentier 44550,,,,143,Rue Parmentier,Montoir-de-Bretagne,
+143 Rue Parmentier,-2.1274,47.322413,,143,Rue Parmentier,,44550
+15 Rue Amiral Duchaffault Nantes,,,,15,Rue Amiral Duchaffault,,44100
+15 Rue Amiral Duchaffault 44100,,,,15,Rue Amiral Duchaffault,Nantes,
+15 Rue Amiral Duchaffault,-1.580268,47.20938,,15,Rue Amiral Duchaffault,,44100
+11 Avenue Botha Nantes,,,,11,Avenue Botha,,44100
+11 Avenue Botha 44100,,,,11,Avenue Botha,Nantes,
+11 Avenue Botha,-1.593097,47.202538,,11,Avenue Botha,,44100
+49 Rue des Clématites Nantes,,,,49,Rue des Clématites,,44100
+49 Rue des Clématites 44100,,,,49,Rue des Clématites,Nantes,
+49 Rue des Clématites,-1.523468,47.23413,,49,Rue des Clématites,,44100
+7 Rue Émile Loubet Nantes,,,,7,Rue Émile Loubet,,44100
+7 Rue Émile Loubet 44100,,,,7,Rue Émile Loubet,Nantes,
+7 Rue Émile Loubet,-1.56902,47.232213,,7,Rue Émile Loubet,,44100
+2 Place Gabriel Trarieux Nantes,,,,2,Place Gabriel Trarieux,,44100
+2 Place Gabriel Trarieux 44100,,,,2,Place Gabriel Trarieux,Nantes,
+2 Place Gabriel Trarieux,-1.522254,47.225914,,2,Place Gabriel Trarieux,,44100
+3 Rue Hectot Nantes,,,,3,Rue Hectot,,44100
+3 Rue Hectot 44100,,,,3,Rue Hectot,Nantes,
+3 Rue Hectot,-1.530976,47.235641,,3,Rue Hectot,,44100
+29 Rue Lamoricière Nantes,,,,29,Rue Lamoricière,,44100
+29 Rue Lamoricière 44100,,,,29,Rue Lamoricière,Nantes,
+29 Rue Lamoricière,-1.571949,47.213409,,29,Rue Lamoricière,,44100
+11B Rue Mellier Nantes,,,,11B,Rue Mellier,,44100
+11B Rue Mellier 44100,,,,11B,Rue Mellier,Nantes,
+11B Rue Mellier,-1.578521,47.210715,,11B,Rue Mellier,,44100
+9 Avenue Père de Foucauld Nantes,,,,9,Avenue Père de Foucauld,,44100
+9 Avenue Père de Foucauld 44100,,,,9,Avenue Père de Foucauld,Nantes,
+9 Avenue Père de Foucauld,-1.576092,47.216529,,9,Avenue Père de Foucauld,,44100
+162 Route de Rennes Nantes,,,,162,Route de Rennes,,44100
+162 Route de Rennes 44100,,,,162,Route de Rennes,Nantes,
+162 Route de Rennes,-1.579779,47.258487,,162,Route de Rennes,,44100
+35 Boulevard du Tertre Nantes,,,,35,Boulevard du Tertre,,44100
+35 Boulevard du Tertre 44100,,,,35,Boulevard du Tertre,Nantes,
+35 Boulevard du Tertre,-1.604462,47.216499,,35,Boulevard du Tertre,,44100
+9 Rue de la Croix Perroche Notre-Dame-des-Landes,,,,9,Rue de la Croix Perroche,,44130
+9 Rue de la Croix Perroche 44130,,,,9,Rue de la Croix Perroche,Notre-Dame-des-Landes,
+9 Rue de la Croix Perroche,-1.705697,47.377936,,9,Rue de la Croix Perroche,,44130
+9 Rue Frédéric Chopin Orvault,,,,9,Rue Frédéric Chopin,,44700
+9 Rue Frédéric Chopin 44700,,,,9,Rue Frédéric Chopin,Orvault,
+9 Rue Frédéric Chopin,-1.58373,47.254271,,9,Rue Frédéric Chopin,,44700
+37 Impasse des Jardins de Belle-Vue Oudon,,,,37,Impasse des Jardins de Belle-Vue,,44521
+37 Impasse des Jardins de Belle-Vue 44521,,,,37,Impasse des Jardins de Belle-Vue,Oudon,
+37 Impasse des Jardins de Belle-Vue,-1.284644,47.35128,,37,Impasse des Jardins de Belle-Vue,,44521
+400 Rue du Lindron Petit-Mars,,,,400,Rue du Lindron,,44390
+400 Rue du Lindron 44390,,,,400,Rue du Lindron,Petit-Mars,
+400 Rue du Lindron,-1.431071,47.387314,,400,Rue du Lindron,,44390
+13 Rue Jean Moulin La Plaine-sur-Mer,,,,13,Rue Jean Moulin,,44770
+13 Rue Jean Moulin 44770,,,,13,Rue Jean Moulin,La Plaine-sur-Mer,
+13 Rue Jean Moulin,-2.176222,47.153645,,13,Rue Jean Moulin,,44770
+10 Rue du Chardonnet Pontchâteau,,,,10,Rue du Chardonnet,,44160
+10 Rue du Chardonnet 44160,,,,10,Rue du Chardonnet,Pontchâteau,
+10 Rue du Chardonnet,-2.081026,47.424722,,10,Rue du Chardonnet,,44160
+125 Rue de la Bernerie Pornic,,,,125,Rue de la Bernerie,,44210
+125 Rue de la Bernerie 44210,,,,125,Rue de la Bernerie,Pornic,
+125 Rue de la Bernerie,-2.077415,47.1071,,125,Rue de la Bernerie,,44210
+6 Rue des Ormes Pornic,,,,6,Rue des Ormes,,44210
+6 Rue des Ormes 44210,,,,6,Rue des Ormes,Pornic,
+6 Rue des Ormes,-2.085849,47.109944,,6,Rue des Ormes,,44210
+20BIS Avenue des Lavandes Pornichet,,,,20BIS,Avenue des Lavandes,,44380
+20BIS Avenue des Lavandes 44380,,,,20BIS,Avenue des Lavandes,Pornichet,
+20BIS Avenue des Lavandes,-2.313842,47.249407,,20BIS,Avenue des Lavandes,,44380
+14 Rue Georges Gralpois Le Pouliguen,,,,14,Rue Georges Gralpois,,44510
+14 Rue Georges Gralpois 44510,,,,14,Rue Georges Gralpois,Le Pouliguen,
+14 Rue Georges Gralpois,-2.438216,47.264914,,14,Rue Georges Gralpois,,44510
+1 Impasse du Tonnelier Puceul,,,,1,Impasse du Tonnelier,,44390
+1 Impasse du Tonnelier 44390,,,,1,Impasse du Tonnelier,Puceul,
+1 Impasse du Tonnelier,-1.616572,47.520386,,1,Impasse du Tonnelier,,44390
+4 Impasse des Couteaux Rezé,,,,4,Impasse des Couteaux,,44400
+4 Impasse des Couteaux 44400,,,,4,Impasse des Couteaux,Rezé,
+4 Impasse des Couteaux,-1.53827,47.18759,,4,Impasse des Couteaux,,44400
+10 Rue Maurice Jouaud Rezé,,,,10,Rue Maurice Jouaud,,44400
+10 Rue Maurice Jouaud 44400,,,,10,Rue Maurice Jouaud,Rezé,
+10 Rue Maurice Jouaud,-1.55813,47.179171,,10,Rue Maurice Jouaud,,44400
+12 Rue de la Sevreniere Gd Rigné Rougé,,,,12,Rue de la Sevreniere Gd Rigné,,44660
+12 Rue de la Sevreniere Gd Rigné 44660,,,,12,Rue de la Sevreniere Gd Rigné,Rougé,
+12 Rue de la Sevreniere Gd Rigné,-1.407284,47.749852,,12,Rue de la Sevreniere Gd Rigné,,44660
+39 Allée des Acacias Saint-Brevin-les-Pins,,,,39,Allée des Acacias,,44250
+39 Allée des Acacias 44250,,,,39,Allée des Acacias,Saint-Brevin-les-Pins,
+39 Allée des Acacias,-2.164335,47.228467,,39,Allée des Acacias,,44250
+228 Avenue de Mindin Saint-Brevin-les-Pins,,,,228,Avenue de Mindin,,44250
+228 Avenue de Mindin 44250,,,,228,Avenue de Mindin,Saint-Brevin-les-Pins,
+228 Avenue de Mindin,-2.165547,47.250165,,228,Avenue de Mindin,,44250
+74 Rue de La Chezine Saint-Étienne-de-Montluc,,,,74,Rue de La Chezine,,44360
+74 Rue de La Chezine 44360,,,,74,Rue de La Chezine,Saint-Étienne-de-Montluc,
+74 Rue de La Chezine,-1.772332,47.27423,,74,Rue de La Chezine,,44360
+15 Rue de la Brétinais Saint-Herblain,,,,15,Rue de la Brétinais,,44800
+15 Rue de la Brétinais 44800,,,,15,Rue de la Brétinais,Saint-Herblain,
+15 Rue de la Brétinais,-1.66486,47.224707,,15,Rue de la Brétinais,,44800
+8 Rue Louis Boutin Saint-Herblain,,,,8,Rue Louis Boutin,,44800
+8 Rue Louis Boutin 44800,,,,8,Rue Louis Boutin,Saint-Herblain,
+8 Rue Louis Boutin,-1.655437,47.211563,,8,Rue Louis Boutin,,44800
+24 Rue de la Gare Saint-Hilaire-de-Chaléons,,,,24,Rue de la Gare,,44680
+24 Rue de la Gare 44680,,,,24,Rue de la Gare,Saint-Hilaire-de-Chaléons,
+24 Rue de la Gare,-1.863331,47.105098,,24,Rue de la Gare,,44680
+55 Rue de Ménac Saint-Joachim,,,,55,Rue de Ménac,,44720
+55 Rue de Ménac 44720,,,,55,Rue de Ménac,Saint-Joachim,
+55 Rue de Ménac,-2.187261,47.37417,,55,Rue de Ménac,,44720
+12 Avenue des Frênes Sainte-Luce-sur-Loire,,,,12,Avenue des Frênes,,44980
+12 Avenue des Frênes 44980,,,,12,Avenue des Frênes,Sainte-Luce-sur-Loire,
+12 Avenue des Frênes,-1.489056,47.252299,,12,Avenue des Frênes,,44980
+11 Rue des Roseaux Saint-Lyphard,,,,11,Rue des Roseaux,,44410
+11 Rue des Roseaux 44410,,,,11,Rue des Roseaux,Saint-Lyphard,
+11 Rue des Roseaux,-2.312695,47.39774,,11,Rue des Roseaux,,44410
+4 Rue des Écoles Saint-Michel-Chef-Chef,,,,4,Rue des Écoles,,44730
+4 Rue des Écoles 44730,,,,4,Rue des Écoles,Saint-Michel-Chef-Chef,
+4 Rue des Écoles,-2.148796,47.181655,,4,Rue des Écoles,,44730
+13 Allée André Malraux Saint-Nazaire,,,,13,Allée André Malraux,,44600
+13 Allée André Malraux 44600,,,,13,Allée André Malraux,Saint-Nazaire,
+13 Allée André Malraux,-2.258431,47.285266,,13,Allée André Malraux,,44600
+16 Allée Edward Jenner Saint-Nazaire,,,,16,Allée Edward Jenner,,44600
+16 Allée Edward Jenner 44600,,,,16,Allée Edward Jenner,Saint-Nazaire,
+16 Allée Edward Jenner,-2.244289,47.277744,,16,Allée Edward Jenner,,44600
+6 Rue Jean-Pierre Dufrexou Saint-Nazaire,,,,6,Rue Jean-Pierre Dufrexou,,44600
+6 Rue Jean-Pierre Dufrexou 44600,,,,6,Rue Jean-Pierre Dufrexou,Saint-Nazaire,
+6 Rue Jean-Pierre Dufrexou,-2.205834,47.272325,,6,Rue Jean-Pierre Dufrexou,,44600
+54TER Route des Québrais Saint-Nazaire,,,,54TER,Route des Québrais,,44600
+54TER Route des Québrais 44600,,,,54TER,Route des Québrais,Saint-Nazaire,
+54TER Route des Québrais,-2.246485,47.283719,,54TER,Route des Québrais,,44600
+6 Rue de la Châtaigneraie Sainte-Pazanne,,,,6,Rue de la Châtaigneraie,,44680
+6 Rue de la Châtaigneraie 44680,,,,6,Rue de la Châtaigneraie,Sainte-Pazanne,
+6 Rue de la Châtaigneraie,-1.80636,47.099608,,6,Rue de la Châtaigneraie,,44680
+5 Rue George Sand Sainte-Reine-de-Bretagne,,,,5,Rue George Sand,,44160
+5 Rue George Sand 44160,,,,5,Rue George Sand,Sainte-Reine-de-Bretagne,
+5 Rue George Sand,-2.189322,47.441669,,5,Rue George Sand,,44160
+5 Avenue Jean Jaurès Saint-Sébastien-sur-Loire,,,,5,Avenue Jean Jaurès,,44230
+5 Avenue Jean Jaurès 44230,,,,5,Avenue Jean Jaurès,Saint-Sébastien-sur-Loire,
+5 Avenue Jean Jaurès,-1.488975,47.206083,,5,Avenue Jean Jaurès,,44230
+4 Rue de l'Allouée Sautron,,,,4,Rue de l'Allouée,,44880
+4 Rue de l'Allouée 44880,,,,4,Rue de l'Allouée,Sautron,
+4 Rue de l'Allouée,-1.678651,47.260428,,4,Rue de l'Allouée,,44880
+51 Route du Chêne Sévérac,,,,51,Route du Chêne,,44530
+51 Route du Chêne 44530,,,,51,Route du Chêne,Sévérac,
+51 Route du Chêne,-2.043178,47.560304,,51,Route du Chêne,,44530
+115 Route de la Gamoterie Sucé-sur-Erdre,,,,115,Route de la Gamoterie,,44240
+115 Route de la Gamoterie 44240,,,,115,Route de la Gamoterie,Sucé-sur-Erdre,
+115 Route de la Gamoterie,-1.506215,47.376569,,115,Route de la Gamoterie,,44240
+1 Impasse de la Blançonnerie Thouaré-sur-Loire,,,,1,Impasse de la Blançonnerie,,44470
+1 Impasse de la Blançonnerie 44470,,,,1,Impasse de la Blançonnerie,Thouaré-sur-Loire,
+1 Impasse de la Blançonnerie,-1.440792,47.268258,,1,Impasse de la Blançonnerie,,44470
+12 Rue Edgar Degas Trignac,,,,12,Rue Edgar Degas,,44570
+12 Rue Edgar Degas 44570,,,,12,Rue Edgar Degas,Trignac,
+12 Rue Edgar Degas,-2.184467,47.316857,,12,Rue Edgar Degas,,44570
+31 Rue du Maréchal de Lattre de Tassigny La Turballe,,,,31,Rue du Maréchal de Lattre de Tassigny,,44420
+31 Rue du Maréchal de Lattre de Tassigny 44420,,,,31,Rue du Maréchal de Lattre de Tassigny,La Turballe,
+31 Rue du Maréchal de Lattre de Tassigny,-2.506815,47.347345,,31,Rue du Maréchal de Lattre de Tassigny,,44420
+11 Chemin des Baillorges Vertou,,,,11,Chemin des Baillorges,,44120
+11 Chemin des Baillorges 44120,,,,11,Chemin des Baillorges,Vertou,
+11 Chemin des Baillorges,-1.4784,47.167084,,11,Chemin des Baillorges,,44120
+5 Avenue de la Juillerie Vertou,,,,5,Avenue de la Juillerie,,44120
+5 Avenue de la Juillerie 44120,,,,5,Avenue de la Juillerie,Vertou,
+5 Avenue de la Juillerie,-1.448851,47.175661,,5,Avenue de la Juillerie,,44120
+10 Rue du Pressoir Vieillevigne,,,,10,Rue du Pressoir,,44116
+10 Rue du Pressoir 44116,,,,10,Rue du Pressoir,Vieillevigne,
+10 Rue du Pressoir,-1.44042,46.965299,,10,Rue du Pressoir,,44116
+41 Rue Bernier Angers,,,,41,Rue Bernier,,49000
+41 Rue Bernier 49000,,,,41,Rue Bernier,Angers,
+41 Rue Bernier,-0.54383,47.462038,,41,Rue Bernier,,49000
+8 Rue du Docteur Michel Gruet Angers,,,,8,Rue du Docteur Michel Gruet,,49000
+8 Rue du Docteur Michel Gruet 49000,,,,8,Rue du Docteur Michel Gruet,Angers,
+8 Rue du Docteur Michel Gruet,-0.510907,47.489724,,8,Rue du Docteur Michel Gruet,,49000
+12 Rue Henri Fruchaud Angers,,,,12,Rue Henri Fruchaud,,49000
+12 Rue Henri Fruchaud 49000,,,,12,Rue Henri Fruchaud,Angers,
+12 Rue Henri Fruchaud,-0.578647,47.481391,,12,Rue Henri Fruchaud,,49000
+68 Rue Maurice Geslin Angers,,,,68,Rue Maurice Geslin,,49000
+68 Rue Maurice Geslin 49000,,,,68,Rue Maurice Geslin,Angers,
+68 Rue Maurice Geslin,-0.514235,47.47993,,68,Rue Maurice Geslin,,49000
+4 Rue Roger Chauviré Angers,,,,4,Rue Roger Chauviré,,49000
+4 Rue Roger Chauviré 49000,,,,4,Rue Roger Chauviré,Angers,
+4 Rue Roger Chauviré,-0.569845,47.47286,,4,Rue Roger Chauviré,,49000
+49 Rue André Malraux Avrillé,,,,49,Rue André Malraux,,49240
+49 Rue André Malraux 49240,,,,49,Rue André Malraux,Avrillé,
+49 Rue André Malraux,-0.591068,47.509567,,49,Rue André Malraux,,49240
+60 Rue de Milngavie Baugé-en-Anjou,,,,60,Rue de Milngavie,,49150
+60 Rue de Milngavie 49150,,,,60,Rue de Milngavie,Baugé-en-Anjou,
+60 Rue de Milngavie,-0.100197,47.546727,,60,Rue de Milngavie,,49150
+16 Impasse Richelieu Beaufort-en-Vallée,,,,16,Impasse Richelieu,,49250
+16 Impasse Richelieu 49250,,,,16,Impasse Richelieu,Beaufort-en-Vallée,
+16 Impasse Richelieu,-0.219054,47.436017,,16,Impasse Richelieu,,49250
+2 Square de la Roseraie Bégrolles-en-Mauges,,,,2,Square de la Roseraie,,49122
+2 Square de la Roseraie 49122,,,,2,Square de la Roseraie,Bégrolles-en-Mauges,
+2 Square de la Roseraie,-0.940641,47.141094,,2,Square de la Roseraie,,49122
+10 Impasse de la Fuye Bouzillé,,,,10,Impasse de la Fuye,,49530
+10 Impasse de la Fuye 49530,,,,10,Impasse de la Fuye,Bouzillé,
+10 Impasse de la Fuye,-1.116254,47.357275,,10,Impasse de la Fuye,,49530
+17 Rue du Maréchal Joffre Brissac-Quincé,,,,17,Rue du Maréchal Joffre,,49320
+17 Rue du Maréchal Joffre 49320,,,,17,Rue du Maréchal Joffre,Brissac-Quincé,
+17 Rue du Maréchal Joffre,-0.448169,47.358061,,17,Rue du Maréchal Joffre,,49320
+9 Avenue Gayot Chalonnes-sur-Loire,,,,9,Avenue Gayot,,49290
+9 Avenue Gayot 49290,,,,9,Avenue Gayot,Chalonnes-sur-Loire,
+9 Avenue Gayot,-0.766173,47.35043,,9,Avenue Gayot,,49290
+2 Rue de Pimodan La Chapelle-sur-Oudon,,,,2,Rue de Pimodan,,49500
+2 Rue de Pimodan 49500,,,,2,Rue de Pimodan,La Chapelle-sur-Oudon,
+2 Rue de Pimodan,-0.830559,47.676215,,2,Rue de Pimodan,,49500
+1 Rue du Mail Chemillé-Melay,,,,1,Rue du Mail,,49120
+1 Rue du Mail 49120,,,,1,Rue du Mail,Chemillé-Melay,
+1 Rue du Mail,-0.727086,47.219184,,1,Rue du Mail,,49120
+21 Rue des Bourgniers Cholet,,,,21,Rue des Bourgniers,,49300
+21 Rue des Bourgniers 49300,,,,21,Rue des Bourgniers,Cholet,
+21 Rue des Bourgniers,-0.887265,47.063354,,21,Rue des Bourgniers,,49300
+13 Square d'Imola Cholet,,,,13,Square d'Imola,,49300
+13 Square d'Imola 49300,,,,13,Square d'Imola,Cholet,
+13 Square d'Imola,-0.873579,47.04359,,13,Square d'Imola,,49300
+35 Rue du Paradis Cholet,,,,35,Rue du Paradis,,49300
+35 Rue du Paradis 49300,,,,35,Rue du Paradis,Cholet,
+35 Rue du Paradis,-0.872798,47.061839,,35,Rue du Paradis,,49300
+39 Boulevard Victor Hugo Cholet,,,,39,Boulevard Victor Hugo,,49300
+39 Boulevard Victor Hugo 49300,,,,39,Boulevard Victor Hugo,Cholet,
+39 Boulevard Victor Hugo,-0.878228,47.066551,,39,Boulevard Victor Hugo,,49300
+1 Rue de l'Église Le Coudray-Macouard,,,,1,Rue de l'Église,,49260
+1 Rue de l'Église 49260,,,,1,Rue de l'Église,Le Coudray-Macouard,
+1 Rue de l'Église,-0.118443,47.193488,,1,Rue de l'Église,,49260
+5 Rue du Pré du Camp Doué-la-Fontaine,,,,5,Rue du Pré du Camp,,49700
+5 Rue du Pré du Camp 49700,,,,5,Rue du Pré du Camp,Doué-la-Fontaine,
+5 Rue du Pré du Camp,-0.274544,47.191634,,5,Rue du Pré du Camp,,49700
+4 Rue des Coteaux du Layon Faye-d'Anjou,,,,4,Rue des Coteaux du Layon,,49380
+4 Rue des Coteaux du Layon 49380,,,,4,Rue des Coteaux du Layon,Faye-d'Anjou,
+4 Rue des Coteaux du Layon,-0.523499,47.292973,,4,Rue des Coteaux du Layon,,49380
+28 Rue des Mésanges Gesté,,,,28,Rue des Mésanges,,49600
+28 Rue des Mésanges 49600,,,,28,Rue des Mésanges,Gesté,
+28 Rue des Mésanges,-1.107495,47.183954,,28,Rue des Mésanges,,49600
+29 Chemin du Haut Plessis Juigné-sur-Loire,,,,29,Chemin du Haut Plessis,,49610
+29 Chemin du Haut Plessis 49610,,,,29,Chemin du Haut Plessis,Juigné-sur-Loire,
+29 Chemin du Haut Plessis,-0.50023,47.385852,,29,Chemin du Haut Plessis,,49610
+12 Place du Bourg Neuf Longué-Jumelles,,,,12,Place du Bourg Neuf,,49160
+12 Place du Bourg Neuf 49160,,,,12,Place du Bourg Neuf,Longué-Jumelles,
+12 Place du Bourg Neuf,-0.105638,47.376055,,12,Place du Bourg Neuf,,49160
+11 Rue Baguenier-Desormeaux Maulévrier,,,,11,Rue Baguenier-Desormeaux,,49360
+11 Rue Baguenier-Desormeaux 49360,,,,11,Rue Baguenier-Desormeaux,Maulévrier,
+11 Rue Baguenier-Desormeaux,-0.738757,47.011938,,11,Rue Baguenier-Desormeaux,,49360
+39 Rue Jean Le Francois La Membrolle-sur-Longuenée,,,,39,Rue Jean Le Francois,,49770
+39 Rue Jean Le Francois 49770,,,,39,Rue Jean Le Francois,La Membrolle-sur-Longuenée,
+39 Rue Jean Le Francois,-0.669329,47.559405,,39,Rue Jean Le Francois,,49770
+6 Impasse du Pressoir Montreuil-Juigné,,,,6,Impasse du Pressoir,,49460
+6 Impasse du Pressoir 49460,,,,6,Impasse du Pressoir,Montreuil-Juigné,
+6 Impasse du Pressoir,-0.598407,47.52821,,6,Impasse du Pressoir,,49460
+35 Route de Brissac Mûrs-Erigné,,,,35,Route de Brissac,,49610
+35 Route de Brissac 49610,,,,35,Route de Brissac,Mûrs-Erigné,
+35 Route de Brissac,-0.521015,47.403884,,35,Route de Brissac,,49610
+25 Allée des Chênes Pellouailles-les-Vignes,,,,25,Allée des Chênes,,49112
+25 Allée des Chênes 49112,,,,25,Allée des Chênes,Pellouailles-les-Vignes,
+25 Allée des Chênes,-0.442702,47.525732,,25,Allée des Chênes,,49112
+4 Avenue Galliéni Les Ponts-de-Cé,,,,4,Avenue Galliéni,,49130
+4 Avenue Galliéni 49130,,,,4,Avenue Galliéni,Les Ponts-de-Cé,
+4 Avenue Galliéni,-0.528803,47.433649,,4,Avenue Galliéni,,49130
+22 Rue de la Villenière La Pouëze,,,,22,Rue de la Villenière,,49370
+22 Rue de la Villenière 49370,,,,22,Rue de la Villenière,La Pouëze,
+22 Rue de la Villenière,-0.811699,47.556209,,22,Rue de la Villenière,,49370
+5 Rue des Charmes Saint-André-de-la-Marche,,,,5,Rue des Charmes,,49450
+5 Rue des Charmes 49450,,,,5,Rue des Charmes,Saint-André-de-la-Marche,
+5 Rue des Charmes,-0.993764,47.106475,,5,Rue des Charmes,,49450
+8 Rue Saint-Maurille Saint-Christophe-du-Bois,,,,8,Rue Saint-Maurille,,49280
+8 Rue Saint-Maurille 49280,,,,8,Rue Saint-Maurille,Saint-Christophe-du-Bois,
+8 Rue Saint-Maurille,-0.942141,47.030194,,8,Rue Saint-Maurille,,49280
+32 Rue Pierre Lepoureau Saint-Georges-des-Gardes,,,,32,Rue Pierre Lepoureau,,49120
+32 Rue Pierre Lepoureau 49120,,,,32,Rue Pierre Lepoureau,Saint-Georges-des-Gardes,
+32 Rue Pierre Lepoureau,-0.757283,47.146712,,32,Rue Pierre Lepoureau,,49120
+4 Rue Paul Gauguin Saint-Lambert-la-Potherie,,,,4,Rue Paul Gauguin,,49070
+4 Rue Paul Gauguin 49070,,,,4,Rue Paul Gauguin,Saint-Lambert-la-Potherie,
+4 Rue Paul Gauguin,-0.681096,47.48353,,4,Rue Paul Gauguin,,49070
+28 Rue du Poirier Saint-Macaire-en-Mauges,,,,28,Rue du Poirier,,49450
+28 Rue du Poirier 49450,,,,28,Rue du Poirier,Saint-Macaire-en-Mauges,
+28 Rue du Poirier,-1.001958,47.124507,,28,Rue du Poirier,,49450
+23 Allée du tumulus Saint-Pierre-Montlimart,,,,23,Allée du tumulus,,49110
+23 Allée du tumulus 49110,,,,23,Allée du tumulus,Saint-Pierre-Montlimart,
+23 Allée du tumulus,-1.038533,47.26494,,23,Allée du tumulus,,49110
+15 Rue des Bouvreuils Saumur,,,,15,Rue des Bouvreuils,,49400
+15 Rue des Bouvreuils 49400,,,,15,Rue des Bouvreuils,Saumur,
+15 Rue des Bouvreuils,-0.071626,47.272718,,15,Rue des Bouvreuils,,49400
+6 Cité André Penot Saumur,,,,6,Cité André Penot,,49400
+6 Cité André Penot 49400,,,,6,Cité André Penot,Saumur,
+6 Cité André Penot,-0.092506,47.246292,,6,Cité André Penot,,49400
+5 Impasse des Haveurs Segré,,,,5,Impasse des Haveurs,,49500
+5 Impasse des Haveurs 49500,,,,5,Impasse des Haveurs,Segré,
+5 Impasse des Haveurs,-0.863685,47.682341,,5,Impasse des Haveurs,,49500
+2 Rue Saint-Pierre Soulaines-sur-Aubance,,,,2,Rue Saint-Pierre,,49610
+2 Rue Saint-Pierre 49610,,,,2,Rue Saint-Pierre,Soulaines-sur-Aubance,
+2 Rue Saint-Pierre,-0.521654,47.363947,,2,Rue Saint-Pierre,,49610
+3 Rue Charles Foyer Torfou,,,,3,Rue Charles Foyer,,49660
+3 Rue Charles Foyer 49660,,,,3,Rue Charles Foyer,Torfou,
+3 Rue Charles Foyer,-1.116083,47.036905,,3,Rue Charles Foyer,,49660
+15BIS Rue des Toises Trélazé,,,,15BIS,Rue des Toises,,49800
+15BIS Rue des Toises 49800,,,,15BIS,Rue des Toises,Trélazé,
+15BIS Rue des Toises,-0.466646,47.445031,,15BIS,Rue des Toises,,49800
+9 Rue du 11 Novembre Vern-d'Anjou,,,,9,Rue du 11 Novembre,,49220
+9 Rue du 11 Novembre 49220,,,,9,Rue du 11 Novembre,Vern-d'Anjou,
+9 Rue du 11 Novembre,-0.834454,47.601598,,9,Rue du 11 Novembre,,49220
+4 Rue des Écoles Villevêque,,,,4,Rue des Écoles,,49140
+4 Rue des Écoles 49140,,,,4,Rue des Écoles,Villevêque,
+4 Rue des Écoles,-0.42294,47.559646,,4,Rue des Écoles,,49140
+5 Route de Laval Azé,,,,5,Route de Laval,,53200
+5 Route de Laval 53200,,,,5,Route de Laval,Azé,
+5 Route de Laval,-0.700041,47.836286,,5,Route de Laval,,53200
+6 Rue des Ormes Bonchamp-lès-Laval,,,,6,Rue des Ormes,,53960
+6 Rue des Ormes 53960,,,,6,Rue des Ormes,Bonchamp-lès-Laval,
+6 Rue des Ormes,-0.706817,48.074814,,6,Rue des Ormes,,53960
+8 Rue de la Bergerie Chantrigné,,,,8,Rue de la Bergerie,,53300
+8 Rue de la Bergerie 53300,,,,8,Rue de la Bergerie,Chantrigné,
+8 Rue de la Bergerie,-0.568959,48.416928,,8,Rue de la Bergerie,,53300
+26 Boulevard Victor Hugo Château-Gontier,,,,26,Boulevard Victor Hugo,,53200
+26 Boulevard Victor Hugo 53200,,,,26,Boulevard Victor Hugo,Château-Gontier,
+26 Boulevard Victor Hugo,-0.712805,47.826162,,26,Boulevard Victor Hugo,,53200
+62 Route de Château Gontier Craon,,,,62,Route de Château Gontier,,53400
+62 Route de Château Gontier 53400,,,,62,Route de Château Gontier,Craon,
+62 Route de Château Gontier,-0.944215,47.846931,,62,Route de Château Gontier,,53400
+19 Rue des Mimosas Ernée,,,,19,Rue des Mimosas,,53500
+19 Rue des Mimosas 53500,,,,19,Rue des Mimosas,Ernée,
+19 Rue des Mimosas,-0.933801,48.304762,,19,Rue des Mimosas,,53500
+24 Rue des Noisetiers Le Genest-Saint-Isle,,,,24,Rue des Noisetiers,,53940
+24 Rue des Noisetiers 53940,,,,24,Rue des Noisetiers,Le Genest-Saint-Isle,
+24 Rue des Noisetiers,-0.89448,48.098622,,24,Rue des Noisetiers,,53940
+13 Rue du Temple Jublains,,,,13,Rue du Temple,,53160
+13 Rue du Temple 53160,,,,13,Rue du Temple,Jublains,
+13 Rue du Temple,-0.496803,48.256702,,13,Rue du Temple,,53160
+37BIS Rue du 124Ieme Régiment I Laval,,,,37BIS,Rue du 124Ieme Régiment I,,53000
+37BIS Rue du 124Ieme Régiment I 53000,,,,37BIS,Rue du 124Ieme Régiment I,Laval,
+37BIS Rue du 124Ieme Régiment I,-0.778598,48.073295,,37BIS,Rue du 124Ieme Régiment I,,53000
+23 Rue Lemercier de Neuville Laval,,,,23,Rue Lemercier de Neuville,,53000
+23 Rue Lemercier de Neuville 53000,,,,23,Rue Lemercier de Neuville,Laval,
+23 Rue Lemercier de Neuville,-0.778088,48.065088,,23,Rue Lemercier de Neuville,,53000
+33 Rue Thomas Naudet Laval,,,,33,Rue Thomas Naudet,,53000
+33 Rue Thomas Naudet 53000,,,,33,Rue Thomas Naudet,Laval,
+33 Rue Thomas Naudet,-0.790594,48.071767,,33,Rue Thomas Naudet,,53000
+28 Lotissement des Gandonnières Martigné-sur-Mayenne,,,,28,Lotissement des Gandonnières,,53470
+28 Lotissement des Gandonnières 53470,,,,28,Lotissement des Gandonnières,Martigné-sur-Mayenne,
+28 Lotissement des Gandonnières,-0.659245,48.194923,,28,Lotissement des Gandonnières,,53470
+5 Résidence de Plein Mer Mayenne,,,,5,Résidence de Plein Mer,,53100
+5 Résidence de Plein Mer 53100,,,,5,Résidence de Plein Mer,Mayenne,
+5 Résidence de Plein Mer,-0.617575,48.2935,,5,Résidence de Plein Mer,,53100
+2BIS Route de la Selle Craonnaise Niafles,,,,2BIS,Route de la Selle Craonnaise,,53400
+2BIS Route de la Selle Craonnaise 53400,,,,2BIS,Route de la Selle Craonnaise,Niafles,
+2BIS Route de la Selle Craonnaise,-1.002331,47.846002,,2BIS,Route de la Selle Craonnaise,,53400
+11 Rue de Kirchheim Renazé,,,,11,Rue de Kirchheim,,53800
+11 Rue de Kirchheim 53800,,,,11,Rue de Kirchheim,Renazé,
+11 Rue de Kirchheim,-1.058142,47.789834,,11,Rue de Kirchheim,,53800
+3 Rue de la Chapelle Anthenaise Saint-Céneré,,,,3,Rue de la Chapelle Anthenaise,,53150
+3 Rue de la Chapelle Anthenaise 53150,,,,3,Rue de la Chapelle Anthenaise,Saint-Céneré,
+3 Rue de la Chapelle Anthenaise,-0.595741,48.121904,,3,Rue de la Chapelle Anthenaise,,53150
+3 Chemin de la Basse Vigne Saint-Martin-de-Connée,,,,3,Chemin de la Basse Vigne,,53160
+3 Chemin de la Basse Vigne 53160,,,,3,Chemin de la Basse Vigne,Saint-Martin-de-Connée,
+3 Chemin de la Basse Vigne,-0.2174,48.214986,,3,Chemin de la Basse Vigne,,53160
+22 Rue de Fromentin Villaines-la-Juhel,,,,22,Rue de Fromentin,,53700
+22 Rue de Fromentin 53700,,,,22,Rue de Fromentin,Villaines-la-Juhel,
+22 Rue de Fromentin,-0.290272,48.343552,,22,Rue de Fromentin,,53700
+3 Rue des Lilas Arnage,,,,3,Rue des Lilas,,72230
+3 Rue des Lilas 72230,,,,3,Rue des Lilas,Arnage,
+3 Rue des Lilas,0.184668,47.94506,,3,Rue des Lilas,,72230
+68 Avenue Nationale La Bazoge,,,,68,Avenue Nationale,,72650
+68 Avenue Nationale 72650,,,,68,Avenue Nationale,La Bazoge,
+68 Avenue Nationale,0.15436,48.099874,,68,Avenue Nationale,,72650
+11 Rue du Professeur Calmette Bonnétable,,,,11,Rue du Professeur Calmette,,72110
+11 Rue du Professeur Calmette 72110,,,,11,Rue du Professeur Calmette,Bonnétable,
+11 Rue du Professeur Calmette,0.435273,48.17576,,11,Rue du Professeur Calmette,,72110
+1 Rue de la Fontaine Saint-Jean Chahaignes,,,,1,Rue de la Fontaine Saint-Jean,,72340
+1 Rue de la Fontaine Saint-Jean 72340,,,,1,Rue de la Fontaine Saint-Jean,Chahaignes,
+1 Rue de la Fontaine Saint-Jean,0.516881,47.74149,,1,Rue de la Fontaine Saint-Jean,,72340
+1 Rue Victor Hugo La Chapelle-Huon,,,,1,Rue Victor Hugo,,72310
+1 Rue Victor Hugo 72310,,,,1,Rue Victor Hugo,La Chapelle-Huon,
+1 Rue Victor Hugo,0.744765,47.859052,,1,Rue Victor Hugo,,72310
+4 Rue Bollée Cherré,,,,4,Rue Bollée,,72400
+4 Rue Bollée 72400,,,,4,Rue Bollée,Cherré,
+4 Rue Bollée,0.668979,48.170775,,4,Rue Bollée,,72400
+11 Rue Jean Moulin Coulaines,,,,11,Rue Jean Moulin,,72190
+11 Rue Jean Moulin 72190,,,,11,Rue Jean Moulin,Coulaines,
+11 Rue Jean Moulin,0.203743,48.030574,,11,Rue Jean Moulin,,72190
+29A Rue du Luart Duneau,,,,29A,Rue du Luart,,72160
+29A Rue du Luart 72160,,,,29A,Rue du Luart,Duneau,
+29A Rue du Luart,0.502663,48.060074,,29A,Rue du Luart,,72160
+5 Cour du Pavillon La Ferté-Bernard,,,,5,Cour du Pavillon,,72400
+5 Cour du Pavillon 72400,,,,5,Cour du Pavillon,La Ferté-Bernard,
+5 Cour du Pavillon,0.652441,48.185177,,5,Cour du Pavillon,,72400
+3 Chemin des Minières Guécélard,,,,3,Chemin des Minières,,72230
+3 Chemin des Minières 72230,,,,3,Chemin des Minières,Guécélard,
+3 Chemin des Minières,0.142678,47.879196,,3,Chemin des Minières,,72230
+37 Rue Léo Delibes La Flèche,,,,37,Rue Léo Delibes,,72200
+37 Rue Léo Delibes 72200,,,,37,Rue Léo Delibes,La Flèche,
+37 Rue Léo Delibes,-0.064474,47.711546,,37,Rue Léo Delibes,,72200
+1598 Route de Gaigner Lombron,,,,1598,Route de Gaigner,,72450
+1598 Route de Gaigner 72450,,,,1598,Route de Gaigner,Lombron,
+1598 Route de Gaigner,0.380472,48.092463,,1598,Route de Gaigner,,72450
+35 Rue Bernard Palissy Malicorne-sur-Sarthe,,,,35,Rue Bernard Palissy,,72270
+35 Rue Bernard Palissy 72270,,,,35,Rue Bernard Palissy,Malicorne-sur-Sarthe,
+35 Rue Bernard Palissy,-0.074195,47.816103,,35,Rue Bernard Palissy,,72270
+15 Rue André Gabelle Le Mans,,,,15,Rue André Gabelle,,72000
+15 Rue André Gabelle 72000,,,,15,Rue André Gabelle,Le Mans,
+15 Rue André Gabelle,0.212339,47.977122,,15,Rue André Gabelle,,72000
+33 Rue de la Briqueterie Le Mans,,,,33,Rue de la Briqueterie,,72000
+33 Rue de la Briqueterie 72000,,,,33,Rue de la Briqueterie,Le Mans,
+33 Rue de la Briqueterie,0.167214,47.99234,,33,Rue de la Briqueterie,,72000
+23 Rue Desaix Le Mans,,,,23,Rue Desaix,,72000
+23 Rue Desaix 72000,,,,23,Rue Desaix,Le Mans,
+23 Rue Desaix,0.182775,48.011719,,23,Rue Desaix,,72000
+93 Rue Gambetta Le Mans,,,,93,Rue Gambetta,,72000
+93 Rue Gambetta 72000,,,,93,Rue Gambetta,Le Mans,
+93 Rue Gambetta,0.189523,48.007066,,93,Rue Gambetta,,72000
+20 Rue Jean Cocteau Le Mans,,,,20,Rue Jean Cocteau,,72000
+20 Rue Jean Cocteau 72000,,,,20,Rue Jean Cocteau,Le Mans,
+20 Rue Jean Cocteau,0.225887,48.013282,,20,Rue Jean Cocteau,,72000
+29 Rue du Maine Le Mans,,,,29,Rue du Maine,,72000
+29 Rue du Maine 72000,,,,29,Rue du Maine,Le Mans,
+29 Rue du Maine,0.199364,47.97083,,29,Rue du Maine,,72000
+62 Rue Paul Éluard Le Mans,,,,62,Rue Paul Éluard,,72000
+62 Rue Paul Éluard 72000,,,,62,Rue Paul Éluard,Le Mans,
+62 Rue Paul Éluard,0.232122,48.003491,,62,Rue Paul Éluard,,72000
+57 Rue Rodolphe Diesel Le Mans,,,,57,Rue Rodolphe Diesel,,72000
+57 Rue Rodolphe Diesel 72000,,,,57,Rue Rodolphe Diesel,Le Mans,
+57 Rue Rodolphe Diesel,0.22534,47.984681,,57,Rue Rodolphe Diesel,,72000
+64 Rue de Valence Le Mans,,,,64,Rue de Valence,,72000
+64 Rue de Valence 72000,,,,64,Rue de Valence,Le Mans,
+64 Rue de Valence,0.224589,48.016576,,64,Rue de Valence,,72000
+43 Route de Sarcé Mayet,,,,43,Route de Sarcé,,72360
+43 Route de Sarcé 72360,,,,43,Route de Sarcé,Mayet,
+43 Route de Sarcé,0.266716,47.750441,,43,Route de Sarcé,,72360
+11 Impasse de la Butte Mulsanne,,,,11,Impasse de la Butte,,72230
+11 Impasse de la Butte 72230,,,,11,Impasse de la Butte,Mulsanne,
+11 Impasse de la Butte,0.254178,47.915242,,11,Impasse de la Butte,,72230
+26 Allée du Stade Parcé-sur-Sarthe,,,,26,Allée du Stade,,72300
+26 Allée du Stade 72300,,,,26,Allée du Stade,Parcé-sur-Sarthe,
+26 Allée du Stade,-0.205098,47.845927,,26,Allée du Stade,,72300
+9 Rue du Levant Pruillé-le-Chétif,,,,9,Rue du Levant,,72700
+9 Rue du Levant 72700,,,,9,Rue du Levant,Pruillé-le-Chétif,
+9 Rue du Levant,0.102413,47.995602,,9,Rue du Levant,,72700
+12 Boulevard de la Gare Sablé-sur-Sarthe,,,,12,Boulevard de la Gare,,72300
+12 Boulevard de la Gare 72300,,,,12,Boulevard de la Gare,Sablé-sur-Sarthe,
+12 Boulevard de la Gare,-0.340541,47.839455,,12,Boulevard de la Gare,,72300
+19 Rue Pasteur Sainte-Cérotte,,,,19,Rue Pasteur,,72120
+19 Rue Pasteur 72120,,,,19,Rue Pasteur,Sainte-Cérotte,
+19 Rue Pasteur,0.688937,47.900524,,19,Rue Pasteur,,72120
+67 Rue Principale Saint-Jean-d'Assé,,,,67,Rue Principale,,72380
+67 Rue Principale 72380,,,,67,Rue Principale,Saint-Jean-d'Assé,
+67 Rue Principale,0.131408,48.149428,,67,Rue Principale,,72380
+2 Rue du Soleil Levant Saint-Pierre-de-Chevillé,,,,2,Rue du Soleil Levant,,72500
+2 Rue du Soleil Levant 72500,,,,2,Rue du Soleil Levant,Saint-Pierre-de-Chevillé,
+2 Rue du Soleil Levant,0.439346,47.645856,,2,Rue du Soleil Levant,,72500
+18BIS Place de l'Église Savigné-l'Évêque,,,,18BIS,Place de l'Église,,72460
+18BIS Place de l'Église 72460,,,,18BIS,Place de l'Église,Savigné-l'Évêque,
+18BIS Place de l'Église,0.296642,48.077027,,18BIS,Place de l'Église,,72460
+1 Rue des Roses Spay,,,,1,Rue des Roses,,72700
+1 Rue des Roses 72700,,,,1,Rue des Roses,Spay,
+1 Rue des Roses,0.147953,47.926834,,1,Rue des Roses,,72700
+17 Rue du Stade Torcé-en-Vallée,,,,17,Rue du Stade,,72110
+17 Rue du Stade 72110,,,,17,Rue du Stade,Torcé-en-Vallée,
+17 Rue du Stade,0.400757,48.134544,,17,Rue du Stade,,72110
+41B Route de Saint-Mars-de-Locquenay Volnay,,,,41B,Route de Saint-Mars-de-Locquenay,,72440
+41B Route de Saint-Mars-de-Locquenay 72440,,,,41B,Route de Saint-Mars-de-Locquenay,Volnay,
+41B Route de Saint-Mars-de-Locquenay,0.477404,47.931001,,41B,Route de Saint-Mars-de-Locquenay,,72440
+2 Rue des Néfliers Aizenay,,,,2,Rue des Néfliers,,85190
+2 Rue des Néfliers 85190,,,,2,Rue des Néfliers,Aizenay,
+2 Rue des Néfliers,-1.612453,46.75089,,2,Rue des Néfliers,,85190
+2 Allée Emile Ruchaud Aubigny,,,,2,Allée Emile Ruchaud,,85430
+2 Allée Emile Ruchaud 85430,,,,2,Allée Emile Ruchaud,Aubigny,
+2 Allée Emile Ruchaud,-1.448445,46.600254,,2,Allée Emile Ruchaud,,85430
+10 Esplanade de la Mer La Barre-de-Monts,,,,10,Esplanade de la Mer,,85550
+10 Esplanade de la Mer 85550,,,,10,Esplanade de la Mer,La Barre-de-Monts,
+10 Esplanade de la Mer,-2.140608,46.891552,,10,Esplanade de la Mer,,85550
+12 Boulevard André Malraux Belleville-sur-Vie,,,,12,Boulevard André Malraux,,85170
+12 Boulevard André Malraux 85170,,,,12,Boulevard André Malraux,Belleville-sur-Vie,
+12 Boulevard André Malraux,-1.421664,46.780359,,12,Boulevard André Malraux,,85170
+3 Allée de la Rochette La Boissière-des-Landes,,,,3,Allée de la Rochette,,85430
+3 Allée de la Rochette 85430,,,,3,Allée de la Rochette,La Boissière-des-Landes,
+3 Allée de la Rochette,-1.458436,46.564232,,3,Allée de la Rochette,,85430
+5 Rue de la Boutinière Bretignolles-sur-Mer,,,,5,Rue de la Boutinière,,85470
+5 Rue de la Boutinière 85470,,,,5,Rue de la Boutinière,Bretignolles-sur-Mer,
+5 Rue de la Boutinière,-1.844072,46.629009,,5,Rue de la Boutinière,,85470
+3 Place de l'Église La Bretonnière-la-Claye,,,,3,Place de l'Église,,85320
+3 Place de l'Église 85320,,,,3,Place de l'Église,La Bretonnière-la-Claye,
+3 Place de l'Église,-1.254924,46.482316,,3,Place de l'Église,,85320
+2 Rue de la Pierre Plate La Chaize-le-Vicomte,,,,2,Rue de la Pierre Plate,,85310
+2 Rue de la Pierre Plate 85310,,,,2,Rue de la Pierre Plate,La Chaize-le-Vicomte,
+2 Rue de la Pierre Plate,-1.292395,46.673324,,2,Rue de la Pierre Plate,,85310
+44 Rue du Maréchal Foch Challans,,,,44,Rue du Maréchal Foch,,85300
+44 Rue du Maréchal Foch 85300,,,,44,Rue du Maréchal Foch,Challans,
+44 Rue du Maréchal Foch,-1.868567,46.835055,,44,Rue du Maréchal Foch,,85300
+4 Rue du Stade Le Champ-Saint-Père,,,,4,Rue du Stade,,85540
+4 Rue du Stade 85540,,,,4,Rue du Stade,Le Champ-Saint-Père,
+4 Rue du Stade,-1.346287,46.506865,,4,Rue du Stade,,85540
+7BIS Rue du Bossard Chasnais,,,,7BIS,Rue du Bossard,,85400
+7BIS Rue du Bossard 85400,,,,7BIS,Rue du Bossard,Chasnais,
+7BIS Rue du Bossard,-1.224799,46.462383,,7BIS,Rue du Bossard,,85400
+26 Rue Jacquard Château-d'Olonne,,,,26,Rue Jacquard,,85180
+26 Rue Jacquard 85180,,,,26,Rue Jacquard,Château-d'Olonne,
+26 Rue Jacquard,-1.734248,46.490831,,26,Rue Jacquard,,85180
+3BIS Rue du Centre Chauché,,,,3BIS,Rue du Centre,,85140
+3BIS Rue du Centre 85140,,,,3BIS,Rue du Centre,Chauché,
+3BIS Rue du Centre,-1.271029,46.828715,,3BIS,Rue du Centre,,85140
+38BIS Rue de la Frise Corpe,,,,38BIS,Rue de la Frise,,85320
+38BIS Rue de la Frise 85320,,,,38BIS,Rue de la Frise,Corpe,
+38BIS Rue de la Frise,-1.186704,46.503122,,38BIS,Rue de la Frise,,85320
+2BIS Rue du Moulin Rompu L'Épine,,,,2BIS,Rue du Moulin Rompu,,85740
+2BIS Rue du Moulin Rompu 85740,,,,2BIS,Rue du Moulin Rompu,L'Épine,
+2BIS Rue du Moulin Rompu,-2.265415,46.978017,,2BIS,Rue du Moulin Rompu,,85740
+5 Impasse du Sextant Le Fenouiller,,,,5,Impasse du Sextant,,85800
+5 Impasse du Sextant 85800,,,,5,Impasse du Sextant,Le Fenouiller,
+5 Impasse du Sextant,-1.920543,46.700406,,5,Impasse du Sextant,,85800
+3 Rue de la Fuie Champanaie Fontenay-le-Comte,,,,3,Rue de la Fuie Champanaie,,85200
+3 Rue de la Fuie Champanaie 85200,,,,3,Rue de la Fuie Champanaie,Fontenay-le-Comte,
+3 Rue de la Fuie Champanaie,-0.797354,46.46695,,3,Rue de la Fuie Champanaie,,85200
+3 Rue des Genêts Fougeré,,,,3,Rue des Genêts,,85480
+3 Rue des Genêts 85480,,,,3,Rue des Genêts,Fougeré,
+3 Rue des Genêts,-1.2356,46.65926,,3,Rue des Genêts,,85480
+3 Rue de l'Église Grand'Landes,,,,3,Rue de l'Église,,85670
+3 Rue de l'Église 85670,,,,3,Rue de l'Église,Grand'Landes,
+3 Rue de l'Église,-1.650527,46.821338,,3,Rue de l'Église,,85670
+11 Rue Claude Debussy L'Herbergement,,,,11,Rue Claude Debussy,,85260
+11 Rue Claude Debussy 85260,,,,11,Rue Claude Debussy,L'Herbergement,
+11 Rue Claude Debussy,-1.373464,46.915988,,11,Rue Claude Debussy,,85260
+8 Rue des Petrels Les Herbiers,,,,8,Rue des Petrels,,85500
+8 Rue des Petrels 85500,,,,8,Rue des Petrels,Les Herbiers,
+8 Rue des Petrels,-1.01287,46.855887,,8,Rue des Petrels,,85500
+34 Rue de la Croix de Ker Chalon L'Île-d'Yeu,,,,34,Rue de la Croix de Ker Chalon,,85350
+34 Rue de la Croix de Ker Chalon 85350,,,,34,Rue de la Croix de Ker Chalon,L'Île-d'Yeu,
+34 Rue de la Croix de Ker Chalon,-2.337617,46.716345,,34,Rue de la Croix de Ker Chalon,,85350
+8 Chemin de la Conche A Marais Jard-sur-Mer,,,,8,Chemin de la Conche A Marais,,85520
+8 Chemin de la Conche A Marais 85520,,,,8,Chemin de la Conche A Marais,Jard-sur-Mer,
+8 Chemin de la Conche A Marais,-1.586628,46.415337,,8,Chemin de la Conche A Marais,,85520
+3 Rue du Moulin Les Landes-Genusson,,,,3,Rue du Moulin,,85130
+3 Rue du Moulin 85130,,,,3,Rue du Moulin,Les Landes-Genusson,
+3 Rue du Moulin,-1.11688,46.968099,,3,Rue du Moulin,,85130
+8 Rue des Bleuets Luçon,,,,8,Rue des Bleuets,,85400
+8 Rue des Bleuets 85400,,,,8,Rue des Bleuets,Luçon,
+8 Rue des Bleuets,-1.154475,46.452875,,8,Rue des Bleuets,,85400
+2 Rue des Primevères Maché,,,,2,Rue des Primevères,,85190
+2 Rue des Primevères 85190,,,,2,Rue des Primevères,Maché,
+2 Rue des Primevères,-1.689473,46.754276,,2,Rue des Primevères,,85190
+14 Rue du Prieuré Mervent,,,,14,Rue du Prieuré,,85200
+14 Rue du Prieuré 85200,,,,14,Rue du Prieuré,Mervent,
+14 Rue du Prieuré,-0.757475,46.522454,,14,Rue du Prieuré,,85200
+1 Place de la Liberté Mortagne-sur-Sèvre,,,,1,Place de la Liberté,,85290
+1 Place de la Liberté 85290,,,,1,Place de la Liberté,Mortagne-sur-Sèvre,
+1 Place de la Liberté,-0.956046,46.992697,,1,Place de la Liberté,,85290
+1 Impasse des Hérons Mouilleron-le-Captif,,,,1,Impasse des Hérons,,85000
+1 Impasse des Hérons 85000,,,,1,Impasse des Hérons,Mouilleron-le-Captif,
+1 Impasse des Hérons,-1.461033,46.71985,,1,Impasse des Hérons,,85000
+42 Basse Rue Noirmoutier-en-l'Île,,,,42,Basse Rue,,85330
+42 Basse Rue 85330,,,,42,Basse Rue,Noirmoutier-en-l'Île,
+42 Basse Rue,-2.254555,47.00615,,42,Basse Rue,,85330
+25 Résidence des Longues Pièces Noirmoutier-en-l'Île,,,,25,Résidence des Longues Pièces,,85330
+25 Résidence des Longues Pièces 85330,,,,25,Résidence des Longues Pièces,Noirmoutier-en-l'Île,
+25 Résidence des Longues Pièces,-2.251874,47.009588,,25,Résidence des Longues Pièces,,85330
+4 Rue des Cordeliers Olonne-sur-Mer,,,,4,Rue des Cordeliers,,85340
+4 Rue des Cordeliers 85340,,,,4,Rue des Cordeliers,Olonne-sur-Mer,
+4 Rue des Cordeliers,-1.780272,46.536713,,4,Rue des Cordeliers,,85340
+25 Rue des Agates Olonne-sur-Mer,,,,25,Rue des Agates,,85340
+25 Rue des Agates 85340,,,,25,Rue des Agates,Olonne-sur-Mer,
+25 Rue des Agates,-1.756648,46.508859,,25,Rue des Agates,,85340
+11 Rue de la Gâte Bourse Le Poiré-sur-Vie,,,,11,Rue de la Gâte Bourse,,85170
+11 Rue de la Gâte Bourse 85170,,,,11,Rue de la Gâte Bourse,Le Poiré-sur-Vie,
+11 Rue de la Gâte Bourse,-1.503435,46.765317,,11,Rue de la Gâte Bourse,,85170
+96 Route de la Bouillée La Réorthe,,,,96,Route de la Bouillée,,85210
+96 Route de la Bouillée 85210,,,,96,Route de la Bouillée,La Réorthe,
+96 Route de la Bouillée,-1.042911,46.603146,,96,Route de la Bouillée,,85210
+17 Impasse de Bougainville La Roche-sur-Yon,,,,17,Impasse de Bougainville,,85000
+17 Impasse de Bougainville 85000,,,,17,Impasse de Bougainville,La Roche-sur-Yon,
+17 Impasse de Bougainville,-1.440972,46.677363,,17,Impasse de Bougainville,,85000
+35BIS Rue Hoche La Roche-sur-Yon,,,,35BIS,Rue Hoche,,85000
+35BIS Rue Hoche 85000,,,,35BIS,Rue Hoche,La Roche-sur-Yon,
+35BIS Rue Hoche,-1.433899,46.670546,,35BIS,Rue Hoche,,85000
+17 Impasse du Petit Luc La Roche-sur-Yon,,,,17,Impasse du Petit Luc,,85000
+17 Impasse du Petit Luc 85000,,,,17,Impasse du Petit Luc,La Roche-sur-Yon,
+17 Impasse du Petit Luc,-1.443349,46.64993,,17,Impasse du Petit Luc,,85000
+12 Rue de l'Ancienne Comédie Les Sables-d'Olonne,,,,12,Rue de l'Ancienne Comédie,,85100
+12 Rue de l'Ancienne Comédie 85100,,,,12,Rue de l'Ancienne Comédie,Les Sables-d'Olonne,
+12 Rue de l'Ancienne Comédie,-1.790952,46.4954,,12,Rue de l'Ancienne Comédie,,85100
+52 Rue des Frères Rochier Les Sables-d'Olonne,,,,52,Rue des Frères Rochier,,85100
+52 Rue des Frères Rochier 85100,,,,52,Rue des Frères Rochier,Les Sables-d'Olonne,
+52 Rue des Frères Rochier,-1.769113,46.497069,,52,Rue des Frères Rochier,,85100
+44 Impasse Renoleau Les Sables-d'Olonne,,,,44,Impasse Renoleau,,85100
+44 Impasse Renoleau 85100,,,,44,Impasse Renoleau,Les Sables-d'Olonne,
+44 Impasse Renoleau,-1.771144,46.497662,,44,Impasse Renoleau,,85100
+112 Rue Georges Clémenceau Saint-Denis-la-Chevasse,,,,112,Rue Georges Clémenceau,,85170
+112 Rue Georges Clémenceau 85170,,,,112,Rue Georges Clémenceau,Saint-Denis-la-Chevasse,
+112 Rue Georges Clémenceau,-1.370356,46.824997,,112,Rue Georges Clémenceau,,85170
+2A Rue de la Paquette Sainte-Gemme-la-Plaine,,,,2A,Rue de la Paquette,,85400
+2A Rue de la Paquette 85400,,,,2A,Rue de la Paquette,Sainte-Gemme-la-Plaine,
+2A Rue de la Paquette,-1.111175,46.482733,,2A,Rue de la Paquette,,85400
+22 Rue de la Cour Rouge Saint-Gilles-Croix-de-Vie,,,,22,Rue de la Cour Rouge,,85800
+22 Rue de la Cour Rouge 85800,,,,22,Rue de la Cour Rouge,Saint-Gilles-Croix-de-Vie,
+22 Rue de la Cour Rouge,-1.923046,46.697724,,22,Rue de la Cour Rouge,,85800
+32 Rue de la Cosse Sainte-Hermine,,,,32,Rue de la Cosse,,85210
+32 Rue de la Cosse 85210,,,,32,Rue de la Cosse,Sainte-Hermine,
+32 Rue de la Cosse,-1.066614,46.54786,,32,Rue de la Cosse,,85210
+21 Avenue du Docteur Lindemann Saint-Hilaire-de-Riez,,,,21,Avenue du Docteur Lindemann,,85270
+21 Avenue du Docteur Lindemann 85270,,,,21,Avenue du Docteur Lindemann,Saint-Hilaire-de-Riez,
+21 Avenue du Docteur Lindemann,-1.972026,46.711524,,21,Avenue du Docteur Lindemann,,85270
+26 Rue de la Petite Tenue Saint-Hilaire-de-Riez,,,,26,Rue de la Petite Tenue,,85270
+26 Rue de la Petite Tenue 85270,,,,26,Rue de la Petite Tenue,Saint-Hilaire-de-Riez,
+26 Rue de la Petite Tenue,-1.960658,46.70162,,26,Rue de la Petite Tenue,,85270
+21 Rue des Armoises Saint-Jean-de-Monts,,,,21,Rue des Armoises,,85160
+21 Rue des Armoises 85160,,,,21,Rue des Armoises,Saint-Jean-de-Monts,
+21 Rue des Armoises,-1.983023,46.762007,,21,Rue des Armoises,,85160
+11 Allée des Portes Vertes Saint-Jean-de-Monts,,,,11,Allée des Portes Vertes,,85160
+11 Allée des Portes Vertes 85160,,,,11,Allée des Portes Vertes,Saint-Jean-de-Monts,
+11 Allée des Portes Vertes,-2.033043,46.793795,,11,Allée des Portes Vertes,,85160
+23 Rue du Chaponnet Brem-sur-Mer,,,,23,Rue du Chaponnet,,85470
+23 Rue du Chaponnet 85470,,,,23,Rue du Chaponnet,Brem-sur-Mer,
+23 Rue du Chaponnet,-1.830844,46.604558,,23,Rue du Chaponnet,,85470
+30 Rue Alexander Fleming Saint-Michel-en-l'Herm,,,,30,Rue Alexander Fleming,,85580
+30 Rue Alexander Fleming 85580,,,,30,Rue Alexander Fleming,Saint-Michel-en-l'Herm,
+30 Rue Alexander Fleming,-1.259513,46.352129,,30,Rue Alexander Fleming,,85580
+2 Rue du Temple Saint-Prouant,,,,2,Rue du Temple,,85110
+2 Rue du Temple 85110,,,,2,Rue du Temple,Saint-Prouant,
+2 Rue du Temple,-0.957903,46.75939,,2,Rue du Temple,,85110
+24BIS Rue de Beauvoir Sallertaine,,,,24BIS,Rue de Beauvoir,,85300
+24BIS Rue de Beauvoir 85300,,,,24BIS,Rue de Beauvoir,Sallertaine,
+24BIS Rue de Beauvoir,-1.898802,46.856718,,24BIS,Rue de Beauvoir,,85300
+54 Impasse Éole Talmont-Saint-Hilaire,,,,54,Impasse Éole,,85440
+54 Impasse Éole 85440,,,,54,Impasse Éole,Talmont-Saint-Hilaire,
+54 Impasse Éole,-1.701311,46.453894,,54,Impasse Éole,,85440
+48 Rue des Bars La Tranche-sur-Mer,,,,48,Rue des Bars,,85360
+48 Rue des Bars 85360,,,,48,Rue des Bars,La Tranche-sur-Mer,
+48 Rue des Bars,-1.457383,46.345871,,48,Rue des Bars,,85360
+1 Rue des Prairies La Tranche-sur-Mer,,,,1,Rue des Prairies,,85360
+1 Rue des Prairies 85360,,,,1,Rue des Prairies,La Tranche-sur-Mer,
+1 Rue des Prairies,-1.454323,46.360697,,1,Rue des Prairies,,85360
+14 Impasse des Landes Venansault,,,,14,Impasse des Landes,,85190
+14 Impasse des Landes 85190,,,,14,Impasse des Landes,Venansault,
+14 Impasse des Landes,-1.521961,46.689133,,14,Impasse des Landes,,85190
+53 Route de la Pointe d'Arçay La Faute-sur-Mer,,,,53,Route de la Pointe d'Arçay,,85460
+53 Route de la Pointe d'Arçay 85460,,,,53,Route de la Pointe d'Arçay,La Faute-sur-Mer,
+53 Route de la Pointe d'Arçay,-1.319468,46.329066,,53,Route de la Pointe d'Arçay,,85460
+rue de la loire Saint-Sébastien,-1.5528,47.2011,,,Rue de la Loire,Saint-Sébastien-sur-Loire,
+rue de la loire Saint-Sébastien sur loire,,,,,Rue de la Loire,Saint-Sébastien-sur-Loire,

--- a/geocoder_tester/world/france/picardie/test_addresses.csv
+++ b/geocoder_tester/world/france/picardie/test_addresses.csv
@@ -1,340 +1,340 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-4 Rue Louis Aragon Athies-sous-Laon,,,,4 Rue Louis Aragon,,,,02840
-4 Rue Louis Aragon 02840,,,,4 Rue Louis Aragon,,,Athies-sous-Laon,
-4 Rue Louis Aragon,3.678912,49.571947,,4 Rue Louis Aragon,,,,02840
-2 Rue du Stade Beautor,,,,2 Rue du Stade,,,,02800
-2 Rue du Stade 02800,,,,2 Rue du Stade,,,Beautor,
-2 Rue du Stade,3.346538,49.656461,,2 Rue du Stade,,,,02800
-303 Rue du Château Billy-sur-Aisne,,,,303 Rue du Château,,,,02200
-303 Rue du Château 02200,,,,303 Rue du Château,,,Billy-sur-Aisne,
-303 Rue du Château,3.385649,49.353834,,303 Rue du Château,,,,02200
-1 Rue de Vailly Bourg-et-Comin,,,,1 Rue de Vailly,,,,02160
-1 Rue de Vailly 02160,,,,1 Rue de Vailly,,,Bourg-et-Comin,
-1 Rue de Vailly,3.656285,49.397290,,1 Rue de Vailly,,,,02160
-7 Rue du Calvaire Bucy-lès-Pierrepont,,,,7 Rue du Calvaire,,,,02350
-7 Rue du Calvaire 02350,,,,7 Rue du Calvaire,,,Bucy-lès-Pierrepont,
-7 Rue du Calvaire,3.902808,49.646259,,7 Rue du Calvaire,,,,02350
-19 Route de Villiers Charly-sur-Marne,,,,19 Route de Villiers,,,,02310
-19 Route de Villiers 02310,,,,19 Route de Villiers,,,Charly-sur-Marne,
-19 Route de Villiers,3.270307,48.983488,,19 Route de Villiers,,,,02310
-3 Résidence Coteau Saint-Vincent Château-Thierry,,,,3 Résidence Coteau Saint-Vincent,,,,02400
-3 Résidence Coteau Saint-Vincent 02400,,,,3 Résidence Coteau Saint-Vincent,,,Château-Thierry,
-3 Résidence Coteau Saint-Vincent,3.393621,49.055252,,3 Résidence Coteau Saint-Vincent,,,,02400
-1 Rue du Vélodrome Chauny,,,,1 Rue du Vélodrome,,,,02300
-1 Rue du Vélodrome 02300,,,,1 Rue du Vélodrome,,,Chauny,
-1 Rue du Vélodrome,3.211315,49.618154,,1 Rue du Vélodrome,,,,02300
-6 Chemin de Puisieux Colonfay,,,,6 Chemin de Puisieux,,,,02120
-6 Chemin de Puisieux 02120,,,,6 Chemin de Puisieux,,,Colonfay,
-6 Chemin de Puisieux,3.709768,49.856597,,6 Chemin de Puisieux,,,,02120
-5 D 8 l'Esperance Croix-Fonsomme,,,,5 D 8 l'Esperance,,,,02110
-5 D 8 l'Esperance 02110,,,,5 D 8 l'Esperance,,,Croix-Fonsomme,
-5 D 8 l'Esperance,3.393975,49.940694,,5 D 8 l'Esperance,,,,02110
-12 Allée Comte de Lostanges Épaux-Bézu,,,,12 Allée Comte de Lostanges,,,,02400
-12 Allée Comte de Lostanges 02400,,,,12 Allée Comte de Lostanges,,,Épaux-Bézu,
-12 Allée Comte de Lostanges,3.345901,49.109409,,12 Allée Comte de Lostanges,,,,02400
-9 Rue de Libération Faucoucourt,,,,9 Rue de Libération,,,,02320
-9 Rue de Libération 02320,,,,9 Rue de Libération,,,Faucoucourt,
-9 Rue de Libération,3.464754,49.531215,,9 Rue de Libération,,,,02320
-12 Lotissement du Chertemps Fontaine-lès-Vervins,,,,12 Lotissement du Chertemps,,,,02140
-12 Lotissement du Chertemps 02140,,,,12 Lotissement du Chertemps,,,Fontaine-lès-Vervins,
-12 Lotissement du Chertemps,3.890474,49.832171,,12 Lotissement du Chertemps,,,,02140
-69 Rue Pierre Sémard Gauchy,,,,69 Rue Pierre Sémard,,,,02430
-69 Rue Pierre Sémard 02430,,,,69 Rue Pierre Sémard,,,Gauchy,
-69 Rue Pierre Sémard,3.286292,49.832078,,69 Rue Pierre Sémard,,,,02430
-348 Rue de Vervins Guise,,,,348 Rue de Vervins,,,,02120
-348 Rue de Vervins 02120,,,,348 Rue de Vervins,,,Guise,
-348 Rue de Vervins,3.630901,49.893466,,348 Rue de Vervins,,,,02120
-68TER Rue de Guise Hirson,,,,68TER Rue de Guise,,,,02500
-68TER Rue de Guise 02500,,,,68TER Rue de Guise,,,Hirson,
-68TER Rue de Guise,4.078064,49.921699,,68TER Rue de Guise,,,,02500
-39 Rue Louis Philipon Juvigny,,,,39 Rue Louis Philipon,,,,02880
-39 Rue Louis Philipon 02880,,,,39 Rue Louis Philipon,,,Juvigny,
-39 Rue Louis Philipon,3.315111,49.448050,,39 Rue Louis Philipon,,,,02880
-4 Rue des Minimes Laon,,,,4 Rue des Minimes,,,,02000
-4 Rue des Minimes 02000,,,,4 Rue des Minimes,,,Laon,
-4 Rue des Minimes,3.650553,49.575085,,4 Rue des Minimes,,,,02000
-4 Rue Vidame Lhuys,,,,4 Rue Vidame,,,,02220
-4 Rue Vidame 02220,,,,4 Rue Vidame,,,Lhuys,
-4 Rue Vidame,3.556260,49.281769,,4 Rue Vidame,,,,02220
-1 Rue de Vervins Martigny,,,,1 Rue de Vervins,,,,02500
-1 Rue de Vervins 02500,,,,1 Rue de Vervins,,,Martigny,
-1 Rue de Vervins,4.132027,49.858366,,1 Rue de Vervins,,,,02500
-44 Rue Clemenceau Montcornet,,,,44 Rue Clemenceau,,,,02340
-44 Rue Clemenceau 02340,,,,44 Rue Clemenceau,,,Montcornet,
-44 Rue Clemenceau,4.011548,49.694718,,44 Rue Clemenceau,,,,02340
-6 Chemin du Lavoir Neuilly-Saint-Front,,,,6 Chemin du Lavoir,,,,02470
-6 Chemin du Lavoir 02470,,,,6 Chemin du Lavoir,,,Neuilly-Saint-Front,
-6 Chemin du Lavoir,3.271091,49.155358,,6 Chemin du Lavoir,,,,02470
-9 Rue du Bois Thomas Omissy,,,,9 Rue du Bois Thomas,,,,02100
-9 Rue du Bois Thomas 02100,,,,9 Rue du Bois Thomas,,,Omissy,
-9 Rue du Bois Thomas,3.315398,49.883146,,9 Rue du Bois Thomas,,,,02100
-20 Rue Heureuse Plomion,,,,20 Rue Heureuse,,,,02140
-20 Rue Heureuse 02140,,,,20 Rue Heureuse,,,Plomion,
-20 Rue Heureuse,4.035620,49.841641,,20 Rue Heureuse,,,,02140
-13 Rue des Fontaines Romery,,,,13 Rue des Fontaines,,,,02120
-13 Rue des Fontaines 02120,,,,13 Rue des Fontaines,,,Romery,
-13 Rue des Fontaines,3.726609,49.898339,,13 Rue des Fontaines,,,,02120
-21 Cité du Gen Leclerc Saint-Michel,,,,21 Cité du Gen Leclerc,,,,02830
-21 Cité du Gen Leclerc 02830,,,,21 Cité du Gen Leclerc,,,Saint-Michel,
-21 Cité du Gen Leclerc,4.139871,49.921938,,21 Cité du Gen Leclerc,,,,02830
-42 Rue de la Chaussée Romaine Saint-Quentin,,,,42 Rue de la Chaussée Romaine,,,,02100
-42 Rue de la Chaussée Romaine 02100,,,,42 Rue de la Chaussée Romaine,,,Saint-Quentin,
-42 Rue de la Chaussée Romaine,3.271552,49.846256,,42 Rue de la Chaussée Romaine,,,,02100
-7 Rue George Sand Saint-Quentin,,,,7 Rue George Sand,,,,02100
-7 Rue George Sand 02100,,,,7 Rue George Sand,,,Saint-Quentin,
-7 Rue George Sand,3.275500,49.838821,,7 Rue George Sand,,,,02100
-74 Rue de Lunéville Saint-Quentin,,,,74 Rue de Lunéville,,,,02100
-74 Rue de Lunéville 02100,,,,74 Rue de Lunéville,,,Saint-Quentin,
-74 Rue de Lunéville,3.296356,49.855525,,74 Rue de Lunéville,,,,02100
-12 Rue Roger Salengro Saint-Quentin,,,,12 Rue Roger Salengro,,,,02100
-12 Rue Roger Salengro 02100,,,,12 Rue Roger Salengro,,,Saint-Quentin,
-12 Rue Roger Salengro,3.278396,49.838660,,12 Rue Roger Salengro,,,,02100
-4 Sentier Derrière Les Jardins Septmonts,,,,4 Sentier Derrière Les Jardins,,,,02200
-4 Sentier Derrière Les Jardins 02200,,,,4 Sentier Derrière Les Jardins,,,Septmonts,
-4 Sentier Derrière Les Jardins,3.361645,49.332634,,4 Sentier Derrière Les Jardins,,,,02200
-13 Avenue Choron Soissons,,,,13 Avenue Choron,,,,02200
-13 Avenue Choron 02200,,,,13 Avenue Choron,,,Soissons,
-13 Avenue Choron,3.318307,49.386554,,13 Avenue Choron,,,,02200
-41 Rue de Vailly Soissons,,,,41 Rue de Vailly,,,,02200
-41 Rue de Vailly 02200,,,,41 Rue de Vailly,,,Soissons,
-41 Rue de Vailly,3.345489,49.390296,,41 Rue de Vailly,,,,02200
-2 Avenue Jean Rostand Tergnier,,,,2 Avenue Jean Rostand,,,,02700
-2 Avenue Jean Rostand 02700,,,,2 Avenue Jean Rostand,,,Tergnier,
-2 Avenue Jean Rostand,3.290371,49.657452,,2 Avenue Jean Rostand,,,,02700
-3 Petite Rue Petite Rue Saint-Vincent Vailly-sur-Aisne,,,,3 Petite Rue Petite Rue Saint-Vincent,,,,02370
-3 Petite Rue Petite Rue Saint-Vincent 02370,,,,3 Petite Rue Petite Rue Saint-Vincent,,,Vailly-sur-Aisne,
-3 Petite Rue Petite Rue Saint-Vincent,3.514706,49.410506,,3 Petite Rue Petite Rue Saint-Vincent,,,,02370
-4 Rue des Lisses Vervins,,,,4 Rue des Lisses,,,,02140
-4 Rue des Lisses 02140,,,,4 Rue des Lisses,,,Vervins,
-4 Rue des Lisses,3.904097,49.830958,,4 Rue des Lisses,,,,02140
-9 Rue Pasteur Villers-Cotterêts,,,,9 Rue Pasteur,,,,02600
-9 Rue Pasteur 02600,,,,9 Rue Pasteur,,,Villers-Cotterêts,
-9 Rue Pasteur,3.085251,49.254680,,9 Rue Pasteur,,,,02600
-3 Rue de la Paix Andeville,,,,3 Rue de la Paix,,,,60570
-3 Rue de la Paix 60570,,,,3 Rue de la Paix,,,Andeville,
-3 Rue de la Paix,2.163663,49.257087,,3 Rue de la Paix,,,,60570
-178 Allée des Pins Auneuil,,,,178 Allée des Pins,,,,60390
-178 Allée des Pins 60390,,,,178 Allée des Pins,,,Auneuil,
-178 Allée des Pins,1.991846,49.363783,,178 Allée des Pins,,,,60390
-434 Rue de la Clergerie Bargny,,,,434 Rue de la Clergerie,,,,60620
-434 Rue de la Clergerie 60620,,,,434 Rue de la Clergerie,,,Bargny,
-434 Rue de la Clergerie,2.958529,49.174537,,434 Rue de la Clergerie,,,,60620
-12 Rue Gay Lussac Beauvais,,,,12 Rue Gay Lussac,,,,60000
-12 Rue Gay Lussac 60000,,,,12 Rue Gay Lussac,,,Beauvais,
-12 Rue Gay Lussac,2.108064,49.409261,,12 Rue Gay Lussac,,,,60000
-99 Rue de Savignies Beauvais,,,,99 Rue de Savignies,,,,60000
-99 Rue de Savignies 60000,,,,99 Rue de Savignies,,,Beauvais,
-99 Rue de Savignies,2.058320,49.439276,,99 Rue de Savignies,,,,60000
-36 Rue Beauxis Lagrave Betz,,,,36 Rue Beauxis Lagrave,,,,60620
-36 Rue Beauxis Lagrave 60620,,,,36 Rue Beauxis Lagrave,,,Betz,
-36 Rue Beauxis Lagrave,2.962609,49.154069,,36 Rue Beauxis Lagrave,,,,60620
-16 Rue Robert Roussey Bouconvillers,,,,16 Rue Robert Roussey,,,,60240
-16 Rue Robert Roussey 60240,,,,16 Rue Robert Roussey,,,Bouconvillers,
-16 Rue Robert Roussey,1.903446,49.176166,,16 Rue Robert Roussey,,,,60240
-92 Rue de Picardie Brétigny,,,,92 Rue de Picardie,,,,60400
-92 Rue de Picardie 60400,,,,92 Rue de Picardie,,,Brétigny,
-92 Rue de Picardie,3.111538,49.566666,,92 Rue de Picardie,,,,60400
-213 Rue du Couvent Cambronne-lès-Clermont,,,,213 Rue du Couvent,,,,60290
-213 Rue du Couvent 60290,,,,213 Rue du Couvent,,,Cambronne-lès-Clermont,
-213 Rue du Couvent,2.414057,49.320418,,213 Rue du Couvent,,,,60290
-262 Rue d'Acate Chambly,,,,262 Rue d'Acate,,,,60230
-262 Rue d'Acate 60230,,,,262 Rue d'Acate,,,Chambly,
-262 Rue d'Acate,2.240369,49.171935,,262 Rue d'Acate,,,,60230
-8 Impasse du Château Chaumont-en-Vexin,,,,8 Impasse du Château,,,,60240
-8 Impasse du Château 60240,,,,8 Impasse du Château,,,Chaumont-en-Vexin,
-8 Impasse du Château,1.874027,49.265112,,8 Impasse du Château,,,,60240
-16 Rue de la Mairie Cires-lès-Mello,,,,16 Rue de la Mairie,,,,60660
-16 Rue de la Mairie 60660,,,,16 Rue de la Mairie,,,Cires-lès-Mello,
-16 Rue de la Mairie,2.358563,49.275059,,16 Rue de la Mairie,,,,60660
-3 Place du Change Compiègne,,,,3 Place du Change,,,,60200
-3 Place du Change 60200,,,,3 Place du Change,,,Compiègne,
-3 Place du Change,2.824334,49.416662,,3 Place du Change,,,,60200
-27 Square du 6e Spahis Compiègne,,,,27 Square du 6e Spahis,,,,60200
-27 Square du 6e Spahis 60200,,,,27 Square du 6e Spahis,,,Compiègne,
-27 Square du 6e Spahis,2.841704,49.422980,,27 Square du 6e Spahis,,,,60200
-69 Rue Gambetta Creil,,,,69 Rue Gambetta,,,,60100
-69 Rue Gambetta 60100,,,,69 Rue Gambetta,,,Creil,
-69 Rue Gambetta,2.473543,49.265148,,69 Rue Gambetta,,,,60100
-42 Avenue de Senlis Crépy-en-Valois,,,,42 Avenue de Senlis,,,,60800
-42 Avenue de Senlis 60800,,,,42 Avenue de Senlis,,,Crépy-en-Valois,
-42 Avenue de Senlis,2.874676,49.232580,,42 Avenue de Senlis,,,,60800
-100BIS Rue du Bos Delincourt,,,,100BIS Rue du Bos,,,,60240
-100BIS Rue du Bos 60240,,,,100BIS Rue du Bos,,,Delincourt,
-100BIS Rue du Bos,1.833112,49.238679,,100BIS Rue du Bos,,,,60240
-149 Avenue de Flandres Estrées-Saint-Denis,,,,149 Avenue de Flandres,,,,60190
-149 Avenue de Flandres 60190,,,,149 Avenue de Flandres,,,Estrées-Saint-Denis,
-149 Avenue de Flandres,2.640098,49.430558,,149 Avenue de Flandres,,,,60190
-311 Rue de Calais Fontaine-Saint-Lucien,,,,311 Rue de Calais,,,,60480
-311 Rue de Calais 60480,,,,311 Rue de Calais,,,Fontaine-Saint-Lucien,
-311 Rue de Calais,2.147425,49.499141,,311 Rue de Calais,,,,60480
-172 Rue de Massival Gilocourt,,,,172 Rue de Massival,,,,60129
-172 Rue de Massival 60129,,,,172 Rue de Massival,,,Gilocourt,
-172 Rue de Massival,2.890232,49.289512,,172 Rue de Massival,,,,60129
-21 Rue d'Amiens Grandvilliers,,,,21 Rue d'Amiens,,,,60210
-21 Rue d'Amiens 60210,,,,21 Rue d'Amiens,,,Grandvilliers,
-21 Rue d'Amiens,1.941860,49.665801,,21 Rue d'Amiens,,,,60210
-9 Rue de la Forêt Hermes,,,,9 Rue de la Forêt,,,,60370
-9 Rue de la Forêt 60370,,,,9 Rue de la Forêt,,,Hermes,
-9 Rue de la Forêt,2.246185,49.367279,,9 Rue de la Forêt,,,,60370
-6 Rue des Sources Lachapelle-aux-Pots,,,,6 Rue des Sources,,,,60650
-6 Rue des Sources 60650,,,,6 Rue des Sources,,,Lachapelle-aux-Pots,
-6 Rue des Sources,1.929924,49.449737,,6 Rue des Sources,,,,60650
-2 Rue Principale Lalandelle,,,,2 Rue Principale,,,,60850
-2 Rue Principale 60850,,,,2 Rue Principale,,,Lalandelle,
-2 Rue Principale,1.873980,49.400010,,2 Rue Principale,,,,60850
-159 Rue de l'Abattoir Liancourt,,,,159 Rue de l'Abattoir,,,,60140
-159 Rue de l'Abattoir 60140,,,,159 Rue de l'Abattoir,,,Liancourt,
-159 Rue de l'Abattoir,2.457045,49.327998,,159 Rue de l'Abattoir,,,,60140
-5 Rue du Pont du Matz Machemont,,,,5 Rue du Pont du Matz,,,,60150
-5 Rue du Pont du Matz 60150,,,,5 Rue du Pont du Matz,,,Machemont,
-5 Rue du Pont du Matz,2.883644,49.488752,,5 Rue du Pont du Matz,,,,60150
-162 Rue de Ressons Marquéglise,,,,162 Rue de Ressons,,,,60490
-162 Rue de Ressons 60490,,,,162 Rue de Ressons,,,Marquéglise,
-162 Rue de Ressons,2.762482,49.518370,,162 Rue de Ressons,,,,60490
-15 Allée des Pervenches Le Mesnil-en-Thelle,,,,15 Allée des Pervenches,,,,60530
-15 Allée des Pervenches 60530,,,,15 Allée des Pervenches,,,Le Mesnil-en-Thelle,
-15 Allée des Pervenches,2.283826,49.180586,,15 Allée des Pervenches,,,,60530
-48 Rue Porte de Baron Montagny-Sainte-Félicité,,,,48 Rue Porte de Baron,,,,60950
-48 Rue Porte de Baron 60950,,,,48 Rue Porte de Baron,,,Montagny-Sainte-Félicité,
-48 Rue Porte de Baron,2.739514,49.132574,,48 Rue Porte de Baron,,,,60950
-4 Rue des Vignes Mortefontaine,,,,4 Rue des Vignes,,,,60128
-4 Rue des Vignes 60128,,,,4 Rue des Vignes,,,Mortefontaine,
-4 Rue des Vignes,2.597408,49.114145,,4 Rue des Vignes,,,,60128
-11 Impasse d'Ormeteau Neuilly-en-Thelle,,,,11 Impasse d'Ormeteau,,,,60530
-11 Impasse d'Ormeteau 60530,,,,11 Impasse d'Ormeteau,,,Neuilly-en-Thelle,
-11 Impasse d'Ormeteau,2.281941,49.228247,,11 Impasse d'Ormeteau,,,,60530
-7 Allée Georges Bizet Nogent-sur-Oise,,,,7 Allée Georges Bizet,,,,60180
-7 Allée Georges Bizet 60180,,,,7 Allée Georges Bizet,,,Nogent-sur-Oise,
-7 Allée Georges Bizet,2.459467,49.270311,,7 Allée Georges Bizet,,,,60180
-52 Rue de Lille Noyon,,,,52 Rue de Lille,,,,60400
-52 Rue de Lille 60400,,,,52 Rue de Lille,,,Noyon,
-52 Rue de Lille,3.002430,49.584211,,52 Rue de Lille,,,,60400
-1 Rue Triolet Péroy-les-Gombries,,,,1 Rue Triolet,,,,60440
-1 Rue Triolet 60440,,,,1 Rue Triolet,,,Péroy-les-Gombries,
-1 Rue Triolet,2.848159,49.162912,,1 Rue Triolet,,,,60440
-338 Rue Basse Pontpoint,,,,338 Rue Basse,,,,60700
-338 Rue Basse 60700,,,,338 Rue Basse,,,Pontpoint,
-338 Rue Basse,2.639452,49.302614,,338 Rue Basse,,,,60700
-11 Rue Principale Prévillers,,,,11 Rue Principale,,,,60360
-11 Rue Principale 60360,,,,11 Rue Principale,,,Prévillers,
-11 Rue Principale,1.996165,49.609573,,11 Rue Principale,,,,60360
-136 Rue de la Fertière Ribécourt-Dreslincourt,,,,136 Rue de la Fertière,,,,60170
-136 Rue de la Fertière 60170,,,,136 Rue de la Fertière,,,Ribécourt-Dreslincourt,
-136 Rue de la Fertière,2.920746,49.516935,,136 Rue de la Fertière,,,,60170
-3 Rue de la Motte Sacy-le-Petit,,,,3 Rue de la Motte,,,,60190
-3 Rue de la Motte 60190,,,,3 Rue de la Motte,,,Sacy-le-Petit,
-3 Rue de la Motte,2.630412,49.361633,,3 Rue de la Motte,,,,60190
-19 Rue du Général de Gaulle Saint-Just-en-Chaussée,,,,19 Rue du Général de Gaulle,,,,60130
-19 Rue du Général de Gaulle 60130,,,,19 Rue du Général de Gaulle,,,Saint-Just-en-Chaussée,
-19 Rue du Général de Gaulle,2.424132,49.504402,,19 Rue du Général de Gaulle,,,,60130
-5 Rue de la Faïencerie Saint-Paul,,,,5 Rue de la Faïencerie,,,,60650
-5 Rue de la Faïencerie 60650,,,,5 Rue de la Faïencerie,,,Saint-Paul,
-5 Rue de la Faïencerie,2.007764,49.430673,,5 Rue de la Faïencerie,,,,60650
-9 Rue du Clos de la Chatelaine Senlis,,,,9 Rue du Clos de la Chatelaine,,,,60300
-9 Rue du Clos de la Chatelaine 60300,,,,9 Rue du Clos de la Chatelaine,,,Senlis,
-9 Rue du Clos de la Chatelaine,2.573152,49.201123,,9 Rue du Clos de la Chatelaine,,,,60300
-90 Rue de Montdidier Suzoy,,,,90 Rue de Montdidier,,,,60400
-90 Rue de Montdidier 60400,,,,90 Rue de Montdidier,,,Suzoy,
-90 Rue de Montdidier,2.947591,49.580856,,90 Rue de Montdidier,,,,60400
-5A Rue du Point du Jour Tracy-le-Mont,,,,5A Rue du Point du Jour,,,,60170
-5A Rue du Point du Jour 60170,,,,5A Rue du Point du Jour,,,Tracy-le-Mont,
-5A Rue du Point du Jour,3.006271,49.467697,,5A Rue du Point du Jour,,,,60170
-14 Chemin des Côtes Le Vaumain,,,,14 Chemin des Côtes,,,,60590
-14 Chemin des Côtes 60590,,,,14 Chemin des Côtes,,,Le Vaumain,
-14 Chemin des Côtes,1.860397,49.349100,,14 Chemin des Côtes,,,,60590
-20 Rue de la Vallee Sainte-Genevieve Verneuil-en-Halatte,,,,20 Rue de la Vallee Sainte-Genevieve,,,,60550
-20 Rue de la Vallee Sainte-Genevieve 60550,,,,20 Rue de la Vallee Sainte-Genevieve,,,Verneuil-en-Halatte,
-20 Rue de la Vallee Sainte-Genevieve,2.526466,49.274395,,20 Rue de la Vallee Sainte-Genevieve,,,,60550
-10 Rue de la Gare Villers-sur-Coudun,,,,10 Rue de la Gare,,,,60150
-10 Rue de la Gare 60150,,,,10 Rue de la Gare,,,Villers-sur-Coudun,
-10 Rue de la Gare,2.796574,49.480220,,10 Rue de la Gare,,,,60150
-7 Rue Mautort Abbeville,,,,7 Rue Mautort,,,,80100
-7 Rue Mautort 80100,,,,7 Rue Mautort,,,Abbeville,
-7 Rue Mautort,1.796008,50.105115,,7 Rue Mautort,,,,80100
-7 Avenue de Flandres Ailly-sur-Noye,,,,7 Avenue de Flandres,,,,80250
-7 Avenue de Flandres 80250,,,,7 Avenue de Flandres,,,Ailly-sur-Noye,
-7 Avenue de Flandres,2.371491,49.756589,,7 Avenue de Flandres,,,,80250
-103 Rue Jean Jaurès Albert,,,,103 Rue Jean Jaurès,,,,80300
-103 Rue Jean Jaurès 80300,,,,103 Rue Jean Jaurès,,,Albert,
-103 Rue Jean Jaurès,2.649792,49.996853,,103 Rue Jean Jaurès,,,,80300
-16 Rue Auguste Renoir Amiens,,,,16 Rue Auguste Renoir,,,,80000
-16 Rue Auguste Renoir 80000,,,,16 Rue Auguste Renoir,,,Amiens,
-16 Rue Auguste Renoir,2.299846,49.914432,,16 Rue Auguste Renoir,,,,80000
-45 Rue du Comte Raoul Amiens,,,,45 Rue du Comte Raoul,,,,80000
-45 Rue du Comte Raoul 80000,,,,45 Rue du Comte Raoul,,,Amiens,
-45 Rue du Comte Raoul,2.315133,49.884827,,45 Rue du Comte Raoul,,,,80000
-32 Boulevard des Fédérés Amiens,,,,32 Boulevard des Fédérés,,,,80000
-32 Boulevard des Fédérés 80000,,,,32 Boulevard des Fédérés,,,Amiens,
-32 Boulevard des Fédérés,2.283949,49.894936,,32 Boulevard des Fédérés,,,,80000
-207 Chaussée Jules Ferry Amiens,,,,207 Chaussée Jules Ferry,,,,80000
-207 Chaussée Jules Ferry 80000,,,,207 Chaussée Jules Ferry,,,Amiens,
-207 Chaussée Jules Ferry,2.330111,49.881449,,207 Chaussée Jules Ferry,,,,80000
-15 Rue Neuve-Dejean Amiens,,,,15 Rue Neuve-Dejean,,,,80000
-15 Rue Neuve-Dejean 80000,,,,15 Rue Neuve-Dejean,,,Amiens,
-15 Rue Neuve-Dejean,2.317871,49.891452,,15 Rue Neuve-Dejean,,,,80000
-21 Rue Sagebien Amiens,,,,21 Rue Sagebien,,,,80000
-21 Rue Sagebien 80000,,,,21 Rue Sagebien,,,Amiens,
-21 Rue Sagebien,2.290934,49.879121,,21 Rue Sagebien,,,,80000
-18 Rue Watteau Amiens,,,,18 Rue Watteau,,,,80000
-18 Rue Watteau 80000,,,,18 Rue Watteau,,,Amiens,
-18 Rue Watteau,2.299377,49.913924,,18 Rue Watteau,,,,80000
-46 Rue du Général Leclerc Beauval,,,,46 Rue du Général Leclerc,,,,80630
-46 Rue du Général Leclerc 80630,,,,46 Rue du Général Leclerc,,,Beauval,
-46 Rue du Général Leclerc,2.329654,50.106097,,46 Rue du Général Leclerc,,,,80630
-40 Rue Alphonse Tellier Boves,,,,40 Rue Alphonse Tellier,,,,80440
-40 Rue Alphonse Tellier 80440,,,,40 Rue Alphonse Tellier,,,Boves,
-40 Rue Alphonse Tellier,2.383901,49.842418,,40 Rue Alphonse Tellier,,,,80440
-7 Rue Marie Curie Camon,,,,7 Rue Marie Curie,,,,80450
-7 Rue Marie Curie 80450,,,,7 Rue Marie Curie,,,Camon,
-7 Rue Marie Curie,2.336398,49.895592,,7 Rue Marie Curie,,,,80450
-364 Hurt Cayeux-sur-Mer,,,,364 Hurt,,,,80410
-364 Hurt 80410,,,,364 Hurt,,,Cayeux-sur-Mer,
-364 Hurt,1.523273,50.172369,,364 Hurt,,,,80410
-2 Rue de Coulonvillers Cramont,,,,2 Rue de Coulonvillers,,,,80370
-2 Rue de Coulonvillers 80370,,,,2 Rue de Coulonvillers,,,Cramont,
-2 Rue de Coulonvillers,2.051850,50.147018,,2 Rue de Coulonvillers,,,,80370
-30 Rue du Bourg Doullens,,,,30 Rue du Bourg,,,,80600
-30 Rue du Bourg 80600,,,,30 Rue du Bourg,,,Doullens,
-30 Rue du Bourg,2.340888,50.155290,,30 Rue du Bourg,,,,80600
-1 Lotissement des Jardins Eppeville,,,,1 Lotissement des Jardins,,,,80400
-1 Lotissement des Jardins 80400,,,,1 Lotissement des Jardins,,,Eppeville,
-1 Lotissement des Jardins,3.064184,49.741836,,1 Lotissement des Jardins,,,,80400
-13 Rue d'en Bas Foucaucourt-Hors-Nesle,,,,13 Rue d'en Bas,,,,80140
-13 Rue d'en Bas 80140,,,,13 Rue d'en Bas,,,Foucaucourt-Hors-Nesle,
-13 Rue d'en Bas,1.725727,49.917335,,13 Rue d'en Bas,,,,80140
-15 Rue des Rainvillers Hallencourt,,,,15 Rue des Rainvillers,,,,80490
-15 Rue des Rainvillers 80490,,,,15 Rue des Rainvillers,,,Hallencourt,
-15 Rue des Rainvillers,1.874789,49.988574,,15 Rue des Rainvillers,,,,80490
-1 Rue de Bezencourt Hornoy-le-Bourg,,,,1 Rue de Bezencourt,,,,80640
-1 Rue de Bezencourt 80640,,,,1 Rue de Bezencourt,,,Hornoy-le-Bourg,
-1 Rue de Bezencourt,1.864063,49.827968,,1 Rue de Bezencourt,,,,80640
-24 Rue Gérard Philipe Longueau,,,,24 Rue Gérard Philipe,,,,80330
-24 Rue Gérard Philipe 80330,,,,24 Rue Gérard Philipe,,,Longueau,
-24 Rue Gérard Philipe,2.362020,49.871947,,24 Rue Gérard Philipe,,,,80330
-5 Rue du Bordet Miraumont,,,,5 Rue du Bordet,,,,80300
-5 Rue du Bordet 80300,,,,5 Rue du Bordet,,,Miraumont,
-5 Rue du Bordet,2.726320,50.092582,,5 Rue du Bordet,,,,80300
-8 Place Verte Oisemont,,,,8 Place Verte,,,,80140
-8 Place Verte 80140,,,,8 Place Verte,,,Oisemont,
-8 Place Verte,1.771397,49.955438,,8 Place Verte,,,,80140
-3BIS Rue Festonval Pierregot,,,,3BIS Rue Festonval,,,,80260
-3BIS Rue Festonval 80260,,,,3BIS Rue Festonval,,,Pierregot,
-3BIS Rue Festonval,2.379097,50.002176,,3BIS Rue Festonval,,,,80260
-11 Rue de la 2E Division Blindée Le Quesne,,,,11 Rue de la 2E Division Blindée,,,,80430
-11 Rue de la 2E Division Blindée 80430,,,,11 Rue de la 2E Division Blindée,,,Le Quesne,
-11 Rue de la 2E Division Blindée,1.790083,49.853216,,11 Rue de la 2E Division Blindée,,,,80430
-3TER Rue Pasteur Roye,,,,3TER Rue Pasteur,,,,80700
-3TER Rue Pasteur 80700,,,,3TER Rue Pasteur,,,Roye,
-3TER Rue Pasteur,2.791594,49.697424,,3TER Rue Pasteur,,,,80700
-20 Rue d'en Haut Saint-Léger-lès-Domart,,,,20 Rue d'en Haut,,,,80780
-20 Rue d'en Haut 80780,,,,20 Rue d'en Haut,,,Saint-Léger-lès-Domart,
-20 Rue d'en Haut,2.142348,50.055549,,20 Rue d'en Haut,,,,80780
-137 Rue Jean Catelas Saleux,,,,137 Rue Jean Catelas,,,,80480
-137 Rue Jean Catelas 80480,,,,137 Rue Jean Catelas,,,Saleux,
-137 Rue Jean Catelas,2.237530,49.857428,,137 Rue Jean Catelas,,,,80480
-12 Rue de Bas Vaudricourt,,,,12 Rue de Bas,,,,80230
-12 Rue de Bas 80230,,,,12 Rue de Bas,,,Vaudricourt,
-12 Rue de Bas,1.553176,50.120772,,12 Rue de Bas,,,,80230
-38 Route de Callenges Vron,,,,38 Route de Callenges,,,,80120
-38 Route de Callenges 80120,,,,38 Route de Callenges,,,Vron,
-38 Route de Callenges,1.759335,50.309294,,38 Route de Callenges,,,,80120
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+4 Rue Louis Aragon Athies-sous-Laon,,,,4,Rue Louis Aragon,,2840
+4 Rue Louis Aragon 02840,,,,4,Rue Louis Aragon,Athies-sous-Laon,
+4 Rue Louis Aragon,3.678912,49.571947,,4,Rue Louis Aragon,,2840
+2 Rue du Stade Beautor,,,,2,Rue du Stade,,2800
+2 Rue du Stade 02800,,,,2,Rue du Stade,Beautor,
+2 Rue du Stade,3.346538,49.656461,,2,Rue du Stade,,2800
+303 Rue du Château Billy-sur-Aisne,,,,303,Rue du Château,,2200
+303 Rue du Château 02200,,,,303,Rue du Château,Billy-sur-Aisne,
+303 Rue du Château,3.385649,49.353834,,303,Rue du Château,,2200
+1 Rue de Vailly Bourg-et-Comin,,,,1,Rue de Vailly,,2160
+1 Rue de Vailly 02160,,,,1,Rue de Vailly,Bourg-et-Comin,
+1 Rue de Vailly,3.656285,49.39729,,1,Rue de Vailly,,2160
+7 Rue du Calvaire Bucy-lès-Pierrepont,,,,7,Rue du Calvaire,,2350
+7 Rue du Calvaire 02350,,,,7,Rue du Calvaire,Bucy-lès-Pierrepont,
+7 Rue du Calvaire,3.902808,49.646259,,7,Rue du Calvaire,,2350
+19 Route de Villiers Charly-sur-Marne,,,,19,Route de Villiers,,2310
+19 Route de Villiers 02310,,,,19,Route de Villiers,Charly-sur-Marne,
+19 Route de Villiers,3.270307,48.983488,,19,Route de Villiers,,2310
+3 Résidence Coteau Saint-Vincent Château-Thierry,,,,3,Résidence Coteau Saint-Vincent,,2400
+3 Résidence Coteau Saint-Vincent 02400,,,,3,Résidence Coteau Saint-Vincent,Château-Thierry,
+3 Résidence Coteau Saint-Vincent,3.393621,49.055252,,3,Résidence Coteau Saint-Vincent,,2400
+1 Rue du Vélodrome Chauny,,,,1,Rue du Vélodrome,,2300
+1 Rue du Vélodrome 02300,,,,1,Rue du Vélodrome,Chauny,
+1 Rue du Vélodrome,3.211315,49.618154,,1,Rue du Vélodrome,,2300
+6 Chemin de Puisieux Colonfay,,,,6,Chemin de Puisieux,,2120
+6 Chemin de Puisieux 02120,,,,6,Chemin de Puisieux,Colonfay,
+6 Chemin de Puisieux,3.709768,49.856597,,6,Chemin de Puisieux,,2120
+5 D 8 l'Esperance Croix-Fonsomme,,,,5,l'Esperance,,2110
+5 D 8 l'Esperance 02110,,,,5,l'Esperance,Croix-Fonsomme,
+5 D 8 l'Esperance,3.393975,49.940694,,5,l'Esperance,,2110
+12 Allée Comte de Lostanges Épaux-Bézu,,,,12,Allée Comte de Lostanges,,2400
+12 Allée Comte de Lostanges 02400,,,,12,Allée Comte de Lostanges,Épaux-Bézu,
+12 Allée Comte de Lostanges,3.345901,49.109409,,12,Allée Comte de Lostanges,,2400
+9 Rue de Libération Faucoucourt,,,,9,Rue de Libération,,2320
+9 Rue de Libération 02320,,,,9,Rue de Libération,Faucoucourt,
+9 Rue de Libération,3.464754,49.531215,,9,Rue de Libération,,2320
+12 Lotissement du Chertemps Fontaine-lès-Vervins,,,,12,Lotissement du Chertemps,,2140
+12 Lotissement du Chertemps 02140,,,,12,Lotissement du Chertemps,Fontaine-lès-Vervins,
+12 Lotissement du Chertemps,3.890474,49.832171,,12,Lotissement du Chertemps,,2140
+69 Rue Pierre Sémard Gauchy,,,,69,Rue Pierre Sémard,,2430
+69 Rue Pierre Sémard 02430,,,,69,Rue Pierre Sémard,Gauchy,
+69 Rue Pierre Sémard,3.286292,49.832078,,69,Rue Pierre Sémard,,2430
+348 Rue de Vervins Guise,,,,348,Rue de Vervins,,2120
+348 Rue de Vervins 02120,,,,348,Rue de Vervins,Guise,
+348 Rue de Vervins,3.630901,49.893466,,348,Rue de Vervins,,2120
+68TER Rue de Guise Hirson,,,,68TER,Rue de Guise,,2500
+68TER Rue de Guise 02500,,,,68TER,Rue de Guise,Hirson,
+68TER Rue de Guise,4.078064,49.921699,,68TER,Rue de Guise,,2500
+39 Rue Louis Philipon Juvigny,,,,39,Rue Louis Philipon,,2880
+39 Rue Louis Philipon 02880,,,,39,Rue Louis Philipon,Juvigny,
+39 Rue Louis Philipon,3.315111,49.44805,,39,Rue Louis Philipon,,2880
+4 Rue des Minimes Laon,,,,4,Rue des Minimes,,2000
+4 Rue des Minimes 02000,,,,4,Rue des Minimes,Laon,
+4 Rue des Minimes,3.650553,49.575085,,4,Rue des Minimes,,2000
+4 Rue Vidame Lhuys,,,,4,Rue Vidame,,2220
+4 Rue Vidame 02220,,,,4,Rue Vidame,Lhuys,
+4 Rue Vidame,3.55626,49.281769,,4,Rue Vidame,,2220
+1 Rue de Vervins Martigny,,,,1,Rue de Vervins,,2500
+1 Rue de Vervins 02500,,,,1,Rue de Vervins,Martigny,
+1 Rue de Vervins,4.132027,49.858366,,1,Rue de Vervins,,2500
+44 Rue Clemenceau Montcornet,,,,44,Rue Clemenceau,,2340
+44 Rue Clemenceau 02340,,,,44,Rue Clemenceau,Montcornet,
+44 Rue Clemenceau,4.011548,49.694718,,44,Rue Clemenceau,,2340
+6 Chemin du Lavoir Neuilly-Saint-Front,,,,6,Chemin du Lavoir,,2470
+6 Chemin du Lavoir 02470,,,,6,Chemin du Lavoir,Neuilly-Saint-Front,
+6 Chemin du Lavoir,3.271091,49.155358,,6,Chemin du Lavoir,,2470
+9 Rue du Bois Thomas Omissy,,,,9,Rue du Bois Thomas,,2100
+9 Rue du Bois Thomas 02100,,,,9,Rue du Bois Thomas,Omissy,
+9 Rue du Bois Thomas,3.315398,49.883146,,9,Rue du Bois Thomas,,2100
+20 Rue Heureuse Plomion,,,,20,Rue Heureuse,,2140
+20 Rue Heureuse 02140,,,,20,Rue Heureuse,Plomion,
+20 Rue Heureuse,4.03562,49.841641,,20,Rue Heureuse,,2140
+13 Rue des Fontaines Romery,,,,13,Rue des Fontaines,,2120
+13 Rue des Fontaines 02120,,,,13,Rue des Fontaines,Romery,
+13 Rue des Fontaines,3.726609,49.898339,,13,Rue des Fontaines,,2120
+21 Cité du Gen Leclerc Saint-Michel,,,,21,Cité du Gen Leclerc,,2830
+21 Cité du Gen Leclerc 02830,,,,21,Cité du Gen Leclerc,Saint-Michel,
+21 Cité du Gen Leclerc,4.139871,49.921938,,21,Cité du Gen Leclerc,,2830
+42 Rue de la Chaussée Romaine Saint-Quentin,,,,42,Rue de la Chaussée Romaine,,2100
+42 Rue de la Chaussée Romaine 02100,,,,42,Rue de la Chaussée Romaine,Saint-Quentin,
+42 Rue de la Chaussée Romaine,3.271552,49.846256,,42,Rue de la Chaussée Romaine,,2100
+7 Rue George Sand Saint-Quentin,,,,7,Rue George Sand,,2100
+7 Rue George Sand 02100,,,,7,Rue George Sand,Saint-Quentin,
+7 Rue George Sand,3.2755,49.838821,,7,Rue George Sand,,2100
+74 Rue de Lunéville Saint-Quentin,,,,74,Rue de Lunéville,,2100
+74 Rue de Lunéville 02100,,,,74,Rue de Lunéville,Saint-Quentin,
+74 Rue de Lunéville,3.296356,49.855525,,74,Rue de Lunéville,,2100
+12 Rue Roger Salengro Saint-Quentin,,,,12,Rue Roger Salengro,,2100
+12 Rue Roger Salengro 02100,,,,12,Rue Roger Salengro,Saint-Quentin,
+12 Rue Roger Salengro,3.278396,49.83866,,12,Rue Roger Salengro,,2100
+4 Sentier Derrière Les Jardins Septmonts,,,,4,Sentier Derrière Les Jardins,,2200
+4 Sentier Derrière Les Jardins 02200,,,,4,Sentier Derrière Les Jardins,Septmonts,
+4 Sentier Derrière Les Jardins,3.361645,49.332634,,4,Sentier Derrière Les Jardins,,2200
+13 Avenue Choron Soissons,,,,13,Avenue Choron,,2200
+13 Avenue Choron 02200,,,,13,Avenue Choron,Soissons,
+13 Avenue Choron,3.318307,49.386554,,13,Avenue Choron,,2200
+41 Rue de Vailly Soissons,,,,41,Rue de Vailly,,2200
+41 Rue de Vailly 02200,,,,41,Rue de Vailly,Soissons,
+41 Rue de Vailly,3.345489,49.390296,,41,Rue de Vailly,,2200
+2 Avenue Jean Rostand Tergnier,,,,2,Avenue Jean Rostand,,2700
+2 Avenue Jean Rostand 02700,,,,2,Avenue Jean Rostand,Tergnier,
+2 Avenue Jean Rostand,3.290371,49.657452,,2,Avenue Jean Rostand,,2700
+3 Petite Rue Petite Rue Saint-Vincent Vailly-sur-Aisne,,,,3,Petite Rue Petite Rue Saint-Vincent,,2370
+3 Petite Rue Petite Rue Saint-Vincent 02370,,,,3,Petite Rue Petite Rue Saint-Vincent,Vailly-sur-Aisne,
+3 Petite Rue Petite Rue Saint-Vincent,3.514706,49.410506,,3,Petite Rue Petite Rue Saint-Vincent,,2370
+4 Rue des Lisses Vervins,,,,4,Rue des Lisses,,2140
+4 Rue des Lisses 02140,,,,4,Rue des Lisses,Vervins,
+4 Rue des Lisses,3.904097,49.830958,,4,Rue des Lisses,,2140
+9 Rue Pasteur Villers-Cotterêts,,,,9,Rue Pasteur,,2600
+9 Rue Pasteur 02600,,,,9,Rue Pasteur,Villers-Cotterêts,
+9 Rue Pasteur,3.085251,49.25468,,9,Rue Pasteur,,2600
+3 Rue de la Paix Andeville,,,,3,Rue de la Paix,,60570
+3 Rue de la Paix 60570,,,,3,Rue de la Paix,Andeville,
+3 Rue de la Paix,2.163663,49.257087,,3,Rue de la Paix,,60570
+178 Allée des Pins Auneuil,,,,178,Allée des Pins,,60390
+178 Allée des Pins 60390,,,,178,Allée des Pins,Auneuil,
+178 Allée des Pins,1.991846,49.363783,,178,Allée des Pins,,60390
+434 Rue de la Clergerie Bargny,,,,434,Rue de la Clergerie,,60620
+434 Rue de la Clergerie 60620,,,,434,Rue de la Clergerie,Bargny,
+434 Rue de la Clergerie,2.958529,49.174537,,434,Rue de la Clergerie,,60620
+12 Rue Gay Lussac Beauvais,,,,12,Rue Gay Lussac,,60000
+12 Rue Gay Lussac 60000,,,,12,Rue Gay Lussac,Beauvais,
+12 Rue Gay Lussac,2.108064,49.409261,,12,Rue Gay Lussac,,60000
+99 Rue de Savignies Beauvais,,,,99,Rue de Savignies,,60000
+99 Rue de Savignies 60000,,,,99,Rue de Savignies,Beauvais,
+99 Rue de Savignies,2.05832,49.439276,,99,Rue de Savignies,,60000
+36 Rue Beauxis Lagrave Betz,,,,36,Rue Beauxis Lagrave,,60620
+36 Rue Beauxis Lagrave 60620,,,,36,Rue Beauxis Lagrave,Betz,
+36 Rue Beauxis Lagrave,2.962609,49.154069,,36,Rue Beauxis Lagrave,,60620
+16 Rue Robert Roussey Bouconvillers,,,,16,Rue Robert Roussey,,60240
+16 Rue Robert Roussey 60240,,,,16,Rue Robert Roussey,Bouconvillers,
+16 Rue Robert Roussey,1.903446,49.176166,,16,Rue Robert Roussey,,60240
+92 Rue de Picardie Brétigny,,,,92,Rue de Picardie,,60400
+92 Rue de Picardie 60400,,,,92,Rue de Picardie,Brétigny,
+92 Rue de Picardie,3.111538,49.566666,,92,Rue de Picardie,,60400
+213 Rue du Couvent Cambronne-lès-Clermont,,,,213,Rue du Couvent,,60290
+213 Rue du Couvent 60290,,,,213,Rue du Couvent,Cambronne-lès-Clermont,
+213 Rue du Couvent,2.414057,49.320418,,213,Rue du Couvent,,60290
+262 Rue d'Acate Chambly,,,,262,Rue d'Acate,,60230
+262 Rue d'Acate 60230,,,,262,Rue d'Acate,Chambly,
+262 Rue d'Acate,2.240369,49.171935,,262,Rue d'Acate,,60230
+8 Impasse du Château Chaumont-en-Vexin,,,,8,Impasse du Château,,60240
+8 Impasse du Château 60240,,,,8,Impasse du Château,Chaumont-en-Vexin,
+8 Impasse du Château,1.874027,49.265112,,8,Impasse du Château,,60240
+16 Rue de la Mairie Cires-lès-Mello,,,,16,Rue de la Mairie,,60660
+16 Rue de la Mairie 60660,,,,16,Rue de la Mairie,Cires-lès-Mello,
+16 Rue de la Mairie,2.358563,49.275059,,16,Rue de la Mairie,,60660
+3 Place du Change Compiègne,,,,3,Place du Change,,60200
+3 Place du Change 60200,,,,3,Place du Change,Compiègne,
+3 Place du Change,2.824334,49.416662,,3,Place du Change,,60200
+27 Square du 6e Spahis Compiègne,,,,27,Square du 6e Spahis,,60200
+27 Square du 6e Spahis 60200,,,,27,Square du 6e Spahis,Compiègne,
+27 Square du 6e Spahis,2.841704,49.42298,,27,Square du 6e Spahis,,60200
+69 Rue Gambetta Creil,,,,69,Rue Gambetta,,60100
+69 Rue Gambetta 60100,,,,69,Rue Gambetta,Creil,
+69 Rue Gambetta,2.473543,49.265148,,69,Rue Gambetta,,60100
+42 Avenue de Senlis Crépy-en-Valois,,,,42,Avenue de Senlis,,60800
+42 Avenue de Senlis 60800,,,,42,Avenue de Senlis,Crépy-en-Valois,
+42 Avenue de Senlis,2.874676,49.23258,,42,Avenue de Senlis,,60800
+100BIS Rue du Bos Delincourt,,,,100BIS,Rue du Bos,,60240
+100BIS Rue du Bos 60240,,,,100BIS,Rue du Bos,Delincourt,
+100BIS Rue du Bos,1.833112,49.238679,,100BIS,Rue du Bos,,60240
+149 Avenue de Flandres Estrées-Saint-Denis,,,,149,Avenue de Flandres,,60190
+149 Avenue de Flandres 60190,,,,149,Avenue de Flandres,Estrées-Saint-Denis,
+149 Avenue de Flandres,2.640098,49.430558,,149,Avenue de Flandres,,60190
+311 Rue de Calais Fontaine-Saint-Lucien,,,,311,Rue de Calais,,60480
+311 Rue de Calais 60480,,,,311,Rue de Calais,Fontaine-Saint-Lucien,
+311 Rue de Calais,2.147425,49.499141,,311,Rue de Calais,,60480
+172 Rue de Massival Gilocourt,,,,172,Rue de Massival,,60129
+172 Rue de Massival 60129,,,,172,Rue de Massival,Gilocourt,
+172 Rue de Massival,2.890232,49.289512,,172,Rue de Massival,,60129
+21 Rue d'Amiens Grandvilliers,,,,21,Rue d'Amiens,,60210
+21 Rue d'Amiens 60210,,,,21,Rue d'Amiens,Grandvilliers,
+21 Rue d'Amiens,1.94186,49.665801,,21,Rue d'Amiens,,60210
+9 Rue de la Forêt Hermes,,,,9,Rue de la Forêt,,60370
+9 Rue de la Forêt 60370,,,,9,Rue de la Forêt,Hermes,
+9 Rue de la Forêt,2.246185,49.367279,,9,Rue de la Forêt,,60370
+6 Rue des Sources Lachapelle-aux-Pots,,,,6,Rue des Sources,,60650
+6 Rue des Sources 60650,,,,6,Rue des Sources,Lachapelle-aux-Pots,
+6 Rue des Sources,1.929924,49.449737,,6,Rue des Sources,,60650
+2 Rue Principale Lalandelle,,,,2,Rue Principale,,60850
+2 Rue Principale 60850,,,,2,Rue Principale,Lalandelle,
+2 Rue Principale,1.87398,49.40001,,2,Rue Principale,,60850
+159 Rue de l'Abattoir Liancourt,,,,159,Rue de l'Abattoir,,60140
+159 Rue de l'Abattoir 60140,,,,159,Rue de l'Abattoir,Liancourt,
+159 Rue de l'Abattoir,2.457045,49.327998,,159,Rue de l'Abattoir,,60140
+5 Rue du Pont du Matz Machemont,,,,5,Rue du Pont du Matz,,60150
+5 Rue du Pont du Matz 60150,,,,5,Rue du Pont du Matz,Machemont,
+5 Rue du Pont du Matz,2.883644,49.488752,,5,Rue du Pont du Matz,,60150
+162 Rue de Ressons Marquéglise,,,,162,Rue de Ressons,,60490
+162 Rue de Ressons 60490,,,,162,Rue de Ressons,Marquéglise,
+162 Rue de Ressons,2.762482,49.51837,,162,Rue de Ressons,,60490
+15 Allée des Pervenches Le Mesnil-en-Thelle,,,,15,Allée des Pervenches,,60530
+15 Allée des Pervenches 60530,,,,15,Allée des Pervenches,Le Mesnil-en-Thelle,
+15 Allée des Pervenches,2.283826,49.180586,,15,Allée des Pervenches,,60530
+48 Rue Porte de Baron Montagny-Sainte-Félicité,,,,48,Rue Porte de Baron,,60950
+48 Rue Porte de Baron 60950,,,,48,Rue Porte de Baron,Montagny-Sainte-Félicité,
+48 Rue Porte de Baron,2.739514,49.132574,,48,Rue Porte de Baron,,60950
+4 Rue des Vignes Mortefontaine,,,,4,Rue des Vignes,,60128
+4 Rue des Vignes 60128,,,,4,Rue des Vignes,Mortefontaine,
+4 Rue des Vignes,2.597408,49.114145,,4,Rue des Vignes,,60128
+11 Impasse d'Ormeteau Neuilly-en-Thelle,,,,11,Impasse d'Ormeteau,,60530
+11 Impasse d'Ormeteau 60530,,,,11,Impasse d'Ormeteau,Neuilly-en-Thelle,
+11 Impasse d'Ormeteau,2.281941,49.228247,,11,Impasse d'Ormeteau,,60530
+7 Allée Georges Bizet Nogent-sur-Oise,,,,7,Allée Georges Bizet,,60180
+7 Allée Georges Bizet 60180,,,,7,Allée Georges Bizet,Nogent-sur-Oise,
+7 Allée Georges Bizet,2.459467,49.270311,,7,Allée Georges Bizet,,60180
+52 Rue de Lille Noyon,,,,52,Rue de Lille,,60400
+52 Rue de Lille 60400,,,,52,Rue de Lille,Noyon,
+52 Rue de Lille,3.00243,49.584211,,52,Rue de Lille,,60400
+1 Rue Triolet Péroy-les-Gombries,,,,1,Rue Triolet,,60440
+1 Rue Triolet 60440,,,,1,Rue Triolet,Péroy-les-Gombries,
+1 Rue Triolet,2.848159,49.162912,,1,Rue Triolet,,60440
+338 Rue Basse Pontpoint,,,,338,Rue Basse,,60700
+338 Rue Basse 60700,,,,338,Rue Basse,Pontpoint,
+338 Rue Basse,2.639452,49.302614,,338,Rue Basse,,60700
+11 Rue Principale Prévillers,,,,11,Rue Principale,,60360
+11 Rue Principale 60360,,,,11,Rue Principale,Prévillers,
+11 Rue Principale,1.996165,49.609573,,11,Rue Principale,,60360
+136 Rue de la Fertière Ribécourt-Dreslincourt,,,,136,Rue de la Fertière,,60170
+136 Rue de la Fertière 60170,,,,136,Rue de la Fertière,Ribécourt-Dreslincourt,
+136 Rue de la Fertière,2.920746,49.516935,,136,Rue de la Fertière,,60170
+3 Rue de la Motte Sacy-le-Petit,,,,3,Rue de la Motte,,60190
+3 Rue de la Motte 60190,,,,3,Rue de la Motte,Sacy-le-Petit,
+3 Rue de la Motte,2.630412,49.361633,,3,Rue de la Motte,,60190
+19 Rue du Général de Gaulle Saint-Just-en-Chaussée,,,,19,Rue du Général de Gaulle,,60130
+19 Rue du Général de Gaulle 60130,,,,19,Rue du Général de Gaulle,Saint-Just-en-Chaussée,
+19 Rue du Général de Gaulle,2.424132,49.504402,,19,Rue du Général de Gaulle,,60130
+5 Rue de la Faïencerie Saint-Paul,,,,5,Rue de la Faïencerie,,60650
+5 Rue de la Faïencerie 60650,,,,5,Rue de la Faïencerie,Saint-Paul,
+5 Rue de la Faïencerie,2.007764,49.430673,,5,Rue de la Faïencerie,,60650
+9 Rue du Clos de la Chatelaine Senlis,,,,9,Rue du Clos de la Chatelaine,,60300
+9 Rue du Clos de la Chatelaine 60300,,,,9,Rue du Clos de la Chatelaine,Senlis,
+9 Rue du Clos de la Chatelaine,2.573152,49.201123,,9,Rue du Clos de la Chatelaine,,60300
+90 Rue de Montdidier Suzoy,,,,90,Rue de Montdidier,,60400
+90 Rue de Montdidier 60400,,,,90,Rue de Montdidier,Suzoy,
+90 Rue de Montdidier,2.947591,49.580856,,90,Rue de Montdidier,,60400
+5A Rue du Point du Jour Tracy-le-Mont,,,,5A,Rue du Point du Jour,,60170
+5A Rue du Point du Jour 60170,,,,5A,Rue du Point du Jour,Tracy-le-Mont,
+5A Rue du Point du Jour,3.006271,49.467697,,5A,Rue du Point du Jour,,60170
+14 Chemin des Côtes Le Vaumain,,,,14,Chemin des Côtes,,60590
+14 Chemin des Côtes 60590,,,,14,Chemin des Côtes,Le Vaumain,
+14 Chemin des Côtes,1.860397,49.3491,,14,Chemin des Côtes,,60590
+20 Rue de la Vallee Sainte-Genevieve Verneuil-en-Halatte,,,,20,Rue de la Vallee Sainte-Genevieve,,60550
+20 Rue de la Vallee Sainte-Genevieve 60550,,,,20,Rue de la Vallee Sainte-Genevieve,Verneuil-en-Halatte,
+20 Rue de la Vallee Sainte-Genevieve,2.526466,49.274395,,20,Rue de la Vallee Sainte-Genevieve,,60550
+10 Rue de la Gare Villers-sur-Coudun,,,,10,Rue de la Gare,,60150
+10 Rue de la Gare 60150,,,,10,Rue de la Gare,Villers-sur-Coudun,
+10 Rue de la Gare,2.796574,49.48022,,10,Rue de la Gare,,60150
+7 Rue Mautort Abbeville,,,,7,Rue Mautort,,80100
+7 Rue Mautort 80100,,,,7,Rue Mautort,Abbeville,
+7 Rue Mautort,1.796008,50.105115,,7,Rue Mautort,,80100
+7 Avenue de Flandres Ailly-sur-Noye,,,,7,Avenue de Flandres,,80250
+7 Avenue de Flandres 80250,,,,7,Avenue de Flandres,Ailly-sur-Noye,
+7 Avenue de Flandres,2.371491,49.756589,,7,Avenue de Flandres,,80250
+103 Rue Jean Jaurès Albert,,,,103,Rue Jean Jaurès,,80300
+103 Rue Jean Jaurès 80300,,,,103,Rue Jean Jaurès,Albert,
+103 Rue Jean Jaurès,2.649792,49.996853,,103,Rue Jean Jaurès,,80300
+16 Rue Auguste Renoir Amiens,,,,16,Rue Auguste Renoir,,80000
+16 Rue Auguste Renoir 80000,,,,16,Rue Auguste Renoir,Amiens,
+16 Rue Auguste Renoir,2.299846,49.914432,,16,Rue Auguste Renoir,,80000
+45 Rue du Comte Raoul Amiens,,,,45,Rue du Comte Raoul,,80000
+45 Rue du Comte Raoul 80000,,,,45,Rue du Comte Raoul,Amiens,
+45 Rue du Comte Raoul,2.315133,49.884827,,45,Rue du Comte Raoul,,80000
+32 Boulevard des Fédérés Amiens,,,,32,Boulevard des Fédérés,,80000
+32 Boulevard des Fédérés 80000,,,,32,Boulevard des Fédérés,Amiens,
+32 Boulevard des Fédérés,2.283949,49.894936,,32,Boulevard des Fédérés,,80000
+207 Chaussée Jules Ferry Amiens,,,,207,Chaussée Jules Ferry,,80000
+207 Chaussée Jules Ferry 80000,,,,207,Chaussée Jules Ferry,Amiens,
+207 Chaussée Jules Ferry,2.330111,49.881449,,207,Chaussée Jules Ferry,,80000
+15 Rue Neuve-Dejean Amiens,,,,15,Rue Neuve-Dejean,,80000
+15 Rue Neuve-Dejean 80000,,,,15,Rue Neuve-Dejean,Amiens,
+15 Rue Neuve-Dejean,2.317871,49.891452,,15,Rue Neuve-Dejean,,80000
+21 Rue Sagebien Amiens,,,,21,Rue Sagebien,,80000
+21 Rue Sagebien 80000,,,,21,Rue Sagebien,Amiens,
+21 Rue Sagebien,2.290934,49.879121,,21,Rue Sagebien,,80000
+18 Rue Watteau Amiens,,,,18,Rue Watteau,,80000
+18 Rue Watteau 80000,,,,18,Rue Watteau,Amiens,
+18 Rue Watteau,2.299377,49.913924,,18,Rue Watteau,,80000
+46 Rue du Général Leclerc Beauval,,,,46,Rue du Général Leclerc,,80630
+46 Rue du Général Leclerc 80630,,,,46,Rue du Général Leclerc,Beauval,
+46 Rue du Général Leclerc,2.329654,50.106097,,46,Rue du Général Leclerc,,80630
+40 Rue Alphonse Tellier Boves,,,,40,Rue Alphonse Tellier,,80440
+40 Rue Alphonse Tellier 80440,,,,40,Rue Alphonse Tellier,Boves,
+40 Rue Alphonse Tellier,2.383901,49.842418,,40,Rue Alphonse Tellier,,80440
+7 Rue Marie Curie Camon,,,,7,Rue Marie Curie,,80450
+7 Rue Marie Curie 80450,,,,7,Rue Marie Curie,Camon,
+7 Rue Marie Curie,2.336398,49.895592,,7,Rue Marie Curie,,80450
+364 Hurt Cayeux-sur-Mer,,,,364,Hurt,,80410
+364 Hurt 80410,,,,364,Hurt,Cayeux-sur-Mer,
+364 Hurt,1.523273,50.172369,,364,Hurt,,80410
+2 Rue de Coulonvillers Cramont,,,,2,Rue de Coulonvillers,,80370
+2 Rue de Coulonvillers 80370,,,,2,Rue de Coulonvillers,Cramont,
+2 Rue de Coulonvillers,2.05185,50.147018,,2,Rue de Coulonvillers,,80370
+30 Rue du Bourg Doullens,,,,30,Rue du Bourg,,80600
+30 Rue du Bourg 80600,,,,30,Rue du Bourg,Doullens,
+30 Rue du Bourg,2.340888,50.15529,,30,Rue du Bourg,,80600
+1 Lotissement des Jardins Eppeville,,,,1,Lotissement des Jardins,,80400
+1 Lotissement des Jardins 80400,,,,1,Lotissement des Jardins,Eppeville,
+1 Lotissement des Jardins,3.064184,49.741836,,1,Lotissement des Jardins,,80400
+13 Rue d'en Bas Foucaucourt-Hors-Nesle,,,,13,Rue d'en Bas,,80140
+13 Rue d'en Bas 80140,,,,13,Rue d'en Bas,Foucaucourt-Hors-Nesle,
+13 Rue d'en Bas,1.725727,49.917335,,13,Rue d'en Bas,,80140
+15 Rue des Rainvillers Hallencourt,,,,15,Rue des Rainvillers,,80490
+15 Rue des Rainvillers 80490,,,,15,Rue des Rainvillers,Hallencourt,
+15 Rue des Rainvillers,1.874789,49.988574,,15,Rue des Rainvillers,,80490
+1 Rue de Bezencourt Hornoy-le-Bourg,,,,1,Rue de Bezencourt,,80640
+1 Rue de Bezencourt 80640,,,,1,Rue de Bezencourt,Hornoy-le-Bourg,
+1 Rue de Bezencourt,1.864063,49.827968,,1,Rue de Bezencourt,,80640
+24 Rue Gérard Philipe Longueau,,,,24,Rue Gérard Philipe,,80330
+24 Rue Gérard Philipe 80330,,,,24,Rue Gérard Philipe,Longueau,
+24 Rue Gérard Philipe,2.36202,49.871947,,24,Rue Gérard Philipe,,80330
+5 Rue du Bordet Miraumont,,,,5,Rue du Bordet,,80300
+5 Rue du Bordet 80300,,,,5,Rue du Bordet,Miraumont,
+5 Rue du Bordet,2.72632,50.092582,,5,Rue du Bordet,,80300
+8 Place Verte Oisemont,,,,8,Place Verte,,80140
+8 Place Verte 80140,,,,8,Place Verte,Oisemont,
+8 Place Verte,1.771397,49.955438,,8,Place Verte,,80140
+3BIS Rue Festonval Pierregot,,,,3BIS,Rue Festonval,,80260
+3BIS Rue Festonval 80260,,,,3BIS,Rue Festonval,Pierregot,
+3BIS Rue Festonval,2.379097,50.002176,,3BIS,Rue Festonval,,80260
+11 Rue de la 2E Division Blindée Le Quesne,,,,11,Rue de la 2E Division Blindée,,80430
+11 Rue de la 2E Division Blindée 80430,,,,11,Rue de la 2E Division Blindée,Le Quesne,
+11 Rue de la 2E Division Blindée,1.790083,49.853216,,11,Rue de la 2E Division Blindée,,80430
+3TER Rue Pasteur Roye,,,,3TER,Rue Pasteur,,80700
+3TER Rue Pasteur 80700,,,,3TER,Rue Pasteur,Roye,
+3TER Rue Pasteur,2.791594,49.697424,,3TER,Rue Pasteur,,80700
+20 Rue d'en Haut Saint-Léger-lès-Domart,,,,20,Rue d'en Haut,,80780
+20 Rue d'en Haut 80780,,,,20,Rue d'en Haut,Saint-Léger-lès-Domart,
+20 Rue d'en Haut,2.142348,50.055549,,20,Rue d'en Haut,,80780
+137 Rue Jean Catelas Saleux,,,,137,Rue Jean Catelas,,80480
+137 Rue Jean Catelas 80480,,,,137,Rue Jean Catelas,Saleux,
+137 Rue Jean Catelas,2.23753,49.857428,,137,Rue Jean Catelas,,80480
+12 Rue de Bas Vaudricourt,,,,12,Rue de Bas,,80230
+12 Rue de Bas 80230,,,,12,Rue de Bas,Vaudricourt,
+12 Rue de Bas,1.553176,50.120772,,12,Rue de Bas,,80230
+38 Route de Callenges Vron,,,,38,Route de Callenges,,80120
+38 Route de Callenges 80120,,,,38,Route de Callenges,Vron,
+38 Route de Callenges,1.759335,50.309294,,38,Route de Callenges,,80120

--- a/geocoder_tester/world/france/provencealpescotedazur/test_addresses.csv
+++ b/geocoder_tester/world/france/provencealpescotedazur/test_addresses.csv
@@ -1,436 +1,436 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-30 Rue des Chapeliers Digne-les-Bains,,,,30 Rue des Chapeliers,,,,04000
-30 Rue des Chapeliers 04000,,,,30 Rue des Chapeliers,,,Digne-les-Bains,
-30 Rue des Chapeliers,6.236155,44.091569,,30 Rue des Chapeliers,,,,04000
-933 Route d'Apt Manosque,,,,933 Route d'Apt,,,,04100
-933 Route d'Apt 04100,,,,933 Route d'Apt,,,Manosque,
-933 Route d'Apt,5.757922,43.831939,,933 Route d'Apt,,,,04100
-13 Rue Alphonse Rolland Oraison,,,,13 Rue Alphonse Rolland,,,,04700
-13 Rue Alphonse Rolland 04700,,,,13 Rue Alphonse Rolland,,,Oraison,
-13 Rue Alphonse Rolland,5.918742,43.918616,,13 Rue Alphonse Rolland,,,,04700
-13 Rue de la Plaine Sainte-Tulle,,,,13 Rue de la Plaine,,,,04220
-13 Rue de la Plaine 04220,,,,13 Rue de la Plaine,,,Sainte-Tulle,
-13 Rue de la Plaine,5.761650,43.785843,,13 Rue de la Plaine,,,,04220
-17 Chemin du Clauzon Gap,,,,17 Chemin du Clauzon,,,,05000
-17 Chemin du Clauzon 05000,,,,17 Chemin du Clauzon,,,Gap,
-17 Chemin du Clauzon,6.107486,44.585189,,17 Chemin du Clauzon,,,,05000
-23 Rue de la Mairie Le Monêtier-les-Bains,,,,23 Rue de la Mairie,,,,05220
-23 Rue de la Mairie 05220,,,,23 Rue de la Mairie,,,Le Monêtier-les-Bains,
-23 Rue de la Mairie,6.508099,44.976243,,23 Rue de la Mairie,,,,05220
-15 Rue Lacan Antibes,,,,15 Rue Lacan,,,,06600
-15 Rue Lacan 06600,,,,15 Rue Lacan,,,Antibes,
-15 Rue Lacan,7.123838,43.582773,,15 Rue Lacan,,,,06600
-11 Chemin du Bois Aspremont,,,,11 Chemin du Bois,,,,06790
-11 Chemin du Bois 06790,,,,11 Chemin du Bois,,,Aspremont,
-11 Chemin du Bois,7.250749,43.786604,,11 Chemin du Bois,,,,06790
-730 Route des Escaillouns Berre-les-Alpes,,,,730 Route des Escaillouns,,,,06390
-730 Route des Escaillouns 06390,,,,730 Route des Escaillouns,,,Berre-les-Alpes,
-730 Route des Escaillouns,7.336633,43.829037,,730 Route des Escaillouns,,,,06390
-582 Promenade Saint-Jean Cabris,,,,582 Promenade Saint-Jean,,,,06530
-582 Promenade Saint-Jean 06530,,,,582 Promenade Saint-Jean,,,Cabris,
-582 Promenade Saint-Jean,6.866844,43.657046,,582 Promenade Saint-Jean,,,,06530
-2665 Route de la Plaine de Caille Caille,,,,2665 Route de la Plaine de Caille,,,,06750
-2665 Route de la Plaine de Caille 06750,,,,2665 Route de la Plaine de Caille,,,Caille,
-2665 Route de la Plaine de Caille,6.760316,43.781557,,2665 Route de la Plaine de Caille,,,,06750
-5 Boulevard Lord Brougham Cannes,,,,5 Boulevard Lord Brougham,,,,06150
-5 Boulevard Lord Brougham 06150,,,,5 Boulevard Lord Brougham,,,Cannes,
-5 Boulevard Lord Brougham,7.003226,43.556886,,5 Boulevard Lord Brougham,,,,06150
-16 Rue du Canal Le Cannet,,,,16 Rue du Canal,,,,06110
-16 Rue du Canal 06110,,,,16 Rue du Canal,,,Le Cannet,
-16 Rue du Canal,7.029540,43.570909,,16 Rue du Canal,,,,06110
-14 Avenue des Cigales Carros,,,,14 Avenue des Cigales,,,,06510
-14 Avenue des Cigales 06510,,,,14 Avenue des Cigales,,,Carros,
-14 Avenue des Cigales,7.191315,43.770882,,14 Avenue des Cigales,,,,06510
-822 Route du Plan de Linéa Coaraze,,,,822 Route du Plan de Linéa,,,,06390
-822 Route du Plan de Linéa 06390,,,,822 Route du Plan de Linéa,,,Coaraze,
-822 Route du Plan de Linéa,7.299132,43.858760,,822 Route du Plan de Linéa,,,,06390
-2 Rue du Murier Cuébris,,,,2 Rue du Murier,,,,06910
-2 Rue du Murier 06910,,,,2 Rue du Murier,,,Cuébris,
-2 Rue du Murier,7.018922,43.886951,,2 Rue du Murier,,,,06910
-190 Cours de la Colle de Rouge N88 La Gaude,,,,190 Cours de la Colle de Rouge N88,,,,06610
-190 Cours de la Colle de Rouge N88 06610,,,,190 Cours de la Colle de Rouge N88,,,La Gaude,
-190 Cours de la Colle de Rouge N88,7.155574,43.705968,,190 Cours de la Colle de Rouge N88,,,,06610
-22 Boulevard Jacques Crouet Grasse,,,,22 Boulevard Jacques Crouet,,,,06520
-22 Boulevard Jacques Crouet 06520,,,,22 Boulevard Jacques Crouet,,,Grasse,
-22 Boulevard Jacques Crouet,6.925281,43.656798,,22 Boulevard Jacques Crouet,,,,06520
-1 Rue du Portal Levens,,,,1 Rue du Portal,,,,06670
-1 Rue du Portal 06670,,,,1 Rue du Portal,,,Levens,
-1 Rue du Portal,7.225881,43.859565,,1 Rue du Portal,,,,06670
-1570 Route des Ciappes de Castellar Menton,,,,1570 Route des Ciappes de Castellar,,,,06500
-1570 Route des Ciappes de Castellar 06500,,,,1570 Route des Ciappes de Castellar,,,Menton,
-1570 Route des Ciappes de Castellar,7.500395,43.783476,,1570 Route des Ciappes de Castellar,,,,06500
-993 Chemin de la Sénéquière Mouans-Sartoux,,,,993 Chemin de la Sénéquière,,,,06370
-993 Chemin de la Sénéquière 06370,,,,993 Chemin de la Sénéquière,,,Mouans-Sartoux,
-993 Chemin de la Sénéquière,6.968666,43.630803,,993 Chemin de la Sénéquière,,,,06370
-8 Rue de Gubert Moulinet,,,,8 Rue de Gubert,,,,06380
-8 Rue de Gubert 06380,,,,8 Rue de Gubert,,,Moulinet,
-8 Rue de Gubert,7.412802,43.941339,,8 Rue de Gubert,,,,06380
-213 Route de Colomars Nice,,,,213 Route de Colomars,,,,06300
-213 Route de Colomars 06300,,,,213 Route de Colomars,,,Nice,
-213 Route de Colomars,7.205110,43.754519,,213 Route de Colomars,,,,06300
-28 Rue de l'Hôtel des Postes Nice,,,,28 Rue de l'Hôtel des Postes,,,,06300
-28 Rue de l'Hôtel des Postes 06300,,,,28 Rue de l'Hôtel des Postes,,,Nice,
-28 Rue de l'Hôtel des Postes,7.271473,43.699629,,28 Rue de l'Hôtel des Postes,,,,06300
-39 Rue Paul Déroulède Nice,,,,39 Rue Paul Déroulède,,,,06300
-39 Rue Paul Déroulède 06300,,,,39 Rue Paul Déroulède,,,Nice,
-39 Rue Paul Déroulède,7.263094,43.700708,,39 Rue Paul Déroulède,,,,06300
-16 Chemin de la Vignette Nice,,,,16 Chemin de la Vignette,,,,06300
-16 Chemin de la Vignette 06300,,,,16 Chemin de la Vignette,,,Nice,
-16 Chemin de la Vignette,7.208998,43.719120,,16 Chemin de la Vignette,,,,06300
-14 Chemin de la Frayère Peymeinade,,,,14 Chemin de la Frayère,,,,06530
-14 Chemin de la Frayère 06530,,,,14 Chemin de la Frayère,,,Peymeinade,
-14 Chemin de la Frayère,6.882741,43.641830,,14 Chemin de la Frayère,,,,06530
-235 Chemin du Tramway Roquefort-les-Pins,,,,235 Chemin du Tramway,,,,06330
-235 Chemin du Tramway 06330,,,,235 Chemin du Tramway,,,Roquefort-les-Pins,
-235 Chemin du Tramway,7.063445,43.660163,,235 Chemin du Tramway,,,,06330
-460 Chemin Departemental 13 Rte de Grasse Saint-Cézaire-sur-Siagne,,,,460 Chemin Departemental 13 Rte de Grasse,,,,06530
-460 Chemin Departemental 13 Rte de Grasse 06530,,,,460 Chemin Departemental 13 Rte de Grasse,,,Saint-Cézaire-sur-Siagne,
-460 Chemin Departemental 13 Rte de Grasse,6.804939,43.647248,,460 Chemin Departemental 13 Rte de Grasse,,,,06530
-194 Chemin des Romarins Saint-Laurent-du-Var,,,,194 Chemin des Romarins,,,,06700
-194 Chemin des Romarins 06700,,,,194 Chemin des Romarins,,,Saint-Laurent-du-Var,
-194 Chemin des Romarins,7.180512,43.664602,,194 Chemin des Romarins,,,,06700
-11 Rue des Voutes Sospel,,,,11 Rue des Voutes,,,,06380
-11 Rue des Voutes 06380,,,,11 Rue des Voutes,,,Sospel,
-11 Rue des Voutes,7.448558,43.876872,,11 Rue des Voutes,,,,06380
-399 Route de Pierascas Tourrettes-sur-Loup,,,,399 Route de Pierascas,,,,06140
-399 Route de Pierascas 06140,,,,399 Route de Pierascas,,,Tourrettes-sur-Loup,
-399 Route de Pierascas,7.072880,43.711277,,399 Route de Pierascas,,,,06140
-75 Boulevard du Cap Vallauris,,,,75 Boulevard du Cap,,,,06220
-75 Boulevard du Cap 06220,,,,75 Boulevard du Cap,,,Vallauris,
-75 Boulevard du Cap,7.060118,43.570042,,75 Boulevard du Cap,,,,06220
-36 Avenue des Pins Vence,,,,36 Avenue des Pins,,,,06140
-36 Avenue des Pins 06140,,,,36 Avenue des Pins,,,Vence,
-36 Avenue des Pins,7.105532,43.718743,,36 Avenue des Pins,,,,06140
-8 Allée de la Tour de la Madone Villeneuve-Loubet,,,,8 Allée de la Tour de la Madone,,,,06270
-8 Allée de la Tour de la Madone 06270,,,,8 Allée de la Tour de la Madone,,,Villeneuve-Loubet,
-8 Allée de la Tour de la Madone,7.113288,43.634314,,8 Allée de la Tour de la Madone,,,,06270
-1 Avenue des Infirmeries Aix-en-Provence,,,,1 Avenue des Infirmeries,,,,13090
-1 Avenue des Infirmeries 13090,,,,1 Avenue des Infirmeries,,,Aix-en-Provence,
-1 Avenue des Infirmeries,5.462783,43.516233,,1 Avenue des Infirmeries,,,,13090
-11 Cours Sextius Aix-en-Provence,,,,11 Cours Sextius,,,,13090
-11 Cours Sextius 13090,,,,11 Cours Sextius,,,Aix-en-Provence,
-11 Cours Sextius,5.443837,43.528339,,11 Cours Sextius,,,,13090
-16 Lotissement Notre-Dame des Anges Allauch,,,,16 Lotissement Notre-Dame des Anges,,,,13190
-16 Lotissement Notre-Dame des Anges 13190,,,,16 Lotissement Notre-Dame des Anges,,,Allauch,
-16 Lotissement Notre-Dame des Anges,5.484550,43.363311,,16 Lotissement Notre-Dame des Anges,,,,13190
-20 Rue Delfo Novi Arles,,,,20 Rue Delfo Novi,,,,13104
-20 Rue Delfo Novi 13104,,,,20 Rue Delfo Novi,,,Arles,
-20 Rue Delfo Novi,4.617719,43.664400,,20 Rue Delfo Novi,,,,13104
-2 Rue Jacquemin Arles,,,,2 Rue Jacquemin,,,,13104
-2 Rue Jacquemin 13104,,,,2 Rue Jacquemin,,,Arles,
-2 Rue Jacquemin,4.631506,43.673112,,2 Rue Jacquemin,,,,13104
-2 Rue Portagnel Arles,,,,2 Rue Portagnel,,,,13104
-2 Rue Portagnel 13104,,,,2 Rue Portagnel,,,Arles,
-2 Rue Portagnel,4.631362,43.679640,,2 Rue Portagnel,,,,13104
-100 Chemin de l'Aumône Vieille Aubagne,,,,100 Chemin de l'Aumône Vieille,,,,13400
-100 Chemin de l'Aumône Vieille 13400,,,,100 Chemin de l'Aumône Vieille,,,Aubagne,
-100 Chemin de l'Aumône Vieille,5.529703,43.286451,,100 Chemin de l'Aumône Vieille,,,,13400
-129 Rue du Vallat Aubagne,,,,129 Rue du Vallat,,,,13400
-129 Rue du Vallat 13400,,,,129 Rue du Vallat,,,Aubagne,
-129 Rue du Vallat,5.598012,43.290970,,129 Rue du Vallat,,,,13400
-7 Chemin de Magne La Bouilladisse,,,,7 Chemin de Magne,,,,13720
-7 Chemin de Magne 13720,,,,7 Chemin de Magne,,,La Bouilladisse,
-7 Chemin de Magne,5.593794,43.393574,,7 Chemin de Magne,,,,13720
-19 Chemin du Plan Capelan Carry-le-Rouet,,,,19 Chemin du Plan Capelan,,,,13620
-19 Chemin du Plan Capelan 13620,,,,19 Chemin du Plan Capelan,,,Carry-le-Rouet,
-19 Chemin du Plan Capelan,5.141116,43.335699,,19 Chemin du Plan Capelan,,,,13620
-33 Rue Claude Debussy Châteaurenard,,,,33 Rue Claude Debussy,,,,13160
-33 Rue Claude Debussy 13160,,,,33 Rue Claude Debussy,,,Châteaurenard,
-33 Rue Claude Debussy,4.851979,43.874230,,33 Rue Claude Debussy,,,,13160
-18 Rue Henri Diffonty La Ciotat,,,,18 Rue Henri Diffonty,,,,13600
-18 Rue Henri Diffonty 13600,,,,18 Rue Henri Diffonty,,,La Ciotat,
-18 Rue Henri Diffonty,5.609487,43.175723,,18 Rue Henri Diffonty,,,,13600
-1 Impasse des Mésanges Ensuès-la-Redonne,,,,1 Impasse des Mésanges,,,,13820
-1 Impasse des Mésanges 13820,,,,1 Impasse des Mésanges,,,Ensuès-la-Redonne,
-1 Impasse des Mésanges,5.212512,43.352148,,1 Impasse des Mésanges,,,,13820
-31 Rue du Puits de Passet Fontvieille,,,,31 Rue du Puits de Passet,,,,13990
-31 Rue du Puits de Passet 13990,,,,31 Rue du Puits de Passet,,,Fontvieille,
-31 Rue du Puits de Passet,4.710541,43.726877,,31 Rue du Puits de Passet,,,,13990
-6 Rue Mignet Gardanne,,,,6 Rue Mignet,,,,13120
-6 Rue Mignet 13120,,,,6 Rue Mignet,,,Gardanne,
-6 Rue Mignet,5.472036,43.455234,,6 Rue Mignet,,,,13120
-4 Impasse de la Lavande Gréasque,,,,4 Impasse de la Lavande,,,,13850
-4 Impasse de la Lavande 13850,,,,4 Impasse de la Lavande,,,Gréasque,
-4 Impasse de la Lavande,5.533649,43.436009,,4 Impasse de la Lavande,,,,13850
-25 Lotissement La Palun Istres,,,,25 Lotissement La Palun,,,,13800
-25 Lotissement La Palun 13800,,,,25 Lotissement La Palun,,,Istres,
-25 Lotissement La Palun,4.976047,43.506638,,25 Lotissement La Palun,,,,13800
-32 Lotissement Les Restanques Mallemort,,,,32 Lotissement Les Restanques,,,,13370
-32 Lotissement Les Restanques 13370,,,,32 Lotissement Les Restanques,,,Mallemort,
-32 Lotissement Les Restanques,5.183941,43.727544,,32 Lotissement Les Restanques,,,,13370
-21 Rue Galinière Martigues,,,,21 Rue Galinière,,,,13500
-21 Rue Galinière 13500,,,,21 Rue Galinière,,,Martigues,
-21 Rue Galinière,5.055315,43.406165,,21 Rue Galinière,,,,13500
-3 Rue de la Bourride Miramas,,,,3 Rue de la Bourride,,,,13140
-3 Rue de la Bourride 13140,,,,3 Rue de la Bourride,,,Miramas,
-3 Rue de la Bourride,5.001276,43.572373,,3 Rue de la Bourride,,,,13140
-6503 Chemin de l'Eau Noves,,,,6503 Chemin de l'Eau,,,,13550
-6503 Chemin de l'Eau 13550,,,,6503 Chemin de l'Eau,,,Noves,
-6503 Chemin de l'Eau,4.900729,43.872602,,6503 Chemin de l'Eau,,,,13550
-48 Avenue de la Gardiette Les Pennes-Mirabeau,,,,48 Avenue de la Gardiette,,,,13170
-48 Avenue de la Gardiette 13170,,,,48 Avenue de la Gardiette,,,Les Pennes-Mirabeau,
-48 Avenue de la Gardiette,5.338169,43.419697,,48 Avenue de la Gardiette,,,,13170
-6 Boulevard Victor Hugo Plan-de-Cuques,,,,6 Boulevard Victor Hugo,,,,13380
-6 Boulevard Victor Hugo 13380,,,,6 Boulevard Victor Hugo,,,Plan-de-Cuques,
-6 Boulevard Victor Hugo,5.466831,43.361087,,6 Boulevard Victor Hugo,,,,13380
-11 Boulevard de la Coopérative Le Puy-Sainte-Réparade,,,,11 Boulevard de la Coopérative,,,,13610
-11 Boulevard de la Coopérative 13610,,,,11 Boulevard de la Coopérative,,,Le Puy-Sainte-Réparade,
-11 Boulevard de la Coopérative,5.436264,43.665288,,11 Boulevard de la Coopérative,,,,13610
-17 Rue du Poilu La Roque-d'Anthéron,,,,17 Rue du Poilu,,,,13640
-17 Rue du Poilu 13640,,,,17 Rue du Poilu,,,La Roque-d'Anthéron,
-17 Rue du Poilu,5.311433,43.715139,,17 Rue du Poilu,,,,13640
-21 Boulevard Général de Gaulle Saint-Étienne-du-Grès,,,,21 Boulevard Général de Gaulle,,,,13103
-21 Boulevard Général de Gaulle 13103,,,,21 Boulevard Général de Gaulle,,,Saint-Étienne-du-Grès,
-21 Boulevard Général de Gaulle,4.725087,43.782449,,21 Boulevard Général de Gaulle,,,,13103
-206 Rue des Pins Saint-Martin-de-Crau,,,,206 Rue des Pins,,,,13310
-206 Rue des Pins 13310,,,,206 Rue des Pins,,,Saint-Martin-de-Crau,
-206 Rue des Pins,4.789785,43.651381,,206 Rue des Pins,,,,13310
-22 Lotissement La Voie Aurelienne Saint-Rémy-de-Provence,,,,22 Lotissement La Voie Aurelienne,,,,13210
-22 Lotissement La Voie Aurelienne 13210,,,,22 Lotissement La Voie Aurelienne,,,Saint-Rémy-de-Provence,
-22 Lotissement La Voie Aurelienne,4.847178,43.782434,,22 Lotissement La Voie Aurelienne,,,,13210
-134 Rue des Moulins Salon-de-Provence,,,,134 Rue des Moulins,,,,13300
-134 Rue des Moulins 13300,,,,134 Rue des Moulins,,,Salon-de-Provence,
-134 Rue des Moulins,5.099604,43.641854,,134 Rue des Moulins,,,,13300
-133 Avenue du 8 Mai 1945 Septèmes-les-Vallons,,,,133 Avenue du 8 Mai 1945,,,,13240
-133 Avenue du 8 Mai 1945 13240,,,,133 Avenue du 8 Mai 1945,,,Septèmes-les-Vallons,
-133 Avenue du 8 Mai 1945,5.365317,43.397083,,133 Avenue du 8 Mai 1945,,,,13240
-25 Cours Esquiros Trets,,,,25 Cours Esquiros,,,,13530
-25 Cours Esquiros 13530,,,,25 Cours Esquiros,,,Trets,
-25 Cours Esquiros,5.686558,43.446655,,25 Cours Esquiros,,,,13530
-6 Impasse des Genets Verquières,,,,6 Impasse des Genets,,,,13670
-6 Impasse des Genets 13670,,,,6 Impasse des Genets,,,Verquières,
-6 Impasse des Genets,4.921382,43.842542,,6 Impasse des Genets,,,,13670
-11 Rue Fontaine d'Arménie Marseille,,,,11 Rue Fontaine d'Arménie,,,,13001
-11 Rue Fontaine d'Arménie 13001,,,,11 Rue Fontaine d'Arménie,,,Marseille,
-11 Rue Fontaine d'Arménie,5.374893,43.299415,,11 Rue Fontaine d'Arménie,,,,13001
-35 Rue du Panier Marseille,,,,35 Rue du Panier,,,,13002
-35 Rue du Panier 13002,,,,35 Rue du Panier,,,Marseille,
-35 Rue du Panier,5.367604,43.299366,,35 Rue du Panier,,,,13002
-9 Rue de Versailles Marseille,,,,9 Rue de Versailles,,,,13003
-9 Rue de Versailles 13003,,,,9 Rue de Versailles,,,Marseille,
-9 Rue de Versailles,5.375093,43.310709,,9 Rue de Versailles,,,,13003
-2 Rue Tournon Marseille,,,,2 Rue Tournon,,,,13004
-2 Rue Tournon 13004,,,,2 Rue Tournon,,,Marseille,
-2 Rue Tournon,5.404800,43.302731,,2 Rue Tournon,,,,13004
-10 Rue de Verdun Marseille,,,,10 Rue de Verdun,,,,13005
-10 Rue de Verdun 13005,,,,10 Rue de Verdun,,,Marseille,
-10 Rue de Verdun,5.395718,43.296491,,10 Rue de Verdun,,,,13005
-5 Impasse Saint-Domingue Marseille,,,,5 Impasse Saint-Domingue,,,,13006
-5 Impasse Saint-Domingue 13006,,,,5 Impasse Saint-Domingue,,,Marseille,
-5 Impasse Saint-Domingue,5.374039,43.281652,,5 Impasse Saint-Domingue,,,,13006
-9 Rue Notre-Dame des Grâces Marseille,,,,9 Rue Notre-Dame des Grâces,,,,13007
-9 Rue Notre-Dame des Grâces 13007,,,,9 Rue Notre-Dame des Grâces,,,Marseille,
-9 Rue Notre-Dame des Grâces,5.348567,43.280428,,9 Rue Notre-Dame des Grâces,,,,13007
-7 Rue Jean Alcazar Marseille,,,,7 Rue Jean Alcazar,,,,13008
-7 Rue Jean Alcazar 13008,,,,7 Rue Jean Alcazar,,,Marseille,
-7 Rue Jean Alcazar,5.391744,43.279568,,7 Rue Jean Alcazar,,,,13008
-44 Avenue Desautel Marseille,,,,44 Avenue Desautel,,,,13009
-44 Avenue Desautel 13009,,,,44 Avenue Desautel,,,Marseille,
-44 Avenue Desautel,5.407131,43.254766,,44 Avenue Desautel,,,,13009
-138 Rue François Mauriac Marseille,,,,138 Rue François Mauriac,,,,13010
-138 Rue François Mauriac 13010,,,,138 Rue François Mauriac,,,Marseille,
-138 Rue François Mauriac,5.423724,43.269851,,138 Rue François Mauriac,,,,13010
-11 Impasse du Cordeau Marseille,,,,11 Impasse du Cordeau,,,,13011
-11 Impasse du Cordeau 13011,,,,11 Impasse du Cordeau,,,Marseille,
-11 Impasse du Cordeau,5.460850,43.293026,,11 Impasse du Cordeau,,,,13011
-9 Lotissement Le Domaine des Faïenciers Marseille,,,,9 Lotissement Le Domaine des Faïenciers,,,,13011
-9 Lotissement Le Domaine des Faïenciers 13011,,,,9 Lotissement Le Domaine des Faïenciers,,,Marseille,
-9 Lotissement Le Domaine des Faïenciers,5.429800,43.293113,,9 Lotissement Le Domaine des Faïenciers,,,,13011
-31 Boulevard Henri Fabre Marseille,,,,31 Boulevard Henri Fabre,,,,13012
-31 Boulevard Henri Fabre 13012,,,,31 Boulevard Henri Fabre,,,Marseille,
-31 Boulevard Henri Fabre,5.416035,43.307605,,31 Boulevard Henri Fabre,,,,13012
-179 Avenue du 24 Avril 1915 Marseille,,,,179 Avenue du 24 Avril 1915,,,,13012
-179 Avenue du 24 Avril 1915 13012,,,,179 Avenue du 24 Avril 1915,,,Marseille,
-179 Avenue du 24 Avril 1915,5.438740,43.308772,,179 Avenue du 24 Avril 1915,,,,13012
-4 Boulevard Michel Marseille,,,,4 Boulevard Michel,,,,13013
-4 Boulevard Michel 13013,,,,4 Boulevard Michel,,,Marseille,
-4 Boulevard Michel,5.410359,43.320262,,4 Boulevard Michel,,,,13013
-19 Impasse du Bois-Chenu Marseille,,,,19 Impasse du Bois-Chenu,,,,13014
-19 Impasse du Bois-Chenu 13014,,,,19 Impasse du Bois-Chenu,,,Marseille,
-19 Impasse du Bois-Chenu,5.400304,43.341514,,19 Impasse du Bois-Chenu,,,,13014
-26 Boulevard Bech Marseille,,,,26 Boulevard Bech,,,,13015
-26 Boulevard Bech 13015,,,,26 Boulevard Bech,,,Marseille,
-26 Boulevard Bech,5.363367,43.363386,,26 Boulevard Bech,,,,13015
-15 Boulevard Paumont Marseille,,,,15 Boulevard Paumont,,,,13015
-15 Boulevard Paumont 13015,,,,15 Boulevard Paumont,,,Marseille,
-15 Boulevard Paumont,5.351411,43.340284,,15 Boulevard Paumont,,,,13015
-52 Chemin du Passet Marseille,,,,52 Chemin du Passet,,,,13016
-52 Chemin du Passet 13016,,,,52 Chemin du Passet,,,Marseille,
-52 Chemin du Passet,5.335897,43.360764,,52 Chemin du Passet,,,,13016
-332 Chemin No 126 du Bourneou Le Beausset,,,,332 Chemin No 126 du Bourneou,,,,83330
-332 Chemin No 126 du Bourneou 83330,,,,332 Chemin No 126 du Bourneou,,,Le Beausset,
-332 Chemin No 126 du Bourneou,5.811577,43.208600,,332 Chemin No 126 du Bourneou,,,,83330
-15 Chemin des Restanques Bormes-les-Mimosas,,,,15 Chemin des Restanques,,,,83230
-15 Chemin des Restanques 83230,,,,15 Chemin des Restanques,,,Bormes-les-Mimosas,
-15 Chemin des Restanques,6.356603,43.141732,,15 Chemin des Restanques,,,,83230
-5 Avenue des Pins Carqueiranne,,,,5 Avenue des Pins,,,,83320
-5 Avenue des Pins 83320,,,,5 Avenue des Pins,,,Carqueiranne,
-5 Avenue des Pins,6.072952,43.102472,,5 Avenue des Pins,,,,83320
-14 Lotissement Bois Fleuri Cogolin,,,,14 Lotissement Bois Fleuri,,,,83310
-14 Lotissement Bois Fleuri 83310,,,,14 Lotissement Bois Fleuri,,,Cogolin,
-14 Lotissement Bois Fleuri,6.524936,43.238195,,14 Lotissement Bois Fleuri,,,,83310
-302 Rue du Thym La Crau,,,,302 Rue du Thym,,,,83260
-302 Rue du Thym 83260,,,,302 Rue du Thym,,,La Crau,
-302 Rue du Thym,6.076723,43.119725,,302 Rue du Thym,,,,83260
-684 Avenue de Grasse Draguignan,,,,684 Avenue de Grasse,,,,83300
-684 Avenue de Grasse 83300,,,,684 Avenue de Grasse,,,Draguignan,
-684 Avenue de Grasse,6.474148,43.538038,,684 Avenue de Grasse,,,,83300
-5 Impasse Ventre La Farlède,,,,5 Impasse Ventre,,,,83210
-5 Impasse Ventre 83210,,,,5 Impasse Ventre,,,La Farlède,
-5 Impasse Ventre,6.046754,43.171436,,5 Impasse Ventre,,,,83210
-74 Allée de la Cigale d'Or Fréjus,,,,74 Allée de la Cigale d'Or,,,,83600
-74 Allée de la Cigale d'Or 83600,,,,74 Allée de la Cigale d'Or,,,Fréjus,
-74 Allée de la Cigale d'Or,6.727121,43.449170,,74 Allée de la Cigale d'Or,,,,83600
-465 Rue du Pas de la Cèpe Fréjus,,,,465 Rue du Pas de la Cèpe,,,,83600
-465 Rue du Pas de la Cèpe 83600,,,,465 Rue du Pas de la Cèpe,,,Fréjus,
-465 Rue du Pas de la Cèpe,6.874097,43.520450,,465 Rue du Pas de la Cèpe,,,,83600
-4 Rue du Lot Domaine des Pins La Garde,,,,4 Rue du Lot Domaine des Pins,,,,83130
-4 Rue du Lot Domaine des Pins 83130,,,,4 Rue du Lot Domaine des Pins,,,La Garde,
-4 Rue du Lot Domaine des Pins,6.001340,43.116684,,4 Rue du Lot Domaine des Pins,,,,83130
-14 Allée Auréa Hyères,,,,14 Allée Auréa,,,,83400
-14 Allée Auréa 83400,,,,14 Allée Auréa,,,Hyères,
-14 Allée Auréa,6.144660,43.116093,,14 Allée Auréa,,,,83400
-21 Rue Marc Riché Hyères,,,,21 Rue Marc Riché,,,,83400
-21 Rue Marc Riché 83400,,,,21 Rue Marc Riché,,,Hyères,
-21 Rue Marc Riché,6.115726,43.103108,,21 Rue Marc Riché,,,,83400
-6108 Impasse du Rossignol Le Lavandou,,,,6108 Impasse du Rossignol,,,,83980
-6108 Impasse du Rossignol 83980,,,,6108 Impasse du Rossignol,,,Le Lavandou,
-6108 Impasse du Rossignol,6.416059,43.150385,,6108 Impasse du Rossignol,,,,83980
-288 Chemin du Pas de l'Ave Lorgues,,,,288 Chemin du Pas de l'Ave,,,,83510
-288 Chemin du Pas de l'Ave 83510,,,,288 Chemin du Pas de l'Ave,,,Lorgues,
-288 Chemin du Pas de l'Ave,6.326831,43.484272,,288 Chemin du Pas de l'Ave,,,,83510
-899 Chemin des Rouvières Le Muy,,,,899 Chemin des Rouvières,,,,83490
-899 Chemin des Rouvières 83490,,,,899 Chemin des Rouvières,,,Le Muy,
-899 Chemin des Rouvières,6.549990,43.484002,,899 Chemin des Rouvières,,,,83490
-45 Avenue Général Albert Azan Pignans,,,,45 Avenue Général Albert Azan,,,,83790
-45 Avenue Général Albert Azan 83790,,,,45 Avenue Général Albert Azan,,,Pignans,
-45 Avenue Général Albert Azan,6.235873,43.304437,,45 Avenue Général Albert Azan,,,,83790
-52 Traverse du Marché Puget-Ville,,,,52 Traverse du Marché,,,,83390
-52 Traverse du Marché 83390,,,,52 Traverse du Marché,,,Puget-Ville,
-52 Traverse du Marché,6.135290,43.288656,,52 Traverse du Marché,,,,83390
-48 Rue du Nid Au Soleil Roquebrune-sur-Argens,,,,48 Rue du Nid Au Soleil,,,,83370
-48 Rue du Nid Au Soleil 83370,,,,48 Rue du Nid Au Soleil,,,Roquebrune-sur-Argens,
-48 Rue du Nid Au Soleil,6.714635,43.350730,,48 Rue du Nid Au Soleil,,,,83370
-6 Boulevard des Cades Sainte-Maxime,,,,6 Boulevard des Cades,,,,83120
-6 Boulevard des Cades 83120,,,,6 Boulevard des Cades,,,Sainte-Maxime,
-6 Boulevard des Cades,6.643041,43.316052,,6 Boulevard des Cades,,,,83120
-453 Chemin du Petit Recours Saint-Maximin-la-Sainte-Baume,,,,453 Chemin du Petit Recours,,,,83470
-453 Chemin du Petit Recours 83470,,,,453 Chemin du Petit Recours,,,Saint-Maximin-la-Sainte-Baume,
-453 Chemin du Petit Recours,5.850618,43.437391,,453 Chemin du Petit Recours,,,,83470
-829 Boulevard Jean Georges Branché Saint-Raphaël,,,,829 Boulevard Jean Georges Branché,,,,83530
-829 Boulevard Jean Georges Branché 83530,,,,829 Boulevard Jean Georges Branché,,,Saint-Raphaël,
-829 Boulevard Jean Georges Branché,6.924382,43.478576,,829 Boulevard Jean Georges Branché,,,,83530
-21 Boulevard Bernard Palissy Saint-Zacharie,,,,21 Boulevard Bernard Palissy,,,,83640
-21 Boulevard Bernard Palissy 83640,,,,21 Boulevard Bernard Palissy,,,Saint-Zacharie,
-21 Boulevard Bernard Palissy,5.708330,43.384033,,21 Boulevard Bernard Palissy,,,,83640
-345 Avenue Auguste Renoir La Seyne-sur-Mer,,,,345 Avenue Auguste Renoir,,,,83500
-345 Avenue Auguste Renoir 83500,,,,345 Avenue Auguste Renoir,,,La Seyne-sur-Mer,
-345 Avenue Auguste Renoir,5.868262,43.085750,,345 Avenue Auguste Renoir,,,,83500
-54 Rue Louis Blanqui La Seyne-sur-Mer,,,,54 Rue Louis Blanqui,,,,83500
-54 Rue Louis Blanqui 83500,,,,54 Rue Louis Blanqui,,,La Seyne-sur-Mer,
-54 Rue Louis Blanqui,5.881829,43.099435,,54 Rue Louis Blanqui,,,,83500
-109 Impasse des Faisses Six-Fours-les-Plages,,,,109 Impasse des Faisses,,,,83140
-109 Impasse des Faisses 83140,,,,109 Impasse des Faisses,,,Six-Fours-les-Plages,
-109 Impasse des Faisses,5.813487,43.078865,,109 Impasse des Faisses,,,,83140
-387 Chemin des Andués Solliès-Pont,,,,387 Chemin des Andués,,,,83210
-387 Chemin des Andués 83210,,,,387 Chemin des Andués,,,Solliès-Pont,
-387 Chemin des Andués,6.050041,43.197059,,387 Chemin des Andués,,,,83210
-111 Hameau Les Camails Le Thoronet,,,,111 Hameau Les Camails,,,,83340
-111 Hameau Les Camails 83340,,,,111 Hameau Les Camails,,,Le Thoronet,
-111 Hameau Les Camails,6.261667,43.475218,,111 Hameau Les Camails,,,,83340
-593 Chemin du Collet de Saint-Pièrre Toulon,,,,593 Chemin du Collet de Saint-Pièrre,,,,83100
-593 Chemin du Collet de Saint-Pièrre 83100,,,,593 Chemin du Collet de Saint-Pièrre,,,Toulon,
-593 Chemin du Collet de Saint-Pièrre,5.912041,43.160528,,593 Chemin du Collet de Saint-Pièrre,,,,83100
-64 Avenue Georges Clemenceau Toulon,,,,64 Avenue Georges Clemenceau,,,,83100
-64 Avenue Georges Clemenceau 83100,,,,64 Avenue Georges Clemenceau,,,Toulon,
-64 Avenue Georges Clemenceau,5.937206,43.123403,,64 Avenue Georges Clemenceau,,,,83100
-18 Rue Masséna Toulon,,,,18 Rue Masséna,,,,83100
-18 Rue Masséna 83100,,,,18 Rue Masséna,,,Toulon,
-18 Rue Masséna,5.935369,43.110195,,18 Rue Masséna,,,,83100
-85 Rue Santa Lucia Toulon,,,,85 Rue Santa Lucia,,,,83100
-85 Rue Santa Lucia 83100,,,,85 Rue Santa Lucia,,,Toulon,
-85 Rue Santa Lucia,5.896875,43.146111,,85 Rue Santa Lucia,,,,83100
-78 Traverse du Pinson La Valette-du-Var,,,,78 Traverse du Pinson,,,,83160
-78 Traverse du Pinson 83160,,,,78 Traverse du Pinson,,,La Valette-du-Var,
-78 Traverse du Pinson,5.987031,43.154275,,78 Traverse du Pinson,,,,83160
-15 Chemin des Aubépines Saint-Mandrier-sur-Mer,,,,15 Chemin des Aubépines,,,,83430
-15 Chemin des Aubépines 83430,,,,15 Chemin des Aubépines,,,Saint-Mandrier-sur-Mer,
-15 Chemin des Aubépines,5.924359,43.075482,,15 Chemin des Aubépines,,,,83430
-5 Rue Alfred Bergier Mft Avignon,,,,5 Rue Alfred Bergier Mft,,,,84140
-5 Rue Alfred Bergier Mft 84140,,,,5 Rue Alfred Bergier Mft,,,Avignon,
-5 Rue Alfred Bergier Mft,4.875017,43.939148,,5 Rue Alfred Bergier Mft,,,,84140
-31 Rue Diane de Poitiers Avignon,,,,31 Rue Diane de Poitiers,,,,84140
-31 Rue Diane de Poitiers 84140,,,,31 Rue Diane de Poitiers,,,Avignon,
-31 Rue Diane de Poitiers,4.822552,43.928334,,31 Rue Diane de Poitiers,,,,84140
-7 Rue Ledru Rollin Avignon,,,,7 Rue Ledru Rollin,,,,84140
-7 Rue Ledru Rollin 84140,,,,7 Rue Ledru Rollin,,,Avignon,
-7 Rue Ledru Rollin,4.812372,43.950804,,7 Rue Ledru Rollin,,,,84140
-10 Rue du Portail Boquier Avignon,,,,10 Rue du Portail Boquier,,,,84140
-10 Rue du Portail Boquier 84140,,,,10 Rue du Portail Boquier,,,Avignon,
-10 Rue du Portail Boquier,4.804947,43.944583,,10 Rue du Portail Boquier,,,,84140
-75 Chemin de la Bindonne Bédarrides,,,,75 Chemin de la Bindonne,,,,84370
-75 Chemin de la Bindonne 84370,,,,75 Chemin de la Bindonne,,,Bédarrides,
-75 Chemin de la Bindonne,4.937503,44.057071,,75 Chemin de la Bindonne,,,,84370
-601 Chemin de la Prefferance Bollène,,,,601 Chemin de la Prefferance,,,,84500
-601 Chemin de la Prefferance 84500,,,,601 Chemin de la Prefferance,,,Bollène,
-601 Chemin de la Prefferance,4.712632,44.277966,,601 Chemin de la Prefferance,,,,84500
-52BIS Chemin de l'Aqueduc Carpentras,,,,52BIS Chemin de l'Aqueduc,,,,84200
-52BIS Chemin de l'Aqueduc 84200,,,,52BIS Chemin de l'Aqueduc,,,Carpentras,
-52BIS Chemin de l'Aqueduc,5.058438,44.064902,,52BIS Chemin de l'Aqueduc,,,,84200
-195 Boulevard du Nord Carpentras,,,,195 Boulevard du Nord,,,,84200
-195 Boulevard du Nord 84200,,,,195 Boulevard du Nord,,,Carpentras,
-195 Boulevard du Nord,5.048548,44.057651,,195 Boulevard du Nord,,,,84200
-6 Domaine de la Noyeraie Caumont-sur-Durance,,,,6 Domaine de la Noyeraie,,,,84510
-6 Domaine de la Noyeraie 84510,,,,6 Domaine de la Noyeraie,,,Caumont-sur-Durance,
-6 Domaine de la Noyeraie,4.952233,43.895967,,6 Domaine de la Noyeraie,,,,84510
-2634 Chemin Romieu Cavaillon,,,,2634 Chemin Romieu,,,,84300
-2634 Chemin Romieu 84300,,,,2634 Chemin Romieu,,,Cavaillon,
-2634 Chemin Romieu,5.052860,43.874299,,2634 Chemin Romieu,,,,84300
-80 Allée Raimbaud d'Orange Courthézon,,,,80 Allée Raimbaud d'Orange,,,,84350
-80 Allée Raimbaud d'Orange 84350,,,,80 Allée Raimbaud d'Orange,,,Courthézon,
-80 Allée Raimbaud d'Orange,4.879376,44.089706,,80 Allée Raimbaud d'Orange,,,,84350
-578 Cours René Char L'Isle-sur-la-Sorgue,,,,578 Cours René Char,,,,84800
-578 Cours René Char 84800,,,,578 Cours René Char,,,L'Isle-sur-la-Sorgue,
-578 Cours René Char,5.054979,43.913808,,578 Cours René Char,,,,84800
-9 Lotissement Les Peupliers L'Isle-sur-la-Sorgue,,,,9 Lotissement Les Peupliers,,,,84800
-9 Lotissement Les Peupliers 84800,,,,9 Lotissement Les Peupliers,,,L'Isle-sur-la-Sorgue,
-9 Lotissement Les Peupliers,5.046234,43.931580,,9 Lotissement Les Peupliers,,,,84800
-246 Chemin de Tinargue Malemort-du-Comtat,,,,246 Chemin de Tinargue,,,,84570
-246 Chemin de Tinargue 84570,,,,246 Chemin de Tinargue,,,Malemort-du-Comtat,
-246 Chemin de Tinargue,5.166013,44.021273,,246 Chemin de Tinargue,,,,84570
-8 Impasse Louis Giraud Monteux,,,,8 Impasse Louis Giraud,,,,84170
-8 Impasse Louis Giraud 84170,,,,8 Impasse Louis Giraud,,,Monteux,
-8 Impasse Louis Giraud,5.003113,44.034636,,8 Impasse Louis Giraud,,,,84170
-99 Chemin des Peyrollets Mormoiron,,,,99 Chemin des Peyrollets,,,,84570
-99 Chemin des Peyrollets 84570,,,,99 Chemin des Peyrollets,,,Mormoiron,
-99 Chemin des Peyrollets,5.185432,44.066491,,99 Chemin des Peyrollets,,,,84570
-169 Avenue Général Raymond Lorho Orange,,,,169 Avenue Général Raymond Lorho,,,,84100
-169 Avenue Général Raymond Lorho 84100,,,,169 Avenue Général Raymond Lorho,,,Orange,
-169 Avenue Général Raymond Lorho,4.819466,44.134117,,169 Avenue Général Raymond Lorho,,,,84100
-53 Clos Saint-Jacques Orange,,,,53 Clos Saint-Jacques,,,,84100
-53 Clos Saint-Jacques 84100,,,,53 Clos Saint-Jacques,,,Orange,
-53 Clos Saint-Jacques,4.824597,44.121110,,53 Clos Saint-Jacques,,,,84100
-18 Rue Grande Pertuis,,,,18 Rue Grande,,,,84120
-18 Rue Grande 84120,,,,18 Rue Grande,,,Pertuis,
-18 Rue Grande,5.502976,43.694931,,18 Rue Grande,,,,84120
-39 Avenue de Provence Piolenc,,,,39 Avenue de Provence,,,,84420
-39 Avenue de Provence 84420,,,,39 Avenue de Provence,,,Piolenc,
-39 Avenue de Provence,4.761619,44.175499,,39 Avenue de Provence,,,,84420
-133 Chemin de Canfier Robion,,,,133 Chemin de Canfier,,,,84440
-133 Chemin de Canfier 84440,,,,133 Chemin de Canfier,,,Robion,
-133 Chemin de Canfier,5.107585,43.848871,,133 Chemin de Canfier,,,,84440
-12 Impasse des Troènes Saint-Saturnin-lès-Avignon,,,,12 Impasse des Troènes,,,,84450
-12 Impasse des Troènes 84450,,,,12 Impasse des Troènes,,,Saint-Saturnin-lès-Avignon,
-12 Impasse des Troènes,4.935709,43.958471,,12 Impasse des Troènes,,,,84450
-274C Rue Marius Chastel Sorgues,,,,274C Rue Marius Chastel,,,,84700
-274C Rue Marius Chastel 84700,,,,274C Rue Marius Chastel,,,Sorgues,
-274C Rue Marius Chastel,4.881426,44.009981,,274C Rue Marius Chastel,,,,84700
-490 Chemin Vieux Le Thor,,,,490 Chemin Vieux,,,,84250
-490 Chemin Vieux 84250,,,,490 Chemin Vieux,,,Le Thor,
-490 Chemin Vieux,4.988444,43.925977,,490 Chemin Vieux,,,,84250
-40 Cours Tivoli Valréas,,,,40 Cours Tivoli,,,,84600
-40 Cours Tivoli 84600,,,,40 Cours Tivoli,,,Valréas,
-40 Cours Tivoli,4.993043,44.382437,,40 Cours Tivoli,,,,84600
-6059 Rue des Vautes Velleron,,,,6059 Rue des Vautes,,,,84740
-6059 Rue des Vautes 84740,,,,6059 Rue des Vautes,,,Velleron,
-6059 Rue des Vautes,5.031515,43.956557,,6059 Rue des Vautes,,,,84740
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+30 Rue des Chapeliers Digne-les-Bains,,,,30,Rue des Chapeliers,,4000
+30 Rue des Chapeliers 04000,,,,30,Rue des Chapeliers,Digne-les-Bains,
+30 Rue des Chapeliers,6.236155,44.091569,,30,Rue des Chapeliers,,4000
+933 Route d'Apt Manosque,,,,933,Route d'Apt,,4100
+933 Route d'Apt 04100,,,,933,Route d'Apt,Manosque,
+933 Route d'Apt,5.757922,43.831939,,933,Route d'Apt,,4100
+13 Rue Alphonse Rolland Oraison,,,,13,Rue Alphonse Rolland,,4700
+13 Rue Alphonse Rolland 04700,,,,13,Rue Alphonse Rolland,Oraison,
+13 Rue Alphonse Rolland,5.918742,43.918616,,13,Rue Alphonse Rolland,,4700
+13 Rue de la Plaine Sainte-Tulle,,,,13,Rue de la Plaine,,4220
+13 Rue de la Plaine 04220,,,,13,Rue de la Plaine,Sainte-Tulle,
+13 Rue de la Plaine,5.76165,43.785843,,13,Rue de la Plaine,,4220
+17 Chemin du Clauzon Gap,,,,17,Chemin du Clauzon,,5000
+17 Chemin du Clauzon 05000,,,,17,Chemin du Clauzon,Gap,
+17 Chemin du Clauzon,6.107486,44.585189,,17,Chemin du Clauzon,,5000
+23 Rue de la Mairie Le Monêtier-les-Bains,,,,23,Rue de la Mairie,,5220
+23 Rue de la Mairie 05220,,,,23,Rue de la Mairie,Le Monêtier-les-Bains,
+23 Rue de la Mairie,6.508099,44.976243,,23,Rue de la Mairie,,5220
+15 Rue Lacan Antibes,,,,15,Rue Lacan,,6600
+15 Rue Lacan 06600,,,,15,Rue Lacan,Antibes,
+15 Rue Lacan,7.123838,43.582773,,15,Rue Lacan,,6600
+11 Chemin du Bois Aspremont,,,,11,Chemin du Bois,,6790
+11 Chemin du Bois 06790,,,,11,Chemin du Bois,Aspremont,
+11 Chemin du Bois,7.250749,43.786604,,11,Chemin du Bois,,6790
+730 Route des Escaillouns Berre-les-Alpes,,,,730,Route des Escaillouns,,6390
+730 Route des Escaillouns 06390,,,,730,Route des Escaillouns,Berre-les-Alpes,
+730 Route des Escaillouns,7.336633,43.829037,,730,Route des Escaillouns,,6390
+582 Promenade Saint-Jean Cabris,,,,582,Promenade Saint-Jean,,6530
+582 Promenade Saint-Jean 06530,,,,582,Promenade Saint-Jean,Cabris,
+582 Promenade Saint-Jean,6.866844,43.657046,,582,Promenade Saint-Jean,,6530
+2665 Route de la Plaine de Caille Caille,,,,2665,Route de la Plaine de Caille,,6750
+2665 Route de la Plaine de Caille 06750,,,,2665,Route de la Plaine de Caille,Caille,
+2665 Route de la Plaine de Caille,6.760316,43.781557,,2665,Route de la Plaine de Caille,,6750
+5 Boulevard Lord Brougham Cannes,,,,5,Boulevard Lord Brougham,,6150
+5 Boulevard Lord Brougham 06150,,,,5,Boulevard Lord Brougham,Cannes,
+5 Boulevard Lord Brougham,7.003226,43.556886,,5,Boulevard Lord Brougham,,6150
+16 Rue du Canal Le Cannet,,,,16,Rue du Canal,,6110
+16 Rue du Canal 06110,,,,16,Rue du Canal,Le Cannet,
+16 Rue du Canal,7.02954,43.570909,,16,Rue du Canal,,6110
+14 Avenue des Cigales Carros,,,,14,Avenue des Cigales,,6510
+14 Avenue des Cigales 06510,,,,14,Avenue des Cigales,Carros,
+14 Avenue des Cigales,7.191315,43.770882,,14,Avenue des Cigales,,6510
+822 Route du Plan de Linéa Coaraze,,,,822,Route du Plan de Linéa,,6390
+822 Route du Plan de Linéa 06390,,,,822,Route du Plan de Linéa,Coaraze,
+822 Route du Plan de Linéa,7.299132,43.85876,,822,Route du Plan de Linéa,,6390
+2 Rue du Murier Cuébris,,,,2,Rue du Murier,,6910
+2 Rue du Murier 06910,,,,2,Rue du Murier,Cuébris,
+2 Rue du Murier,7.018922,43.886951,,2,Rue du Murier,,6910
+190 Cours de la Colle de Rouge N88 La Gaude,,,,190,Cours de la Colle de Rouge N88,,6610
+190 Cours de la Colle de Rouge N88 06610,,,,190,Cours de la Colle de Rouge N88,La Gaude,
+190 Cours de la Colle de Rouge N88,7.155574,43.705968,,190,Cours de la Colle de Rouge N88,,6610
+22 Boulevard Jacques Crouet Grasse,,,,22,Boulevard Jacques Crouet,,6520
+22 Boulevard Jacques Crouet 06520,,,,22,Boulevard Jacques Crouet,Grasse,
+22 Boulevard Jacques Crouet,6.925281,43.656798,,22,Boulevard Jacques Crouet,,6520
+1 Rue du Portal Levens,,,,1,Rue du Portal,,6670
+1 Rue du Portal 06670,,,,1,Rue du Portal,Levens,
+1 Rue du Portal,7.225881,43.859565,,1,Rue du Portal,,6670
+1570 Route des Ciappes de Castellar Menton,,,,1570,Route des Ciappes de Castellar,,6500
+1570 Route des Ciappes de Castellar 06500,,,,1570,Route des Ciappes de Castellar,Menton,
+1570 Route des Ciappes de Castellar,7.500395,43.783476,,1570,Route des Ciappes de Castellar,,6500
+993 Chemin de la Sénéquière Mouans-Sartoux,,,,993,Chemin de la Sénéquière,,6370
+993 Chemin de la Sénéquière 06370,,,,993,Chemin de la Sénéquière,Mouans-Sartoux,
+993 Chemin de la Sénéquière,6.968666,43.630803,,993,Chemin de la Sénéquière,,6370
+8 Rue de Gubert Moulinet,,,,8,Rue de Gubert,,6380
+8 Rue de Gubert 06380,,,,8,Rue de Gubert,Moulinet,
+8 Rue de Gubert,7.412802,43.941339,,8,Rue de Gubert,,6380
+213 Route de Colomars Nice,,,,213,Route de Colomars,,6300
+213 Route de Colomars 06300,,,,213,Route de Colomars,Nice,
+213 Route de Colomars,7.20511,43.754519,,213,Route de Colomars,,6300
+28 Rue de l'Hôtel des Postes Nice,,,,28,Rue de l'Hôtel des Postes,,6300
+28 Rue de l'Hôtel des Postes 06300,,,,28,Rue de l'Hôtel des Postes,Nice,
+28 Rue de l'Hôtel des Postes,7.271473,43.699629,,28,Rue de l'Hôtel des Postes,,6300
+39 Rue Paul Déroulède Nice,,,,39,Rue Paul Déroulède,,6300
+39 Rue Paul Déroulède 06300,,,,39,Rue Paul Déroulède,Nice,
+39 Rue Paul Déroulède,7.263094,43.700708,,39,Rue Paul Déroulède,,6300
+16 Chemin de la Vignette Nice,,,,16,Chemin de la Vignette,,6300
+16 Chemin de la Vignette 06300,,,,16,Chemin de la Vignette,Nice,
+16 Chemin de la Vignette,7.208998,43.71912,,16,Chemin de la Vignette,,6300
+14 Chemin de la Frayère Peymeinade,,,,14,Chemin de la Frayère,,6530
+14 Chemin de la Frayère 06530,,,,14,Chemin de la Frayère,Peymeinade,
+14 Chemin de la Frayère,6.882741,43.64183,,14,Chemin de la Frayère,,6530
+235 Chemin du Tramway Roquefort-les-Pins,,,,235,Chemin du Tramway,,6330
+235 Chemin du Tramway 06330,,,,235,Chemin du Tramway,Roquefort-les-Pins,
+235 Chemin du Tramway,7.063445,43.660163,,235,Chemin du Tramway,,6330
+460 Chemin Departemental 13 Rte de Grasse Saint-Cézaire-sur-Siagne,,,,460,Chemin Departemental 13 Rte de Grasse,,6530
+460 Chemin Departemental 13 Rte de Grasse 06530,,,,460,Chemin Departemental 13 Rte de Grasse,Saint-Cézaire-sur-Siagne,
+460 Chemin Departemental 13 Rte de Grasse,6.804939,43.647248,,460,Chemin Departemental 13 Rte de Grasse,,6530
+194 Chemin des Romarins Saint-Laurent-du-Var,,,,194,Chemin des Romarins,,6700
+194 Chemin des Romarins 06700,,,,194,Chemin des Romarins,Saint-Laurent-du-Var,
+194 Chemin des Romarins,7.180512,43.664602,,194,Chemin des Romarins,,6700
+11 Rue des Voutes Sospel,,,,11,Rue des Voutes,,6380
+11 Rue des Voutes 06380,,,,11,Rue des Voutes,Sospel,
+11 Rue des Voutes,7.448558,43.876872,,11,Rue des Voutes,,6380
+399 Route de Pierascas Tourrettes-sur-Loup,,,,399,Route de Pierascas,,6140
+399 Route de Pierascas 06140,,,,399,Route de Pierascas,Tourrettes-sur-Loup,
+399 Route de Pierascas,7.07288,43.711277,,399,Route de Pierascas,,6140
+75 Boulevard du Cap Vallauris,,,,75,Boulevard du Cap,,6220
+75 Boulevard du Cap 06220,,,,75,Boulevard du Cap,Vallauris,
+75 Boulevard du Cap,7.060118,43.570042,,75,Boulevard du Cap,,6220
+36 Avenue des Pins Vence,,,,36,Avenue des Pins,,6140
+36 Avenue des Pins 06140,,,,36,Avenue des Pins,Vence,
+36 Avenue des Pins,7.105532,43.718743,,36,Avenue des Pins,,6140
+8 Allée de la Tour de la Madone Villeneuve-Loubet,,,,8,Allée de la Tour de la Madone,,6270
+8 Allée de la Tour de la Madone 06270,,,,8,Allée de la Tour de la Madone,Villeneuve-Loubet,
+8 Allée de la Tour de la Madone,7.113288,43.634314,,8,Allée de la Tour de la Madone,,6270
+1 Avenue des Infirmeries Aix-en-Provence,,,,1,Avenue des Infirmeries,,13090
+1 Avenue des Infirmeries 13090,,,,1,Avenue des Infirmeries,Aix-en-Provence,
+1 Avenue des Infirmeries,5.462783,43.516233,,1,Avenue des Infirmeries,,13090
+11 Cours Sextius Aix-en-Provence,,,,11,Cours Sextius,,13090
+11 Cours Sextius 13090,,,,11,Cours Sextius,Aix-en-Provence,
+11 Cours Sextius,5.443837,43.528339,,11,Cours Sextius,,13090
+16 Lotissement Notre-Dame des Anges Allauch,,,,16,Lotissement Notre-Dame des Anges,,13190
+16 Lotissement Notre-Dame des Anges 13190,,,,16,Lotissement Notre-Dame des Anges,Allauch,
+16 Lotissement Notre-Dame des Anges,5.48455,43.363311,,16,Lotissement Notre-Dame des Anges,,13190
+20 Rue Delfo Novi Arles,,,,20,Rue Delfo Novi,,13104
+20 Rue Delfo Novi 13104,,,,20,Rue Delfo Novi,Arles,
+20 Rue Delfo Novi,4.617719,43.6644,,20,Rue Delfo Novi,,13104
+2 Rue Jacquemin Arles,,,,2,Rue Jacquemin,,13104
+2 Rue Jacquemin 13104,,,,2,Rue Jacquemin,Arles,
+2 Rue Jacquemin,4.631506,43.673112,,2,Rue Jacquemin,,13104
+2 Rue Portagnel Arles,,,,2,Rue Portagnel,,13104
+2 Rue Portagnel 13104,,,,2,Rue Portagnel,Arles,
+2 Rue Portagnel,4.631362,43.67964,,2,Rue Portagnel,,13104
+100 Chemin de l'Aumône Vieille Aubagne,,,,100,Chemin de l'Aumône Vieille,,13400
+100 Chemin de l'Aumône Vieille 13400,,,,100,Chemin de l'Aumône Vieille,Aubagne,
+100 Chemin de l'Aumône Vieille,5.529703,43.286451,,100,Chemin de l'Aumône Vieille,,13400
+129 Rue du Vallat Aubagne,,,,129,Rue du Vallat,,13400
+129 Rue du Vallat 13400,,,,129,Rue du Vallat,Aubagne,
+129 Rue du Vallat,5.598012,43.29097,,129,Rue du Vallat,,13400
+7 Chemin de Magne La Bouilladisse,,,,7,Chemin de Magne,,13720
+7 Chemin de Magne 13720,,,,7,Chemin de Magne,La Bouilladisse,
+7 Chemin de Magne,5.593794,43.393574,,7,Chemin de Magne,,13720
+19 Chemin du Plan Capelan Carry-le-Rouet,,,,19,Chemin du Plan Capelan,,13620
+19 Chemin du Plan Capelan 13620,,,,19,Chemin du Plan Capelan,Carry-le-Rouet,
+19 Chemin du Plan Capelan,5.141116,43.335699,,19,Chemin du Plan Capelan,,13620
+33 Rue Claude Debussy Châteaurenard,,,,33,Rue Claude Debussy,,13160
+33 Rue Claude Debussy 13160,,,,33,Rue Claude Debussy,Châteaurenard,
+33 Rue Claude Debussy,4.851979,43.87423,,33,Rue Claude Debussy,,13160
+18 Rue Henri Diffonty La Ciotat,,,,18,Rue Henri Diffonty,,13600
+18 Rue Henri Diffonty 13600,,,,18,Rue Henri Diffonty,La Ciotat,
+18 Rue Henri Diffonty,5.609487,43.175723,,18,Rue Henri Diffonty,,13600
+1 Impasse des Mésanges Ensuès-la-Redonne,,,,1,Impasse des Mésanges,,13820
+1 Impasse des Mésanges 13820,,,,1,Impasse des Mésanges,Ensuès-la-Redonne,
+1 Impasse des Mésanges,5.212512,43.352148,,1,Impasse des Mésanges,,13820
+31 Rue du Puits de Passet Fontvieille,,,,31,Rue du Puits de Passet,,13990
+31 Rue du Puits de Passet 13990,,,,31,Rue du Puits de Passet,Fontvieille,
+31 Rue du Puits de Passet,4.710541,43.726877,,31,Rue du Puits de Passet,,13990
+6 Rue Mignet Gardanne,,,,6,Rue Mignet,,13120
+6 Rue Mignet 13120,,,,6,Rue Mignet,Gardanne,
+6 Rue Mignet,5.472036,43.455234,,6,Rue Mignet,,13120
+4 Impasse de la Lavande Gréasque,,,,4,Impasse de la Lavande,,13850
+4 Impasse de la Lavande 13850,,,,4,Impasse de la Lavande,Gréasque,
+4 Impasse de la Lavande,5.533649,43.436009,,4,Impasse de la Lavande,,13850
+25 Lotissement La Palun Istres,,,,25,Lotissement La Palun,,13800
+25 Lotissement La Palun 13800,,,,25,Lotissement La Palun,Istres,
+25 Lotissement La Palun,4.976047,43.506638,,25,Lotissement La Palun,,13800
+32 Lotissement Les Restanques Mallemort,,,,32,Lotissement Les Restanques,,13370
+32 Lotissement Les Restanques 13370,,,,32,Lotissement Les Restanques,Mallemort,
+32 Lotissement Les Restanques,5.183941,43.727544,,32,Lotissement Les Restanques,,13370
+21 Rue Galinière Martigues,,,,21,Rue Galinière,,13500
+21 Rue Galinière 13500,,,,21,Rue Galinière,Martigues,
+21 Rue Galinière,5.055315,43.406165,,21,Rue Galinière,,13500
+3 Rue de la Bourride Miramas,,,,3,Rue de la Bourride,,13140
+3 Rue de la Bourride 13140,,,,3,Rue de la Bourride,Miramas,
+3 Rue de la Bourride,5.001276,43.572373,,3,Rue de la Bourride,,13140
+6503 Chemin de l'Eau Noves,,,,6503,Chemin de l'Eau,,13550
+6503 Chemin de l'Eau 13550,,,,6503,Chemin de l'Eau,Noves,
+6503 Chemin de l'Eau,4.900729,43.872602,,6503,Chemin de l'Eau,,13550
+48 Avenue de la Gardiette Les Pennes-Mirabeau,,,,48,Avenue de la Gardiette,,13170
+48 Avenue de la Gardiette 13170,,,,48,Avenue de la Gardiette,Les Pennes-Mirabeau,
+48 Avenue de la Gardiette,5.338169,43.419697,,48,Avenue de la Gardiette,,13170
+6 Boulevard Victor Hugo Plan-de-Cuques,,,,6,Boulevard Victor Hugo,,13380
+6 Boulevard Victor Hugo 13380,,,,6,Boulevard Victor Hugo,Plan-de-Cuques,
+6 Boulevard Victor Hugo,5.466831,43.361087,,6,Boulevard Victor Hugo,,13380
+11 Boulevard de la Coopérative Le Puy-Sainte-Réparade,,,,11,Boulevard de la Coopérative,,13610
+11 Boulevard de la Coopérative 13610,,,,11,Boulevard de la Coopérative,Le Puy-Sainte-Réparade,
+11 Boulevard de la Coopérative,5.436264,43.665288,,11,Boulevard de la Coopérative,,13610
+17 Rue du Poilu La Roque-d'Anthéron,,,,17,Rue du Poilu,,13640
+17 Rue du Poilu 13640,,,,17,Rue du Poilu,La Roque-d'Anthéron,
+17 Rue du Poilu,5.311433,43.715139,,17,Rue du Poilu,,13640
+21 Boulevard Général de Gaulle Saint-Étienne-du-Grès,,,,21,Boulevard Général de Gaulle,,13103
+21 Boulevard Général de Gaulle 13103,,,,21,Boulevard Général de Gaulle,Saint-Étienne-du-Grès,
+21 Boulevard Général de Gaulle,4.725087,43.782449,,21,Boulevard Général de Gaulle,,13103
+206 Rue des Pins Saint-Martin-de-Crau,,,,206,Rue des Pins,,13310
+206 Rue des Pins 13310,,,,206,Rue des Pins,Saint-Martin-de-Crau,
+206 Rue des Pins,4.789785,43.651381,,206,Rue des Pins,,13310
+22 Lotissement La Voie Aurelienne Saint-Rémy-de-Provence,,,,22,Lotissement La Voie Aurelienne,,13210
+22 Lotissement La Voie Aurelienne 13210,,,,22,Lotissement La Voie Aurelienne,Saint-Rémy-de-Provence,
+22 Lotissement La Voie Aurelienne,4.847178,43.782434,,22,Lotissement La Voie Aurelienne,,13210
+134 Rue des Moulins Salon-de-Provence,,,,134,Rue des Moulins,,13300
+134 Rue des Moulins 13300,,,,134,Rue des Moulins,Salon-de-Provence,
+134 Rue des Moulins,5.099604,43.641854,,134,Rue des Moulins,,13300
+133 Avenue du 8 Mai 1945 Septèmes-les-Vallons,,,,133,Avenue du 8 Mai 1945,,13240
+133 Avenue du 8 Mai 1945 13240,,,,133,Avenue du 8 Mai 1945,Septèmes-les-Vallons,
+133 Avenue du 8 Mai 1945,5.365317,43.397083,,133,Avenue du 8 Mai 1945,,13240
+25 Cours Esquiros Trets,,,,25,Cours Esquiros,,13530
+25 Cours Esquiros 13530,,,,25,Cours Esquiros,Trets,
+25 Cours Esquiros,5.686558,43.446655,,25,Cours Esquiros,,13530
+6 Impasse des Genets Verquières,,,,6,Impasse des Genets,,13670
+6 Impasse des Genets 13670,,,,6,Impasse des Genets,Verquières,
+6 Impasse des Genets,4.921382,43.842542,,6,Impasse des Genets,,13670
+11 Rue Fontaine d'Arménie Marseille,,,,11,Rue Fontaine d'Arménie,,13001
+11 Rue Fontaine d'Arménie 13001,,,,11,Rue Fontaine d'Arménie,Marseille,
+11 Rue Fontaine d'Arménie,5.374893,43.299415,,11,Rue Fontaine d'Arménie,,13001
+35 Rue du Panier Marseille,,,,35,Rue du Panier,,13002
+35 Rue du Panier 13002,,,,35,Rue du Panier,Marseille,
+35 Rue du Panier,5.367604,43.299366,,35,Rue du Panier,,13002
+9 Rue de Versailles Marseille,,,,9,Rue de Versailles,,13003
+9 Rue de Versailles 13003,,,,9,Rue de Versailles,Marseille,
+9 Rue de Versailles,5.375093,43.310709,,9,Rue de Versailles,,13003
+2 Rue Tournon Marseille,,,,2,Rue Tournon,,13004
+2 Rue Tournon 13004,,,,2,Rue Tournon,Marseille,
+2 Rue Tournon,5.4048,43.302731,,2,Rue Tournon,,13004
+10 Rue de Verdun Marseille,,,,10,Rue de Verdun,,13005
+10 Rue de Verdun 13005,,,,10,Rue de Verdun,Marseille,
+10 Rue de Verdun,5.395718,43.296491,,10,Rue de Verdun,,13005
+5 Impasse Saint-Domingue Marseille,,,,5,Impasse Saint-Domingue,,13006
+5 Impasse Saint-Domingue 13006,,,,5,Impasse Saint-Domingue,Marseille,
+5 Impasse Saint-Domingue,5.374039,43.281652,,5,Impasse Saint-Domingue,,13006
+9 Rue Notre-Dame des Grâces Marseille,,,,9,Rue Notre-Dame des Grâces,,13007
+9 Rue Notre-Dame des Grâces 13007,,,,9,Rue Notre-Dame des Grâces,Marseille,
+9 Rue Notre-Dame des Grâces,5.348567,43.280428,,9,Rue Notre-Dame des Grâces,,13007
+7 Rue Jean Alcazar Marseille,,,,7,Rue Jean Alcazar,,13008
+7 Rue Jean Alcazar 13008,,,,7,Rue Jean Alcazar,Marseille,
+7 Rue Jean Alcazar,5.391744,43.279568,,7,Rue Jean Alcazar,,13008
+44 Avenue Desautel Marseille,,,,44,Avenue Desautel,,13009
+44 Avenue Desautel 13009,,,,44,Avenue Desautel,Marseille,
+44 Avenue Desautel,5.407131,43.254766,,44,Avenue Desautel,,13009
+138 Rue François Mauriac Marseille,,,,138,Rue François Mauriac,,13010
+138 Rue François Mauriac 13010,,,,138,Rue François Mauriac,Marseille,
+138 Rue François Mauriac,5.423724,43.269851,,138,Rue François Mauriac,,13010
+11 Impasse du Cordeau Marseille,,,,11,Impasse du Cordeau,,13011
+11 Impasse du Cordeau 13011,,,,11,Impasse du Cordeau,Marseille,
+11 Impasse du Cordeau,5.46085,43.293026,,11,Impasse du Cordeau,,13011
+9 Lotissement Le Domaine des Faïenciers Marseille,,,,9,Lotissement Le Domaine des Faïenciers,,13011
+9 Lotissement Le Domaine des Faïenciers 13011,,,,9,Lotissement Le Domaine des Faïenciers,Marseille,
+9 Lotissement Le Domaine des Faïenciers,5.4298,43.293113,,9,Lotissement Le Domaine des Faïenciers,,13011
+31 Boulevard Henri Fabre Marseille,,,,31,Boulevard Henri Fabre,,13012
+31 Boulevard Henri Fabre 13012,,,,31,Boulevard Henri Fabre,Marseille,
+31 Boulevard Henri Fabre,5.416035,43.307605,,31,Boulevard Henri Fabre,,13012
+179 Avenue du 24 Avril 1915 Marseille,,,,179,Avenue du 24 Avril 1915,,13012
+179 Avenue du 24 Avril 1915 13012,,,,179,Avenue du 24 Avril 1915,Marseille,
+179 Avenue du 24 Avril 1915,5.43874,43.308772,,179,Avenue du 24 Avril 1915,,13012
+4 Boulevard Michel Marseille,,,,4,Boulevard Michel,,13013
+4 Boulevard Michel 13013,,,,4,Boulevard Michel,Marseille,
+4 Boulevard Michel,5.410359,43.320262,,4,Boulevard Michel,,13013
+19 Impasse du Bois-Chenu Marseille,,,,19,Impasse du Bois-Chenu,,13014
+19 Impasse du Bois-Chenu 13014,,,,19,Impasse du Bois-Chenu,Marseille,
+19 Impasse du Bois-Chenu,5.400304,43.341514,,19,Impasse du Bois-Chenu,,13014
+26 Boulevard Bech Marseille,,,,26,Boulevard Bech,,13015
+26 Boulevard Bech 13015,,,,26,Boulevard Bech,Marseille,
+26 Boulevard Bech,5.363367,43.363386,,26,Boulevard Bech,,13015
+15 Boulevard Paumont Marseille,,,,15,Boulevard Paumont,,13015
+15 Boulevard Paumont 13015,,,,15,Boulevard Paumont,Marseille,
+15 Boulevard Paumont,5.351411,43.340284,,15,Boulevard Paumont,,13015
+52 Chemin du Passet Marseille,,,,52,Chemin du Passet,,13016
+52 Chemin du Passet 13016,,,,52,Chemin du Passet,Marseille,
+52 Chemin du Passet,5.335897,43.360764,,52,Chemin du Passet,,13016
+332 Chemin No 126 du Bourneou Le Beausset,,,,332,Chemin No 126 du Bourneou,,83330
+332 Chemin No 126 du Bourneou 83330,,,,332,Chemin No 126 du Bourneou,Le Beausset,
+332 Chemin No 126 du Bourneou,5.811577,43.2086,,332,Chemin No 126 du Bourneou,,83330
+15 Chemin des Restanques Bormes-les-Mimosas,,,,15,Chemin des Restanques,,83230
+15 Chemin des Restanques 83230,,,,15,Chemin des Restanques,Bormes-les-Mimosas,
+15 Chemin des Restanques,6.356603,43.141732,,15,Chemin des Restanques,,83230
+5 Avenue des Pins Carqueiranne,,,,5,Avenue des Pins,,83320
+5 Avenue des Pins 83320,,,,5,Avenue des Pins,Carqueiranne,
+5 Avenue des Pins,6.072952,43.102472,,5,Avenue des Pins,,83320
+14 Lotissement Bois Fleuri Cogolin,,,,14,Lotissement Bois Fleuri,,83310
+14 Lotissement Bois Fleuri 83310,,,,14,Lotissement Bois Fleuri,Cogolin,
+14 Lotissement Bois Fleuri,6.524936,43.238195,,14,Lotissement Bois Fleuri,,83310
+302 Rue du Thym La Crau,,,,302,Rue du Thym,,83260
+302 Rue du Thym 83260,,,,302,Rue du Thym,La Crau,
+302 Rue du Thym,6.076723,43.119725,,302,Rue du Thym,,83260
+684 Avenue de Grasse Draguignan,,,,684,Avenue de Grasse,,83300
+684 Avenue de Grasse 83300,,,,684,Avenue de Grasse,Draguignan,
+684 Avenue de Grasse,6.474148,43.538038,,684,Avenue de Grasse,,83300
+5 Impasse Ventre La Farlède,,,,5,Impasse Ventre,,83210
+5 Impasse Ventre 83210,,,,5,Impasse Ventre,La Farlède,
+5 Impasse Ventre,6.046754,43.171436,,5,Impasse Ventre,,83210
+74 Allée de la Cigale d'Or Fréjus,,,,74,Allée de la Cigale d'Or,,83600
+74 Allée de la Cigale d'Or 83600,,,,74,Allée de la Cigale d'Or,Fréjus,
+74 Allée de la Cigale d'Or,6.727121,43.44917,,74,Allée de la Cigale d'Or,,83600
+465 Rue du Pas de la Cèpe Fréjus,,,,465,Rue du Pas de la Cèpe,,83600
+465 Rue du Pas de la Cèpe 83600,,,,465,Rue du Pas de la Cèpe,Fréjus,
+465 Rue du Pas de la Cèpe,6.874097,43.52045,,465,Rue du Pas de la Cèpe,,83600
+4 Rue du Lot Domaine des Pins La Garde,,,,4,Rue du Lot Domaine des Pins,,83130
+4 Rue du Lot Domaine des Pins 83130,,,,4,Rue du Lot Domaine des Pins,La Garde,
+4 Rue du Lot Domaine des Pins,6.00134,43.116684,,4,Rue du Lot Domaine des Pins,,83130
+14 Allée Auréa Hyères,,,,14,Allée Auréa,,83400
+14 Allée Auréa 83400,,,,14,Allée Auréa,Hyères,
+14 Allée Auréa,6.14466,43.116093,,14,Allée Auréa,,83400
+21 Rue Marc Riché Hyères,,,,21,Rue Marc Riché,,83400
+21 Rue Marc Riché 83400,,,,21,Rue Marc Riché,Hyères,
+21 Rue Marc Riché,6.115726,43.103108,,21,Rue Marc Riché,,83400
+6108 Impasse du Rossignol Le Lavandou,,,,6108,Impasse du Rossignol,,83980
+6108 Impasse du Rossignol 83980,,,,6108,Impasse du Rossignol,Le Lavandou,
+6108 Impasse du Rossignol,6.416059,43.150385,,6108,Impasse du Rossignol,,83980
+288 Chemin du Pas de l'Ave Lorgues,,,,288,Chemin du Pas de l'Ave,,83510
+288 Chemin du Pas de l'Ave 83510,,,,288,Chemin du Pas de l'Ave,Lorgues,
+288 Chemin du Pas de l'Ave,6.326831,43.484272,,288,Chemin du Pas de l'Ave,,83510
+899 Chemin des Rouvières Le Muy,,,,899,Chemin des Rouvières,,83490
+899 Chemin des Rouvières 83490,,,,899,Chemin des Rouvières,Le Muy,
+899 Chemin des Rouvières,6.54999,43.484002,,899,Chemin des Rouvières,,83490
+45 Avenue Général Albert Azan Pignans,,,,45,Avenue Général Albert Azan,,83790
+45 Avenue Général Albert Azan 83790,,,,45,Avenue Général Albert Azan,Pignans,
+45 Avenue Général Albert Azan,6.235873,43.304437,,45,Avenue Général Albert Azan,,83790
+52 Traverse du Marché Puget-Ville,,,,52,Traverse du Marché,,83390
+52 Traverse du Marché 83390,,,,52,Traverse du Marché,Puget-Ville,
+52 Traverse du Marché,6.13529,43.288656,,52,Traverse du Marché,,83390
+48 Rue du Nid Au Soleil Roquebrune-sur-Argens,,,,48,Rue du Nid Au Soleil,,83370
+48 Rue du Nid Au Soleil 83370,,,,48,Rue du Nid Au Soleil,Roquebrune-sur-Argens,
+48 Rue du Nid Au Soleil,6.714635,43.35073,,48,Rue du Nid Au Soleil,,83370
+6 Boulevard des Cades Sainte-Maxime,,,,6,Boulevard des Cades,,83120
+6 Boulevard des Cades 83120,,,,6,Boulevard des Cades,Sainte-Maxime,
+6 Boulevard des Cades,6.643041,43.316052,,6,Boulevard des Cades,,83120
+453 Chemin du Petit Recours Saint-Maximin-la-Sainte-Baume,,,,453,Chemin du Petit Recours,,83470
+453 Chemin du Petit Recours 83470,,,,453,Chemin du Petit Recours,Saint-Maximin-la-Sainte-Baume,
+453 Chemin du Petit Recours,5.850618,43.437391,,453,Chemin du Petit Recours,,83470
+829 Boulevard Jean Georges Branché Saint-Raphaël,,,,829,Boulevard Jean Georges Branché,,83530
+829 Boulevard Jean Georges Branché 83530,,,,829,Boulevard Jean Georges Branché,Saint-Raphaël,
+829 Boulevard Jean Georges Branché,6.924382,43.478576,,829,Boulevard Jean Georges Branché,,83530
+21 Boulevard Bernard Palissy Saint-Zacharie,,,,21,Boulevard Bernard Palissy,,83640
+21 Boulevard Bernard Palissy 83640,,,,21,Boulevard Bernard Palissy,Saint-Zacharie,
+21 Boulevard Bernard Palissy,5.70833,43.384033,,21,Boulevard Bernard Palissy,,83640
+345 Avenue Auguste Renoir La Seyne-sur-Mer,,,,345,Avenue Auguste Renoir,,83500
+345 Avenue Auguste Renoir 83500,,,,345,Avenue Auguste Renoir,La Seyne-sur-Mer,
+345 Avenue Auguste Renoir,5.868262,43.08575,,345,Avenue Auguste Renoir,,83500
+54 Rue Louis Blanqui La Seyne-sur-Mer,,,,54,Rue Louis Blanqui,,83500
+54 Rue Louis Blanqui 83500,,,,54,Rue Louis Blanqui,La Seyne-sur-Mer,
+54 Rue Louis Blanqui,5.881829,43.099435,,54,Rue Louis Blanqui,,83500
+109 Impasse des Faisses Six-Fours-les-Plages,,,,109,Impasse des Faisses,,83140
+109 Impasse des Faisses 83140,,,,109,Impasse des Faisses,Six-Fours-les-Plages,
+109 Impasse des Faisses,5.813487,43.078865,,109,Impasse des Faisses,,83140
+387 Chemin des Andués Solliès-Pont,,,,387,Chemin des Andués,,83210
+387 Chemin des Andués 83210,,,,387,Chemin des Andués,Solliès-Pont,
+387 Chemin des Andués,6.050041,43.197059,,387,Chemin des Andués,,83210
+111 Hameau Les Camails Le Thoronet,,,,111,Hameau Les Camails,,83340
+111 Hameau Les Camails 83340,,,,111,Hameau Les Camails,Le Thoronet,
+111 Hameau Les Camails,6.261667,43.475218,,111,Hameau Les Camails,,83340
+593 Chemin du Collet de Saint-Pièrre Toulon,,,,593,Chemin du Collet de Saint-Pièrre,,83100
+593 Chemin du Collet de Saint-Pièrre 83100,,,,593,Chemin du Collet de Saint-Pièrre,Toulon,
+593 Chemin du Collet de Saint-Pièrre,5.912041,43.160528,,593,Chemin du Collet de Saint-Pièrre,,83100
+64 Avenue Georges Clemenceau Toulon,,,,64,Avenue Georges Clemenceau,,83100
+64 Avenue Georges Clemenceau 83100,,,,64,Avenue Georges Clemenceau,Toulon,
+64 Avenue Georges Clemenceau,5.937206,43.123403,,64,Avenue Georges Clemenceau,,83100
+18 Rue Masséna Toulon,,,,18,Rue Masséna,,83100
+18 Rue Masséna 83100,,,,18,Rue Masséna,Toulon,
+18 Rue Masséna,5.935369,43.110195,,18,Rue Masséna,,83100
+85 Rue Santa Lucia Toulon,,,,85,Rue Santa Lucia,,83100
+85 Rue Santa Lucia 83100,,,,85,Rue Santa Lucia,Toulon,
+85 Rue Santa Lucia,5.896875,43.146111,,85,Rue Santa Lucia,,83100
+78 Traverse du Pinson La Valette-du-Var,,,,78,Traverse du Pinson,,83160
+78 Traverse du Pinson 83160,,,,78,Traverse du Pinson,La Valette-du-Var,
+78 Traverse du Pinson,5.987031,43.154275,,78,Traverse du Pinson,,83160
+15 Chemin des Aubépines Saint-Mandrier-sur-Mer,,,,15,Chemin des Aubépines,,83430
+15 Chemin des Aubépines 83430,,,,15,Chemin des Aubépines,Saint-Mandrier-sur-Mer,
+15 Chemin des Aubépines,5.924359,43.075482,,15,Chemin des Aubépines,,83430
+5 Rue Alfred Bergier Mft Avignon,,,,5,Rue Alfred Bergier Mft,,84140
+5 Rue Alfred Bergier Mft 84140,,,,5,Rue Alfred Bergier Mft,Avignon,
+5 Rue Alfred Bergier Mft,4.875017,43.939148,,5,Rue Alfred Bergier Mft,,84140
+31 Rue Diane de Poitiers Avignon,,,,31,Rue Diane de Poitiers,,84140
+31 Rue Diane de Poitiers 84140,,,,31,Rue Diane de Poitiers,Avignon,
+31 Rue Diane de Poitiers,4.822552,43.928334,,31,Rue Diane de Poitiers,,84140
+7 Rue Ledru Rollin Avignon,,,,7,Rue Ledru Rollin,,84140
+7 Rue Ledru Rollin 84140,,,,7,Rue Ledru Rollin,Avignon,
+7 Rue Ledru Rollin,4.812372,43.950804,,7,Rue Ledru Rollin,,84140
+10 Rue du Portail Boquier Avignon,,,,10,Rue du Portail Boquier,,84140
+10 Rue du Portail Boquier 84140,,,,10,Rue du Portail Boquier,Avignon,
+10 Rue du Portail Boquier,4.804947,43.944583,,10,Rue du Portail Boquier,,84140
+75 Chemin de la Bindonne Bédarrides,,,,75,Chemin de la Bindonne,,84370
+75 Chemin de la Bindonne 84370,,,,75,Chemin de la Bindonne,Bédarrides,
+75 Chemin de la Bindonne,4.937503,44.057071,,75,Chemin de la Bindonne,,84370
+601 Chemin de la Prefferance Bollène,,,,601,Chemin de la Prefferance,,84500
+601 Chemin de la Prefferance 84500,,,,601,Chemin de la Prefferance,Bollène,
+601 Chemin de la Prefferance,4.712632,44.277966,,601,Chemin de la Prefferance,,84500
+52BIS Chemin de l'Aqueduc Carpentras,,,,52BIS,Chemin de l'Aqueduc,,84200
+52BIS Chemin de l'Aqueduc 84200,,,,52BIS,Chemin de l'Aqueduc,Carpentras,
+52BIS Chemin de l'Aqueduc,5.058438,44.064902,,52BIS,Chemin de l'Aqueduc,,84200
+195 Boulevard du Nord Carpentras,,,,195,Boulevard du Nord,,84200
+195 Boulevard du Nord 84200,,,,195,Boulevard du Nord,Carpentras,
+195 Boulevard du Nord,5.048548,44.057651,,195,Boulevard du Nord,,84200
+6 Domaine de la Noyeraie Caumont-sur-Durance,,,,6,Domaine de la Noyeraie,,84510
+6 Domaine de la Noyeraie 84510,,,,6,Domaine de la Noyeraie,Caumont-sur-Durance,
+6 Domaine de la Noyeraie,4.952233,43.895967,,6,Domaine de la Noyeraie,,84510
+2634 Chemin Romieu Cavaillon,,,,2634,Chemin Romieu,,84300
+2634 Chemin Romieu 84300,,,,2634,Chemin Romieu,Cavaillon,
+2634 Chemin Romieu,5.05286,43.874299,,2634,Chemin Romieu,,84300
+80 Allée Raimbaud d'Orange Courthézon,,,,80,Allée Raimbaud d'Orange,,84350
+80 Allée Raimbaud d'Orange 84350,,,,80,Allée Raimbaud d'Orange,Courthézon,
+80 Allée Raimbaud d'Orange,4.879376,44.089706,,80,Allée Raimbaud d'Orange,,84350
+578 Cours René Char L'Isle-sur-la-Sorgue,,,,578,Cours René Char,,84800
+578 Cours René Char 84800,,,,578,Cours René Char,L'Isle-sur-la-Sorgue,
+578 Cours René Char,5.054979,43.913808,,578,Cours René Char,,84800
+9 Lotissement Les Peupliers L'Isle-sur-la-Sorgue,,,,9,Lotissement Les Peupliers,,84800
+9 Lotissement Les Peupliers 84800,,,,9,Lotissement Les Peupliers,L'Isle-sur-la-Sorgue,
+9 Lotissement Les Peupliers,5.046234,43.93158,,9,Lotissement Les Peupliers,,84800
+246 Chemin de Tinargue Malemort-du-Comtat,,,,246,Chemin de Tinargue,,84570
+246 Chemin de Tinargue 84570,,,,246,Chemin de Tinargue,Malemort-du-Comtat,
+246 Chemin de Tinargue,5.166013,44.021273,,246,Chemin de Tinargue,,84570
+8 Impasse Louis Giraud Monteux,,,,8,Impasse Louis Giraud,,84170
+8 Impasse Louis Giraud 84170,,,,8,Impasse Louis Giraud,Monteux,
+8 Impasse Louis Giraud,5.003113,44.034636,,8,Impasse Louis Giraud,,84170
+99 Chemin des Peyrollets Mormoiron,,,,99,Chemin des Peyrollets,,84570
+99 Chemin des Peyrollets 84570,,,,99,Chemin des Peyrollets,Mormoiron,
+99 Chemin des Peyrollets,5.185432,44.066491,,99,Chemin des Peyrollets,,84570
+169 Avenue Général Raymond Lorho Orange,,,,169,Avenue Général Raymond Lorho,,84100
+169 Avenue Général Raymond Lorho 84100,,,,169,Avenue Général Raymond Lorho,Orange,
+169 Avenue Général Raymond Lorho,4.819466,44.134117,,169,Avenue Général Raymond Lorho,,84100
+53 Clos Saint-Jacques Orange,,,,53,Clos Saint-Jacques,,84100
+53 Clos Saint-Jacques 84100,,,,53,Clos Saint-Jacques,Orange,
+53 Clos Saint-Jacques,4.824597,44.12111,,53,Clos Saint-Jacques,,84100
+18 Rue Grande Pertuis,,,,18,Rue Grande,,84120
+18 Rue Grande 84120,,,,18,Rue Grande,Pertuis,
+18 Rue Grande,5.502976,43.694931,,18,Rue Grande,,84120
+39 Avenue de Provence Piolenc,,,,39,Avenue de Provence,,84420
+39 Avenue de Provence 84420,,,,39,Avenue de Provence,Piolenc,
+39 Avenue de Provence,4.761619,44.175499,,39,Avenue de Provence,,84420
+133 Chemin de Canfier Robion,,,,133,Chemin de Canfier,,84440
+133 Chemin de Canfier 84440,,,,133,Chemin de Canfier,Robion,
+133 Chemin de Canfier,5.107585,43.848871,,133,Chemin de Canfier,,84440
+12 Impasse des Troènes Saint-Saturnin-lès-Avignon,,,,12,Impasse des Troènes,,84450
+12 Impasse des Troènes 84450,,,,12,Impasse des Troènes,Saint-Saturnin-lès-Avignon,
+12 Impasse des Troènes,4.935709,43.958471,,12,Impasse des Troènes,,84450
+274C Rue Marius Chastel Sorgues,,,,274C,Rue Marius Chastel,,84700
+274C Rue Marius Chastel 84700,,,,274C,Rue Marius Chastel,Sorgues,
+274C Rue Marius Chastel,4.881426,44.009981,,274C,Rue Marius Chastel,,84700
+490 Chemin Vieux Le Thor,,,,490,Chemin Vieux,,84250
+490 Chemin Vieux 84250,,,,490,Chemin Vieux,Le Thor,
+490 Chemin Vieux,4.988444,43.925977,,490,Chemin Vieux,,84250
+40 Cours Tivoli Valréas,,,,40,Cours Tivoli,,84600
+40 Cours Tivoli 84600,,,,40,Cours Tivoli,Valréas,
+40 Cours Tivoli,4.993043,44.382437,,40,Cours Tivoli,,84600
+6059 Rue des Vautes Velleron,,,,6059,Rue des Vautes,,84740
+6059 Rue des Vautes 84740,,,,6059,Rue des Vautes,Velleron,
+6059 Rue des Vautes,5.031515,43.956557,,6059,Rue des Vautes,,84740

--- a/geocoder_tester/world/france/rhonealpes/test_addresses.csv
+++ b/geocoder_tester/world/france/rhonealpes/test_addresses.csv
@@ -1,654 +1,654 @@
-query,lon,lat,limit,expected_name,expected_housenumber,expected_street,expected_city,expected_postcode
-71 Rue du Midi Arbignieu,,,,71 Rue du Midi,,,,01300
-71 Rue du Midi 01300,,,,71 Rue du Midi,,,,01300
-71 Rue du Midi,5.651220,45.727888,,71 Rue du Midi,,,,01300
-3 Lotissement des Bruyères Béligneux,,,,3 Lotissement des Bruyères,,,,01360
-3 Lotissement des Bruyères 01360,,,,3 Lotissement des Bruyères,,,Béligneux,
-3 Lotissement des Bruyères,5.119688,45.849975,,3 Lotissement des Bruyères,,,,01360
-2 Lotissement les Barronnières Beynost,,,,2 Lotissement les Barronnières,,,,01700
-2 Lotissement les Barronnières 01700,,,,2 Lotissement les Barronnières,,,Beynost,
-2 Lotissement les Barronnières,5.009839,45.834903,,2 Lotissement les Barronnières,,,,01700
-18 Avenue de Jasseron Bourg-en-Bresse,,,,18 Avenue de Jasseron,,,,01000
-18 Avenue de Jasseron 01000,,,,18 Avenue de Jasseron,,,Bourg-en-Bresse,
-18 Avenue de Jasseron,5.245963,46.211275,,18 Avenue de Jasseron,,,,01000
-13 Rue de la Cité Briord,,,,13 Rue de la Cité,,,,01470
-13 Rue de la Cité 01470,,,,13 Rue de la Cité,,,Briord,
-13 Rue de la Cité,5.453720,45.789074,,13 Rue de la Cité,,,,01470
-1BIS Chemin de la Vie du Bois Château-Gaillard,,,,1BIS Chemin de la Vie du Bois,,,,01500
-1BIS Chemin de la Vie du Bois 01500,,,,1BIS Chemin de la Vie du Bois,,,Château-Gaillard,
-1BIS Chemin de la Vie du Bois,5.326293,45.958574,,1BIS Chemin de la Vie du Bois,,,,01500
-104 Route de la Buissonnière Condeissiat,,,,104 Route de la Buissonnière,,,,01400
-104 Route de la Buissonnière 01400,,,,104 Route de la Buissonnière,,,Condeissiat,
-104 Route de la Buissonnière,5.083460,46.158620,,104 Route de la Buissonnière,,,,01400
-170 Chemin des Aranyes Divonne-les-Bains,,,,170 Chemin des Aranyes,,,,01220
-170 Chemin des Aranyes 01220,,,,170 Chemin des Aranyes,,,Divonne-les-Bains,
-170 Chemin des Aranyes,6.132675,46.362707,,170 Chemin des Aranyes,,,,01220
-17 Chemin des Jargilières Ferney-Voltaire,,,,17 Chemin des Jargilières,,,,01210
-17 Chemin des Jargilières 01210,,,,17 Chemin des Jargilières,,,Ferney-Voltaire,
-17 Chemin des Jargilières,6.115320,46.254142,,17 Chemin des Jargilières,,,,01210
-337 Grand-Rue Grilly,,,,337 Grand-Rue,,,,01220
-337 Grand-Rue 01220,,,,337 Grand-Rue,,,Grilly,
-337 Grand-Rue,6.118239,46.329142,,337 Grand-Rue,,,,01220
-150 Place du Platre Jujurieux,,,,150 Place du Platre,,,,01640
-150 Place du Platre 01640,,,,150 Place du Platre,,,Jujurieux,
-150 Place du Platre,5.430910,46.047761,,150 Place du Platre,,,,01640
-317 Rue de la Gare Massieux,,,,317 Rue de la Gare,,,,01600
-317 Rue de la Gare 01600,,,,317 Rue de la Gare,,,Massieux,
-317 Rue de la Gare,4.819576,45.906150,,317 Rue de la Gare,,,,01600
-71 Impasse des Berlie Miribel,,,,71 Impasse des Berlie,,,,01700
-71 Impasse des Berlie 01700,,,,71 Impasse des Berlie,,,Miribel,
-71 Impasse des Berlie,4.961274,45.828364,,71 Impasse des Berlie,,,,01700
-1 Chemin des Muriers Montmerle-sur-Saône,,,,1 Chemin des Muriers,,,,01090
-1 Chemin des Muriers 01090,,,,1 Chemin des Muriers,,,Montmerle-sur-Saône,
-1 Chemin des Muriers,4.763544,46.076027,,1 Chemin des Muriers,,,,01090
-303 Rue des Hautains de la Crotte Ornex,,,,303 Rue des Hautains de la Crotte,,,,01210
-303 Rue des Hautains de la Crotte 01210,,,,303 Rue des Hautains de la Crotte,,,Ornex,
-303 Rue des Hautains de la Crotte,6.101622,46.270873,,303 Rue des Hautains de la Crotte,,,,01210
-32 Impasse sous Millier Parves,,,,32 Impasse sous Millier,,,,01300
-32 Impasse sous Millier 01300,,,,32 Impasse sous Millier,,,Parves,
-32 Impasse sous Millier,5.733193,45.741999,,32 Impasse sous Millier,,,,01300
-74 Chemin des Pruniers Pougny,,,,74 Chemin des Pruniers,,,,01550
-74 Chemin des Pruniers 01550,,,,74 Chemin des Pruniers,,,Pougny,
-74 Chemin des Pruniers,5.953276,46.136237,,74 Chemin des Pruniers,,,,01550
-13 Impasse de la Grange Raclet Saint-André-de-Corcy,,,,13 Impasse de la Grange Raclet,,,,01390
-13 Impasse de la Grange Raclet 01390,,,,13 Impasse de la Grange Raclet,,,Saint-André-de-Corcy,
-13 Impasse de la Grange Raclet,4.952409,45.935141,,13 Impasse de la Grange Raclet,,,,01390
-499 Lotissement Les Fayettes Saint-Didier-de-Formans,,,,499 Lotissement Les Fayettes,,,,01600
-499 Lotissement Les Fayettes 01600,,,,499 Lotissement Les Fayettes,,,Saint-Didier-de-Formans,
-499 Lotissement Les Fayettes,4.773252,45.954384,,499 Lotissement Les Fayettes,,,,01600
-13 Grande Rue des Brovonnes Saint-Marcel,,,,13 Grande Rue des Brovonnes,,,,01390
-13 Grande Rue des Brovonnes 01390,,,,13 Grande Rue des Brovonnes,,,Saint-Marcel,
-13 Grande Rue des Brovonnes,4.983415,45.952445,,13 Grande Rue des Brovonnes,,,,01390
-4 Impasse des Chênes Samognat,,,,4 Impasse des Chênes,,,,01580
-4 Impasse des Chênes 01580,,,,4 Impasse des Chênes,,,Samognat,
-4 Impasse des Chênes,5.570487,46.249293,,4 Impasse des Chênes,,,,01580
-655 Rue de Fenières Thoiry,,,,655 Rue de Fenières,,,,01710
-655 Rue de Fenières 01710,,,,655 Rue de Fenières,,,Thoiry,
-655 Rue de Fenières,5.969659,46.225401,,655 Rue de Fenières,,,,01710
-23 Chemin de la Fruitière Versonnex,,,,23 Chemin de la Fruitière,,,,01210
-23 Chemin de la Fruitière 01210,,,,23 Chemin de la Fruitière,,,Versonnex,
-23 Chemin de la Fruitière,6.096438,46.303280,,23 Chemin de la Fruitière,,,,01210
-124 Allée des Ecluses Viriat,,,,124 Allée des Ecluses,,,,01440
-124 Allée des Ecluses 01440,,,,124 Allée des Ecluses,,,Viriat,
-124 Allée des Ecluses,5.213705,46.217523,,124 Allée des Ecluses,,,,01440
-30 Boulevard Gambetta Aubenas,,,,30 Boulevard Gambetta,,,,07200
-30 Boulevard Gambetta 07200,,,,30 Boulevard Gambetta,,,Aubenas,
-30 Boulevard Gambetta,4.390374,44.619548,,30 Boulevard Gambetta,,,,07200
-4 Lotissement Les Oliviers Charmes-sur-Rhône,,,,4 Lotissement Les Oliviers,,,,07800
-4 Lotissement Les Oliviers 07800,,,,4 Lotissement Les Oliviers,,,Charmes-sur-Rhône,
-4 Lotissement Les Oliviers,4.838387,44.864818,,4 Lotissement Les Oliviers,,,,07800
-5 Rue Victor Hugo Cruas,,,,5 Rue Victor Hugo,,,,07350
-5 Rue Victor Hugo 07350,,,,5 Rue Victor Hugo,,,Cruas,
-5 Rue Victor Hugo,4.775005,44.662054,,5 Rue Victor Hugo,,,,07350
-6 Route Nationale Labégude,,,,6 Route Nationale,,,,07200
-6 Route Nationale 07200,,,,6 Route Nationale,,,Labégude,
-6 Route Nationale,4.364493,44.649574,,6 Route Nationale,,,,07200
-83A Route d'Aubenas Privas,,,,83A Route d'Aubenas,,,,07000
-83A Route d'Aubenas 07000,,,,83A Route d'Aubenas,,,Privas,
-83A Route d'Aubenas,4.575742,44.729159,,83A Route d'Aubenas,,,,07000
-175 Route de la Mairie Saint-Désirat,,,,175 Route de la Mairie,,,,07340
-175 Route de la Mairie 07340,,,,175 Route de la Mairie,,,Saint-Désirat,
-175 Route de la Mairie,4.785556,45.254270,,175 Route de la Mairie,,,,07340
-22 Allée du Plantier Saint-Péray,,,,22 Allée du Plantier,,,,07130
-22 Allée du Plantier 07130,,,,22 Allée du Plantier,,,Saint-Péray,
-22 Allée du Plantier,4.847865,44.948976,,22 Allée du Plantier,,,,07130
-39 Chemin des Helviens Le Teil,,,,39 Chemin des Helviens,,,,07400
-39 Chemin des Helviens 07400,,,,39 Chemin des Helviens,,,Le Teil,
-39 Chemin des Helviens,4.662550,44.549280,,39 Chemin des Helviens,,,,07400
-38TER Rue des Luettes Tournon-sur-Rhône,,,,38TER Rue des Luettes,,,,07300
-38TER Rue des Luettes 07300,,,,38TER Rue des Luettes,,,Tournon-sur-Rhône,
-38TER Rue des Luettes,4.843824,45.057647,,38TER Rue des Luettes,,,,07300
-21 Chemin de Barulas Viviers,,,,21 Chemin de Barulas,,,,07220
-21 Chemin de Barulas 07220,,,,21 Chemin de Barulas,,,Viviers,
-21 Chemin de Barulas,4.682277,44.483215,,21 Chemin de Barulas,,,,07220
-5 Lotissement Le Point du Jour Beauvallon,,,,5 Lotissement Le Point du Jour,,,,26800
-5 Lotissement Le Point du Jour 26800,,,,5 Lotissement Le Point du Jour,,,Beauvallon,
-5 Lotissement Le Point du Jour,4.915161,44.855969,,5 Lotissement Le Point du Jour,,,,26800
-682 Route des Gamelles Bourg-lès-Valence,,,,682 Route des Gamelles,,,,26500
-682 Route des Gamelles 26500,,,,682 Route des Gamelles,,,Bourg-lès-Valence,
-682 Route des Gamelles,4.898542,44.968199,,682 Route des Gamelles,,,,26500
-9 Allée des Vignes Chabeuil,,,,9 Allée des Vignes,,,,26120
-9 Allée des Vignes 26120,,,,9 Allée des Vignes,,,Chabeuil,
-9 Allée des Vignes,5.012226,44.903936,,9 Allée des Vignes,,,,26120
-15 Rue du Lieutenant Michel Prunet Crest,,,,15 Rue du Lieutenant Michel Prunet,,,,26400
-15 Rue du Lieutenant Michel Prunet 26400,,,,15 Rue du Lieutenant Michel Prunet,,,Crest,
-15 Rue du Lieutenant Michel Prunet,5.008723,44.733202,,15 Rue du Lieutenant Michel Prunet,,,,26400
-6236 Rue du Huit Mai 1945 Étoile-sur-Rhône,,,,6236 Rue du 8 Mai 1945,,,,26800
-6236 Rue du Huit Mai 1945 26800,,,,6236 Rue du 8 Mai 1945,,,Étoile-sur-Rhône,
-6236 Rue du Huit Mai 1945,4.896874,44.836841,,6236 Rue du 8 Mai 1945,,,,26800
-28 Rue des Clots Loriol-sur-Drôme,,,,28 Rue des Clots,,,,26270
-28 Rue des Clots 26270,,,,28 Rue des Clots,,,Loriol-sur-Drôme,
-28 Rue des Clots,4.830877,44.764844,,28 Rue des Clots,,,,26270
-115 Rue du Boulanger Mirmande,,,,115 Rue du Boulanger,,,,26270
-115 Rue du Boulanger 26270,,,,115 Rue du Boulanger,,,Mirmande,
-115 Rue du Boulanger,4.834896,44.698695,,115 Rue du Boulanger,,,,26270
-21 Rue Georges Brassens Montélimar,,,,21 Rue Georges Brassens,,,,26200
-21 Rue Georges Brassens 26200,,,,21 Rue Georges Brassens,,,Montélimar,
-21 Rue Georges Brassens,4.755610,44.576516,,21 Rue Georges Brassens,,,,26200
-14 Vieille Route du Teil Montélimar,,,,14 Vieille Route du Teil,,,,26200
-14 Vieille Route du Teil 26200,,,,14 Vieille Route du Teil,,,Montélimar,
-14 Vieille Route du Teil,4.731572,44.558359,,14 Vieille Route du Teil,,,,26200
-5 Allée Charles Gounod Pierrelatte,,,,5 Allée Charles Gounod,,,,26700
-5 Allée Charles Gounod 26700,,,,5 Allée Charles Gounod,,,Pierrelatte,
-5 Allée Charles Gounod,4.694689,44.365609,,5 Allée Charles Gounod,,,,26700
-15 Rue Victor Hugo Portes-lès-Valence,,,,15 Rue Victor Hugo,,,,26800
-15 Rue Victor Hugo 26800,,,,15 Rue Victor Hugo,,,Portes-lès-Valence,
-15 Rue Victor Hugo,4.878442,44.869579,,15 Rue Victor Hugo,,,,26800
-12 Rue Gaillard Romans-sur-Isère,,,,12 Rue Gaillard,,,,26100
-12 Rue Gaillard 26100,,,,12 Rue Gaillard,,,Romans-sur-Isère,
-12 Rue Gaillard,5.047856,45.046710,,12 Rue Gaillard,,,,26100
-55 Allée des Peupliers Saint-Barthélemy-de-Vals,,,,55 Allée des Peupliers,,,,26240
-55 Allée des Peupliers 26240,,,,55 Allée des Peupliers,,,Saint-Barthélemy-de-Vals,
-55 Allée des Peupliers,4.866406,45.172857,,55 Allée des Peupliers,,,,26240
-1BIS Rue de la Pousterle Saint-Paul-Trois-Châteaux,,,,1BIS Rue de la Pousterle,,,,26130
-1BIS Rue de la Pousterle 26130,,,,1BIS Rue de la Pousterle,,,Saint-Paul-Trois-Châteaux,
-1BIS Rue de la Pousterle,4.769158,44.350009,,1BIS Rue de la Pousterle,,,,26130
-275 Impasse des Genêts Suze-la-Rousse,,,,275 Impasse des Genêts,,,,26790
-275 Impasse des Genêts 26790,,,,275 Impasse des Genêts,,,Suze-la-Rousse,
-275 Impasse des Genêts,4.836092,44.297845,,275 Impasse des Genêts,,,,26790
-22 Rue Colette Valence,,,,22 Rue Colette,,,,26000
-22 Rue Colette 26000,,,,22 Rue Colette,,,Valence,
-22 Rue Colette,4.881536,44.908171,,22 Rue Colette,,,,26000
-1 Rue du Maréchal Foch Valence,,,,1 Rue du Maréchal Foch,,,,26000
-1 Rue du Maréchal Foch 26000,,,,1 Rue du Maréchal Foch,,,Valence,
-1 Rue du Maréchal Foch,4.901738,44.937949,,1 Rue du Maréchal Foch,,,,26000
-5 Chemin des Grands Blancs Gervans,,,,5 Chemin des Grands Blancs,,,,26600
-5 Chemin des Grands Blancs 26600,,,,5 Chemin des Grands Blancs,,,Gervans,
-5 Chemin des Grands Blancs,4.831904,45.113003,,5 Chemin des Grands Blancs,,,,26600
-13 Rue de Gasavignard Assieu,,,,13 Rue de Gasavignard,,,,38150
-13 Rue de Gasavignard 38150,,,,13 Rue de Gasavignard,,,Assieu,
-13 Rue de Gasavignard,4.860239,45.406170,,13 Rue de Gasavignard,,,,38150
-36 Chemin du Gurdin La Bâtie-Montgascon,,,,36 Chemin du Gurdin,,,,38110
-36 Chemin du Gurdin 38110,,,,36 Chemin du Gurdin,,,La Bâtie-Montgascon,
-36 Chemin du Gurdin,5.533308,45.569391,,36 Chemin du Gurdin,,,,38110
-3 Lotissement des Mésanges Biviers,,,,3 Lotissement des Mésanges,,,,38330
-3 Lotissement des Mésanges 38330,,,,3 Lotissement des Mésanges,,,Biviers,
-3 Lotissement des Mésanges,5.804175,45.233897,,3 Lotissement des Mésanges,,,,38330
-14 Rue des Pâquerettes Bourgoin-Jallieu,,,,14 Rue des Pâquerettes,,,,38300
-14 Rue des Pâquerettes 38300,,,,14 Rue des Pâquerettes,,,Bourgoin-Jallieu,
-14 Rue des Pâquerettes,5.283596,45.593782,,14 Rue des Pâquerettes,,,,38300
-25 Chemin de Pévrin Cessieu,,,,25 Chemin de Pévrin,,,,38110
-25 Chemin de Pévrin 38110,,,,25 Chemin de Pévrin,,,Cessieu,
-25 Chemin de Pévrin,5.407829,45.568561,,25 Chemin de Pévrin,,,,38110
-129 Chemin du Granjon Charantonnay,,,,129 Chemin du Granjon,,,,38790
-129 Chemin du Granjon 38790,,,,129 Chemin du Granjon,,,Charantonnay,
-129 Chemin du Granjon,5.106241,45.538471,,129 Chemin du Granjon,,,,38790
-34 Rue du Château Chavanoz,,,,34 Rue du Château,,,,38230
-34 Rue du Château 38230,,,,34 Rue du Château,,,Chavanoz,
-34 Rue du Château,5.167467,45.777709,,34 Rue du Château,,,,38230
-4 Allée Montaler Claix,,,,4 Allée Montaler,,,,38640
-4 Allée Montaler 38640,,,,4 Allée Montaler,,,Claix,
-4 Allée Montaler,5.670668,45.130661,,4 Allée Montaler,,,,38640
-19 Rue des Remparts La Côte-Saint-André,,,,19 Rue des Remparts,,,,38260
-19 Rue des Remparts 38260,,,,19 Rue des Remparts,,,La Côte-Saint-André,
-19 Rue des Remparts,5.259863,45.395187,,19 Rue des Remparts,,,,38260
-17 Avenue des Fleurs Diémoz,,,,17 Avenue des Fleurs,,,,38790
-17 Avenue des Fleurs 38790,,,,17 Avenue des Fleurs,,,Diémoz,
-17 Avenue des Fleurs,5.093148,45.588669,,17 Avenue des Fleurs,,,,38790
-36 Rue Jean Moulin Échirolles,,,,36 Rue Jean Moulin,,,,38130
-36 Rue Jean Moulin 38130,,,,36 Rue Jean Moulin,,,Échirolles,
-36 Rue Jean Moulin,5.698649,45.142399,,36 Rue Jean Moulin,,,,38130
-331 Chemin sous l'École Faverges-de-la-Tour,,,,331 Chemin sous l'École,,,,38110
-331 Chemin sous l'École 38110,,,,331 Chemin sous l'École,,,Faverges-de-la-Tour,
-331 Chemin sous l'École,5.502051,45.595432,,331 Chemin sous l'École,,,,38110
-40 Rue du Docteur Ludovic Klein Froges,,,,40 Rue du Docteur Ludovic Klein,,,,38190
-40 Rue du Docteur Ludovic Klein 38190,,,,40 Rue du Docteur Ludovic Klein,,,Froges,
-40 Rue du Docteur Ludovic Klein,5.920758,45.277324,,40 Rue du Docteur Ludovic Klein,,,,38190
-11 Avenue Albert 1er de Belgique Grenoble,,,,11 Avenue Albert 1er de Belgique,,,,38000
-11 Avenue Albert 1er de Belgique 38000,,,,11 Avenue Albert 1er de Belgique,,,Grenoble,
-11 Avenue Albert 1er de Belgique,5.732519,45.181713,,11 Avenue Albert 1er de Belgique,,,,38000
-1 Chemin de Gordes Grenoble,,,,1 Chemin de Gordes,,,,38000
-1 Chemin de Gordes 38000,,,,1 Chemin de Gordes,,,Grenoble,
-1 Chemin de Gordes,5.732519,45.175525,,1 Chemin de Gordes,,,,38000
-6 Rue Prosper Mérimée Grenoble,,,,6 Rue Prosper Mérimée,,,,38000
-6 Rue Prosper Mérimée 38000,,,,6 Rue Prosper Mérimée,,,Grenoble,
-6 Rue Prosper Mérimée,5.728118,45.172884,,6 Rue Prosper Mérimée,,,,38000
-51 Avenue de Murcia L'Isle-d'Abeau,,,,51 Avenue de Murcia,,,,38080
-51 Avenue de Murcia 38080,,,,51 Avenue de Murcia,,,L'Isle-d'Abeau,
-51 Avenue de Murcia,5.248591,45.619333,,51 Avenue de Murcia,,,,38080
-2527 Route de Saint-Germain Luzinay,,,,2527 Route de Saint-Germain,,,,38200
-2527 Route de Saint-Germain 38200,,,,2527 Route de Saint-Germain,,,Luzinay,
-2527 Route de Saint-Germain,4.981570,45.599532,,2527 Route de Saint-Germain,,,,38200
-133 Rue Grande Rue Monestier-de-Clermont,,,,133 Rue Grande Rue,,,,38650
-133 Rue Grande Rue 38650,,,,133 Rue Grande Rue,,,Monestier-de-Clermont,
-133 Rue Grande Rue,5.634036,44.915516,,133 Rue Grande Rue,,,,38650
-20 Route du Grand Prè La Motte-d'Aveillans,,,,20 Route du Grand Prè,,,,38770
-20 Route du Grand Prè 38770,,,,20 Route du Grand Prè,,,La Motte-d'Aveillans,
-20 Route du Grand Prè,5.731757,44.960157,,20 Route du Grand Prè,,,,38770
-106 Rue du Maupas Noyarey,,,,106 Rue du Maupas,,,,38360
-106 Rue du Maupas 38360,,,,106 Rue du Maupas,,,Noyarey,
-106 Rue du Maupas,5.631349,45.244027,,106 Rue du Maupas,,,,38360
-523 Route de Brésin Le Pin,,,,523 Route de Brésin,,,,38730
-523 Route de Brésin 38730,,,,523 Route de Brésin,,,,38730
-523 Route de Brésin,5.517661,45.468200,,523 Route de Brésin,,,,38730
-6 Rue du Canal du Drac Le Pont-de-Claix,,,,6 Rue du Canal du Drac,,,,38800
-6 Rue du Canal du Drac 38800,,,,6 Rue du Canal du Drac,,,Le Pont-de-Claix,
-6 Rue du Canal du Drac,5.696753,45.124476,,6 Rue du Canal du Drac,,,,38800
-987 Chemin du Priolaz Romagnieu,,,,987 Chemin de Priolaz,,,,38480
-987 Chemin du Priolaz 38480,,,,987 Chemin de Priolaz,,,Romagnieu,
-987 Chemin du Priolaz,5.616106,45.553830,,987 Chemin de Priolaz,,,,38480
-23 Rue Pasteur Saint-André-le-Gaz,,,,23 Rue Pasteur,,,,38490
-23 Rue Pasteur 38490,,,,23 Rue Pasteur,,,Saint-André-le-Gaz,
-23 Rue Pasteur,5.527340,45.543927,,23 Rue Pasteur,,,,38490
-74 Route de Ferrossière Saint-Didier-de-la-Tour,,,,74 Route de Ferrossière,,,,38110
-74 Route de Ferrossière 38110,,,,74 Route de Ferrossière,,,Saint-Didier-de-la-Tour,
-74 Route de Ferrossière,5.468255,45.559857,,74 Route de Ferrossière,,,,38110
-7 Rue Joseph Servanin Saint-Georges-d'Espéranche,,,,7 Rue Joseph Servanin,,,,38790
-7 Rue Joseph Servanin 38790,,,,7 Rue Joseph Servanin,,,Saint-Georges-d'Espéranche,
-7 Rue Joseph Servanin,5.077563,45.560161,,7 Rue Joseph Servanin,,,,38790
-19 Rue Charles Berty Saint-Laurent-du-Pont,,,,19 Rue Charles Berty,,,,38380
-19 Rue Charles Berty 38380,,,,19 Rue Charles Berty,,,Saint-Laurent-du-Pont,
-19 Rue Charles Berty,5.731019,45.389024,,19 Rue Charles Berty,,,,38380
-17 Rue Jacques Anquetil Saint-Martin-d'Hères,,,,17 Rue Jacques Anquetil,,,,38400
-17 Rue Jacques Anquetil 38400,,,,17 Rue Jacques Anquetil,,,Saint-Martin-d'Hères,
-17 Rue Jacques Anquetil,5.753371,45.171806,,17 Rue Jacques Anquetil,,,,38400
-243 Chemin du Brinchet Saint-Nazaire-les-Eymes,,,,243 Chemin du Brinchet,,,,38330
-243 Chemin du Brinchet 38330,,,,243 Chemin du Brinchet,,,Saint-Nazaire-les-Eymes,
-243 Chemin du Brinchet,5.852739,45.253718,,243 Chemin du Brinchet,,,,38330
-90 Route de Barens Saint-Romain-de-Jalionas,,,,90 Route de Barens,,,,38460
-90 Route de Barens 38460,,,,90 Route de Barens,,,Saint-Romain-de-Jalionas,
-90 Route de Barens,5.213390,45.737810,,90 Route de Barens,,,,38460
-12B Rue Jean Rostand Salaise-sur-Sanne,,,,12B Rue Jean Rostand,,,,38150
-12B Rue Jean Rostand 38150,,,,12B Rue Jean Rostand,,,Salaise-sur-Sanne,
-12B Rue Jean Rostand,4.810286,45.345459,,12B Rue Jean Rostand,,,,38150
-28 Rue des Murailles Seyssinet-Pariset,,,,28 Rue des Murailles,,,,38180
-28 Rue des Murailles 38180,,,,28 Rue des Murailles,,,Seyssinet-Pariset,
-28 Rue des Murailles,5.690661,45.179447,,28 Rue des Murailles,,,,38180
-595 Chemin de l'Étang Berger Thodure,,,,595 Chemin de l'Étang Berger,,,,38260
-595 Chemin de l'Étang Berger 38260,,,,595 Chemin de l'Étang Berger,,,Thodure,
-595 Chemin de l'Étang Berger,5.140099,45.311305,,595 Chemin de l'Étang Berger,,,,38260
-44 Avenue de la Gare Tullins,,,,44 Avenue de la Gare,,,,38210
-44 Avenue de la Gare 38210,,,,44 Avenue de la Gare,,,Tullins,
-44 Avenue de la Gare,5.488241,45.300807,,44 Avenue de la Gare,,,,38210
-48BIS Chemin de l'Eau Vernioz,,,,48BIS Chemin de l'Eau,,,,38150
-48BIS Chemin de l'Eau 38150,,,,48BIS Chemin de l'Eau,,,Vernioz,
-48BIS Chemin de l'Eau,4.877780,45.426346,,48BIS Chemin de l'Eau,,,,38150
-30 Rue Bartholdi Vienne,,,,30 Rue Auguste Bartholdi,,,,38200
-30 Rue Bartholdi 38200,,,,30 Rue Auguste Bartholdi,,,Vienne,
-30 Rue Bartholdi,4.912712,45.516770,,30 Rue Auguste Bartholdi,,,,38200
-48 Route des Celliers Vif,,,,48 Route des Celliers,,,,38450
-48 Route des Celliers 38450,,,,48 Route des Celliers,,,Vif,
-48 Route des Celliers,5.661361,45.048116,,48 Route des Celliers,,,,38450
-10 Chemin Vert Villard-de-Lans,,,,10 Chemin Vert,,,,38250
-10 Chemin Vert 38250,,,,10 Chemin Vert,,,Villard-de-Lans,
-10 Chemin Vert,5.564280,45.068207,,10 Chemin Vert,,,,38250
-596 Route de Valence Vinay,,,,596 Route de Valence,,,,38470
-596 Route de Valence 38470,,,,596 Route de Valence,,,Vinay,
-596 Route de Valence,5.397078,45.199880,,596 Route de Valence,,,,38470
-6 Place de la République Voiron,,,,6 Place de la République,,,,38500
-6 Place de la République 38500,,,,6 Place de la République,,,Voiron,
-6 Place de la République,5.591458,45.367702,,6 Place de la République,,,,38500
-9 Avenue de Saint-Marcellin Bonson,,,,9 Avenue de Saint-Marcellin,,,,42160
-9 Avenue de Saint-Marcellin 42160,,,,9 Avenue de Saint-Marcellin,,,Bonson,
-9 Avenue de Saint-Marcellin,4.210461,45.520523,,9 Avenue de Saint-Marcellin,,,,42160
-120 Allée de la Chana Champdieu,,,,120 Allée de la Chana,,,,42600
-120 Allée de la Chana 42600,,,,120 Allée de la Chana,,,Champdieu,
-120 Allée de la Chana,4.048975,45.643583,,120 Allée de la Chana,,,,42600
-5 Rue des Lilas Commelle-Vernay,,,,5 Rue des Lilas,,,,42120
-5 Rue des Lilas 42120,,,,5 Rue des Lilas,,,Commelle-Vernay,
-5 Rue des Lilas,4.067571,45.990440,,5 Rue des Lilas,,,,42120
-3 Rue Jean-Marie Nigay Feurs,,,,3 Rue Jean-Marie Nigay,,,,42110
-3 Rue Jean-Marie Nigay 42110,,,,3 Rue Jean-Marie Nigay,,,Feurs,
-3 Rue Jean-Marie Nigay,4.224515,45.742044,,3 Rue Jean-Marie Nigay,,,,42110
-2 Rue Jean Macé Fraisses,,,,2 Rue Jean Macé,,,,42490
-2 Rue Jean Macé 42490,,,,2 Rue Jean Macé,,,Fraisses,
-2 Rue Jean Macé,4.264596,45.387243,,2 Rue Jean Macé,,,,42490
-24 Rue de l'Artisanat Mably,,,,24 Rue de l'Artisanat,,,,42300
-24 Rue de l'Artisanat 42300,,,,24 Rue de l'Artisanat,,,Mably,
-24 Rue de l'Artisanat,4.049330,46.068859,,24 Rue de l'Artisanat,,,,42300
-4BIS Rue des Legouve Montbrison,,,,4BIS Rue des Legouve,,,,42600
-4BIS Rue des Legouve 42600,,,,4BIS Rue des Legouve,,,Montbrison,
-4BIS Rue des Legouve,4.064809,45.606866,,4BIS Rue des Legouve,,,,42600
-48 Place de la Liberté Panissières,,,,48 Place de la Liberté,,,,42360
-48 Place de la Liberté 42360,,,,48 Place de la Liberté,,,Panissières,
-48 Place de la Liberté,4.344788,45.791668,,48 Place de la Liberté,,,,42360
-15 Rue Denfert-Rochereau La Ricamarie,,,,15 Rue Denfert-Rochereau,,,,42150
-15 Rue Denfert-Rochereau 42150,,,,15 Rue Denfert-Rochereau,,,La Ricamarie,
-15 Rue Denfert-Rochereau,4.365803,45.401768,,15 Rue Denfert-Rochereau,,,,42150
-2626 Rue de Saint-Romain Riorges,,,,2626 Rue de Saint-Romain,,,,42153
-2626 Rue de Saint-Romain 42153,,,,2626 Rue de Saint-Romain,,,Riorges,
-2626 Rue de Saint-Romain,4.026861,46.054980,,2626 Rue de Saint-Romain,,,,42153
-2 Rue Bellevue Roanne,,,,2 Rue Bellevue,,,,42300
-2 Rue Bellevue 42300,,,,2 Rue Bellevue,,,Roanne,
-2 Rue Bellevue,4.063596,46.027664,,2 Rue Bellevue,,,,42300
-7 Rue Jules Massenet Roanne,,,,7 Rue Jules Massenet,,,,42300
-7 Rue Jules Massenet 42300,,,,7 Rue Jules Massenet,,,Roanne,
-7 Rue Jules Massenet,4.055731,46.024390,,7 Rue Jules Massenet,,,,42300
-26 Rue Jean Monnet Roche-la-Molière,,,,26 Rue Jean Monnet,,,,42230
-26 Rue Jean Monnet 42230,,,,26 Rue Jean Monnet,,,Roche-la-Molière,
-26 Rue Jean Monnet,4.313609,45.435683,,26 Rue Jean Monnet,,,,42230
-79 Route de la Chabure Saint-Chamond,,,,79 Route de la Chabure,,,,42400
-79 Route de la Chabure 42400,,,,79 Route de la Chabure,,,Saint-Chamond,
-79 Route de la Chabure,4.485001,45.450912,,79 Route de la Chabure,,,,42400
-1 Rue du Soleil Levant Saint-Christo-en-Jarez,,,,1 Rue du Soleil Levant,,,,42320
-1 Rue du Soleil Levant 42320,,,,1 Rue du Soleil Levant,,,Saint-Christo-en-Jarez,
-1 Rue du Soleil Levant,4.486989,45.545133,,1 Rue du Soleil Levant,,,,42320
-18 Rue de Chavassieux Saint-Étienne,,,,18 Rue de Chavassieux,,,,42100
-18 Rue de Chavassieux 42100,,,,18 Rue de Chavassieux,,,Saint-Étienne,
-18 Rue de Chavassieux,4.368271,45.445876,,18 Rue de Chavassieux,,,,42100
-6 Passage du Gazomêtre Saint-Étienne,,,,6 Passage du Gazomètre,,,,42100
-6 Passage du Gazomêtre 42100,,,,6 Passage du Gazomètre,,,Saint-Étienne,
-6 Passage du Gazomêtre,4.439609,45.434532,,6 Passage du Gazomètre,,,,42100
-104 Rue de la Montat Saint-Étienne,,,,104 Rue de la Montat,,,,42100
-104 Rue de la Montat 42100,,,,104 Rue de la Montat,,,Saint-Étienne,
-104 Rue de la Montat,4.411026,45.442595,,104 Rue de la Montat,,,,42100
-18 Rue de Tardy Saint-Étienne,,,,18 Rue de Tardy,,,,42100
-18 Rue de Tardy 42100,,,,18 Rue de Tardy,,,Saint-Étienne,
-18 Rue de Tardy,4.384639,45.427799,,18 Rue de Tardy,,,,42100
-375 Route du Mont du Feu Genilac,,,,375 Route du Mont du Feu,,,,42800
-375 Route du Mont du Feu 42800,,,,375 Route du Mont du Feu,,,Genilac,
-375 Route du Mont du Feu,4.583861,45.526417,,375 Route du Mont du Feu,,,,42800
-2 Route des Cités Saint-Julien-la-Vêtre,,,,2 Route des Cités,,,,42440
-2 Route des Cités 42440,,,,2 Route des Cités,,,Saint-Julien-la-Vêtre,
-2 Route des Cités,3.824623,45.813799,,2 Route des Cités,,,,42440
-50 Rue de la Plagne Saint-Paul-en-Jarez,,,,50 Rue de la Plagne,,,,42740
-50 Rue de la Plagne 42740,,,,50 Rue de la Plagne,,,Saint-Paul-en-Jarez,
-50 Rue de la Plagne,4.575049,45.481849,,50 Rue de la Plagne,,,,42740
-27 Route de Saint-Côme Saint-Just-Saint-Rambert,,,,27 Route de Saint-Côme,,,,42170
-27 Route de Saint-Côme 42170,,,,27 Route de Saint-Côme,,,Saint-Just-Saint-Rambert,
-27 Route de Saint-Côme,4.239280,45.505083,,27 Route de Saint-Côme,,,,42170
-5 Rue Auguste Barret Sury-le-Comtal,,,,5 Rue Auguste Barret,,,,42450
-5 Rue Auguste Barret 42450,,,,5 Rue Auguste Barret,,,Sury-le-Comtal,
-5 Rue Auguste Barret,4.184336,45.540943,,5 Rue Auguste Barret,,,,42450
-4 Impasse Jean Zay Unieux,,,,4 Impasse Jean Zay,,,,42240
-4 Impasse Jean Zay 42240,,,,4 Impasse Jean Zay,,,Unieux,
-4 Impasse Jean Zay,4.277781,45.395143,,4 Impasse Jean Zay,,,,42240
-25 Rue des Cotes du Vernois Villerest,,,,25 Rue des Cotes du Vernois,,,,42300
-25 Rue des Cotes du Vernois 42300,,,,25 Rue des Cotes du Vernois,,,Villerest,
-25 Rue des Cotes du Vernois,4.043665,46.021085,,25 Rue des Cotes du Vernois,,,,42300
-493 Avenue du Champ d'Asile L'Arbresle,,,,493 Avenue du Champ d'Asile,,,,69210
-493 Avenue du Champ d'Asile 69210,,,,493 Avenue du Champ d'Asile,,,L'Arbresle,
-493 Avenue du Champ d'Asile,4.602992,45.833977,,493 Avenue du Champ d'Asile,,,,69210
-24 Place du Marché Bessenay,,,,24 Place du Marché,,,,69690
-24 Place du Marché 69690,,,,24 Place du Marché,,,Bessenay,
-24 Place du Marché,4.553018,45.776179,,24 Place du Marché,,,,69690
-153 Route du Pont de Chêne Brindas,,,,153 Route du Pont de Chêne,,,,69126
-153 Route du Pont de Chêne 69126,,,,153 Route du Pont de Chêne,,,Brindas,
-153 Route du Pont de Chêne,4.732078,45.723409,,153 Route du Pont de Chêne,,,,69126
-40 Chemin de la Vie Guerse Bron,,,,40 Chemin de la Vie Guerse,,,,69500
-40 Chemin de la Vie Guerse 69500,,,,40 Chemin de la Vie Guerse,,,Bron,
-40 Chemin de la Vie Guerse,4.933654,45.740700,,40 Chemin de la Vie Guerse,,,,69500
-16B Rue de la Tarentaise Caluire-et-Cuire,,,,16B Rue de la Tarentaise,,,,69300
-16B Rue de la Tarentaise 69300,,,,16B Rue de la Tarentaise,,,Caluire-et-Cuire,
-16B Rue de la Tarentaise,4.823688,45.785788,,16B Rue de la Tarentaise,,,,69300
-21 Chemin des Cailloux Charly,,,,21 Chemin des Cailloux,,,,69390
-21 Chemin des Cailloux 69390,,,,21 Chemin des Cailloux,,,Charly,
-21 Chemin des Cailloux,4.785364,45.654203,,21 Chemin des Cailloux,,,,69390
-2 Chemin des Prés Secs Civrieux-d'Azergues,,,,2 Chemin des Prés Secs,,,,69380
-2 Chemin des Prés Secs 69380,,,,2 Chemin des Prés Secs,,,Civrieux-d'Azergues,
-2 Chemin des Prés Secs,4.703734,45.856237,,2 Chemin des Prés Secs,,,,69380
-102 Avenue Pierre Dumond Craponne,,,,102 Avenue Pierre Dumond,,,,69290
-102 Avenue Pierre Dumond 69290,,,,102 Avenue Pierre Dumond,,,Craponne,
-102 Avenue Pierre Dumond,4.721378,45.747416,,102 Avenue Pierre Dumond,,,,69290
-678 Rue des Rivetières Dracé,,,,678 Rue des Rivetières,,,,69220
-678 Rue des Rivetières 69220,,,,678 Rue des Rivetières,,,Dracé,
-678 Rue des Rivetières,4.760704,46.155751,,678 Rue des Rivetières,,,,69220
-33 Chemin de Montgay Fontaines-sur-Saône,,,,33 Chemin de Montgay,,,,69270
-33 Chemin de Montgay 69270,,,,33 Chemin de Montgay,,,Fontaines-sur-Saône,
-33 Chemin de Montgay,4.861090,45.831976,,33 Chemin de Montgay,,,,69270
-6 Chemin de la Perle Givors,,,,6 Chemin de la Perle,,,,69700
-6 Chemin de la Perle 69700,,,,6 Chemin de la Perle,,,Givors,
-6 Chemin de la Perle,4.750301,45.580299,,6 Chemin de la Perle,,,,69700
-9 Rue Marcel Paul Grigny,,,,9 Rue Marcel Paul,,,,69520
-9 Rue Marcel Paul 69520,,,,9 Rue Marcel Paul,,,Grigny,
-9 Rue Marcel Paul,4.781991,45.607959,,9 Rue Marcel Paul,,,,69520
-33 Domaine de l'Étang Lentilly,,,,33 Domaine de l'Étang,,,,69210
-33 Domaine de l'Étang 69210,,,,33 Domaine de l'Étang,,,Lentilly,
-33 Domaine de l'Étang,4.671859,45.819288,,33 Domaine de l'Étang,,,,69210
-150 Chemin du Bois Don Lozanne,,,,150 Chemin du Bois Don,,,,69380
-150 Chemin du Bois Don 69380,,,,150 Chemin du Bois Don,,,Lozanne,
-150 Chemin du Bois Don,4.688746,45.864026,,150 Chemin du Bois Don,,,,69380
-390 Chemin des Trois Bois Morancé,,,,390 Chemin des Trois Bois,,,,69480
-390 Chemin des Trois Bois 69480,,,,390 Chemin des Trois Bois,,,Morancé,
-390 Chemin des Trois Bois,4.707248,45.890011,,390 Chemin des Trois Bois,,,,69480
-12 Rue Fernand Forest Oullins,,,,12 Rue Fernand Forest,,,,69600
-12 Rue Fernand Forest 69600,,,,12 Rue Fernand Forest,,,Oullins,
-12 Rue Fernand Forest,4.803198,45.722023,,12 Rue Fernand Forest,,,,69600
-366 Chemin du Paradis Pommiers,,,,366 Chemin du Paradis,,,,69480
-366 Chemin du Paradis 69480,,,,366 Chemin du Paradis,,,Pommiers,
-366 Chemin du Paradis,4.681926,45.966464,,366 Chemin du Paradis,,,,69480
-9 Rue des Roches Sourcieux-les-Mines,,,,9 Rue des Roches,,,,69210
-9 Rue des Roches 69210,,,,9 Rue des Roches,,,Sourcieux-les-Mines,
-9 Rue des Roches,4.629770,45.799167,,9 Rue des Roches,,,,69210
-265 Rue des Guérins Saint-Didier-sur-Beaujeu,,,,265 Rue des Guérins,,,,69430
-265 Rue des Guérins 69430,,,,265 Rue des Guérins,,,Saint-Didier-sur-Beaujeu,
-265 Rue des Guérins,4.565371,46.164203,,265 Rue des Guérins,,,,69430
-21 Rue du Neyrard Sainte-Foy-lès-Lyon,,,,21 Rue du Neyrard,,,,69110
-21 Rue du Neyrard 69110,,,,21 Rue du Neyrard,,,Sainte-Foy-lès-Lyon,
-21 Rue du Neyrard,4.801978,45.734129,,21 Rue du Neyrard,,,,69110
-26 Rue du Cornet Saint-Genis-les-Ollières,,,,26 Rue du Cornet,,,,69290
-26 Rue du Cornet 69290,,,,26 Rue du Cornet,,,Saint-Genis-les-Ollières,
-26 Rue du Cornet,4.721758,45.755684,,26 Rue du Cornet,,,,69290
-663 Route des Brouilly Saint-Lager,,,,663 Route des Brouilly,,,,69220
-663 Route des Brouilly 69220,,,,663 Route des Brouilly,,,Saint-Lager,
-663 Route des Brouilly,4.672601,46.111487,,663 Route des Brouilly,,,,69220
-73 Impasse des Maraichers Taponas,,,,73 Impasse des Maraîchers,,,,69220
-73 Impasse des Maraichers 69220,,,,73 Impasse des Maraîchers,,,Taponas,
-73 Impasse des Maraichers,4.753904,46.113933,,73 Impasse des Maraîchers,,,,69220
-40 Avenue de la République Tassin-la-Demi-Lune,,,,40 Avenue de la République,,,,69160
-40 Avenue de la République 69160,,,,40 Avenue de la République,,,Tassin-la-Demi-Lune,
-40 Avenue de la République,4.780399,45.764062,,40 Avenue de la République,,,,69160
-25B Rue Balland Vaulx-en-Velin,,,,25B Rue Balland,,,,69120
-25B Rue Balland 69120,,,,25B Rue Balland,,,Vaulx-en-Velin,
-25B Rue Balland,4.907498,45.773664,,25B Rue Balland,,,,69120
-36 Rue Victor Hugo Vaulx-en-Velin,,,,36 Rue Victor Hugo,,,,69120
-36 Rue Victor Hugo 69120,,,,36 Rue Victor Hugo,,,Vaulx-en-Velin,
-36 Rue Victor Hugo,4.923935,45.785912,,36 Rue Victor Hugo,,,,69120
-24 Rue Pierre Dupont Vénissieux,,,,24 Rue Pierre Dupont,,,,69200
-24 Rue Pierre Dupont 69200,,,,24 Rue Pierre Dupont,,,Vénissieux,
-24 Rue Pierre Dupont,4.870589,45.695952,,24 Rue Pierre Dupont,,,,69200
-35 Rue Hector Berlioz Villefranche-sur-Saône,,,,35 Rue Hector Berlioz,,,,69400
-35 Rue Hector Berlioz 69400,,,,35 Rue Hector Berlioz,,,Villefranche-sur-Saône,
-35 Rue Hector Berlioz,4.721373,45.980203,,35 Rue Hector Berlioz,,,,69400
-22 Rue Raspail Villeurbanne,,,,22 Rue Raspail,,,,69100
-22 Rue Raspail 69100,,,,22 Rue Raspail,,,Villeurbanne,
-22 Rue Raspail,4.882217,45.773359,,22 Rue Raspail,,,,69100
-38 Rue Jean-Claude Vivant Villeurbanne,,,,38 Rue Jean-Claude Vivant,,,,69100
-38 Rue Jean-Claude Vivant 69100,,,,38 Rue Jean-Claude Vivant,,,Villeurbanne,
-38 Rue Jean-Claude Vivant,4.868025,45.768635,,38 Rue Jean-Claude Vivant,,,,69100
-100 Cours Tolstoï Villeurbanne,,,,100 Cours Tolstoï,,,,69100
-100 Cours Tolstoï 69100,,,,100 Cours Tolstoï,,,Villeurbanne,
-100 Cours Tolstoï,4.879328,45.762315,,100 Cours Tolstoï,,,,69100
-68 Avenue du Progrès Chassieu,,,,68 Avenue du Progrès,,,,69680
-68 Avenue du Progrès 69680,,,,68 Avenue du Progrès,,,Chassieu,
-68 Avenue du Progrès,4.963698,45.730519,,68 Avenue du Progrès,,,,69680
-16 Rue Anatole France Décines-Charpieu,,,,16 Rue Anatole France,,,,69150
-16 Rue Anatole France 69150,,,,16 Rue Anatole France,,,Décines-Charpieu,
-16 Rue Anatole France,4.951930,45.771300,,16 Rue Anatole France,,,,69150
-17 Rue d'Auvergne Feyzin,,,,17 Rue d'Auvergne,,,,69320
-17 Rue d'Auvergne 69320,,,,17 Rue d'Auvergne,,,Feyzin,
-17 Rue d'Auvergne,4.860090,45.664058,,17 Rue d'Auvergne,,,,69320
-1 Impasse Pierre Dupont Genas,,,,1 Impasse Pierre Dupont,,,,69740
-1 Impasse Pierre Dupont 69740,,,,1 Impasse Pierre Dupont,,,Genas,
-1 Impasse Pierre Dupont,5.000590,45.722506,,1 Impasse Pierre Dupont,,,,69740
-42 Rue Armand Salacrou Meyzieu,,,,42 Rue Armand Salacrou,,,,69330
-42 Rue Armand Salacrou 69330,,,,42 Rue Armand Salacrou,,,Meyzieu,
-42 Rue Armand Salacrou,4.999610,45.785047,,42 Rue Armand Salacrou,,,,69330
-8 Rue Marivaux Meyzieu,,,,8 Rue Marivaux,,,,69330
-8 Rue Marivaux 69330,,,,8 Rue Marivaux,,,Meyzieu,
-8 Rue Marivaux,4.987752,45.771953,,8 Rue Marivaux,,,,69330
-3 Rue Joliot-Curie Mions,,,,3 Rue Joliot-Curie,,,,69780
-3 Rue Joliot-Curie 69780,,,,3 Rue Joliot-Curie,,,Mions,
-3 Rue Joliot-Curie,4.945128,45.680533,,3 Rue Joliot-Curie,,,,69780
-15 Allée des Cavaliers Rillieux-la-Pape,,,,15 Allée des Cavaliers,,,,69140
-15 Allée des Cavaliers 69140,,,,15 Allée des Cavaliers,,,Rillieux-la-Pape,
-15 Allée des Cavaliers,4.888308,45.818904,,15 Allée des Cavaliers,,,,69140
-23 Chemin de Quincieu Saint-Bonnet-de-Mure,,,,23 Chemin de Quincieu,,,,69720
-23 Chemin de Quincieu 69720,,,,23 Chemin de Quincieu,,,Saint-Bonnet-de-Mure,
-23 Chemin de Quincieu,5.036118,45.704843,,23 Chemin de Quincieu,,,,69720
-10 2e Avenue Saint-Priest,,,,10 2e Avenue,,,,69800
-10 2e Avenue 69800,,,,10 2e Avenue,,,Saint-Priest,
-10 2e Avenue,4.898453,45.702513,,10 2e Avenue,,,,69800
-39 Rue Centrale Saint-Symphorien-d'Ozon,,,,39 Rue Centrale,,,,69360
-39 Rue Centrale 69360,,,,39 Rue Centrale,,,Saint-Symphorien-d'Ozon,
-39 Rue Centrale,4.855765,45.633635,,39 Rue Centrale,,,,69360
-5 Chemin de Papillon Ternay,,,,5 Chemin de Papillon,,,,69360
-5 Chemin de Papillon 69360,,,,5 Chemin de Papillon,,,Ternay,
-5 Chemin de Papillon,4.801087,45.596221,,5 Chemin de Papillon,,,,69360
-2 Rue Childebert Lyon,,,,2 Rue Childebert,,,,69002
-2 Rue Childebert 69002,,,,2 Rue Childebert,,,Lyon,
-2 Rue Childebert,4.834232,45.760219,,2 Rue Childebert,,,,69002
-23 Rue François Villon Lyon,,,,23 Rue François Villon,,,,69003
-23 Rue François Villon 69003,,,,23 Rue François Villon,,,Lyon,
-23 Rue François Villon,4.890268,45.742610,,23 Rue François Villon,,,,69003
-51 Rue Deleuvre Lyon,,,,51 Rue Deleuvre,,,,69004
-51 Rue Deleuvre 69004,,,,51 Rue Deleuvre,,,Lyon,
-51 Rue Deleuvre,4.825272,45.780077,,51 Rue Deleuvre,,,,69004
-32 Rue Tramassac Lyon,,,,32 Rue Tramassac,,,,69005
-32 Rue Tramassac 69005,,,,32 Rue Tramassac,,,Lyon,
-32 Rue Tramassac,4.825515,45.760464,,32 Rue Tramassac,,,,69005
-60 Cours Gambetta Lyon,,,,60 Cours Gambetta,,,,69007
-60 Cours Gambetta 69007,,,,60 Cours Gambetta,,,Lyon,
-60 Cours Gambetta,4.848349,45.753314,,60 Cours Gambetta,,,,69007
-31 Rue Henri Barbusse Lyon,,,,31 Rue Henri Barbusse,,,,69008
-31 Rue Henri Barbusse 69008,,,,31 Rue Henri Barbusse,,,Lyon,
-31 Rue Henri Barbusse,4.856546,45.730484,,31 Rue Henri Barbusse,,,,69008
-21 Rue Jean Zay Lyon,,,,21 Rue Jean Zay,,,,69009
-21 Rue Jean Zay 69009,,,,21 Rue Jean Zay,,,Lyon,
-21 Rue Jean Zay,4.801252,45.766324,,21 Rue Jean Zay,,,,69009
-166 Avenue du Petit Port Aix-les-Bains,,,,166 Avenue du Petit Port,,,,73100
-166 Avenue du Petit Port 73100,,,,166 Avenue du Petit Port,,,Aix-les-Bains,
-166 Avenue du Petit Port,5.896628,45.694642,,166 Avenue du Petit Port,,,,73100
-120 Chemin du Nant Bauchet Arbin,,,,120 Chemin du Nant Bauchet,,,,73800
-120 Chemin du Nant Bauchet 73800,,,,120 Chemin du Nant Bauchet,,,Arbin,
-120 Chemin du Nant Bauchet,6.073832,45.510952,,120 Chemin du Nant Bauchet,,,,73800
-1249 Avenue du Maréchal Leclerc Bourg-Saint-Maurice,,,,1249 Avenue du Maréchal Leclerc,,,,73700
-1249 Avenue du Maréchal Leclerc 73700,,,,1249 Avenue du Maréchal Leclerc,,,Bourg-Saint-Maurice,
-1249 Avenue du Maréchal Leclerc,6.762228,45.609582,,1249 Avenue du Maréchal Leclerc,,,,73700
-35 Rue Émile Combes Chambéry,,,,35 Rue Émile Combes,,,,73000
-35 Rue Émile Combes 73000,,,,35 Rue Émile Combes,,,Chambéry,
-35 Rue Émile Combes,5.918722,45.559311,,35 Rue Émile Combes,,,,73000
-258 Route des Platières La Chavanne,,,,258 Route des Platières,,,,73800
-258 Route des Platières 73800,,,,258 Route des Platières,,,La Chavanne,
-258 Route des Platières,6.071095,45.488933,,258 Route des Platières,,,,73800
-638 Route de Corsuet Grésy-sur-Aix,,,,638 Route de Corsuet,,,,73100
-638 Route de Corsuet 73100,,,,638 Route de Corsuet,,,Grésy-sur-Aix,
-638 Route de Corsuet,5.911992,45.713434,,638 Route de Corsuet,,,,73100
-461 Avenue Alphonse Daudet La Motte-Servolex,,,,461 Avenue Alphonse Daudet,,,,73290
-461 Avenue Alphonse Daudet 73290,,,,461 Avenue Alphonse Daudet,,,La Motte-Servolex,
-461 Avenue Alphonse Daudet,5.873360,45.587883,,461 Avenue Alphonse Daudet,,,,73290
-5 Rue Amélie Gex La Ravoire,,,,5 Rue Amélie Gex,,,,73490
-5 Rue Amélie Gex 73490,,,,5 Rue Amélie Gex,,,La Ravoire,
-5 Rue Amélie Gex,5.958842,45.553969,,5 Rue Amélie Gex,,,,73490
-214A Route du Petit Bois Saint-Genix-sur-Guiers,,,,214A Route du Petit Bois,,,,73240
-214A Route du Petit Bois 73240,,,,214A Route du Petit Bois,,,Saint-Genix-sur-Guiers,
-214A Route du Petit Bois,5.665062,45.586809,,214A Route du Petit Bois,,,,73240
-1540 Route du Grand Village Tours-en-Savoie,,,,1540 Route du Grand Village,,,,73790
-1540 Route du Grand Village 73790,,,,1540 Route du Grand Village,,,Tours-en-Savoie,
-1540 Route du Grand Village,6.441014,45.650407,,1540 Route du Grand Village,,,,73790
-3 Passage des Bains Annecy,,,,3 Passage des Bains,,,,74000
-3 Passage des Bains 74000,,,,3 Passage des Bains,,,Annecy,
-3 Passage des Bains,6.123348,45.899438,,3 Passage des Bains,,,,74000
-12 Chemin de la Thuillere Annecy-le-Vieux,,,,12 Chemin de la Thuillère,,,,74940
-12 Chemin de la Thuillere 74940,,,,12 Chemin de la Thuillère,,,Annecy-le-Vieux,
-12 Chemin de la Thuillere,6.164267,45.922017,,12 Chemin de la Thuillère,,,,74940
-90 Route de Fessy Arenthon,,,,90 Route de Fessy,,,,74800
-90 Route de Fessy 74800,,,,90 Route de Fessy,,,Arenthon,
-90 Route de Fessy,6.339992,46.094066,,90 Route de Fessy,,,,74800
-21 Allée du Clos Meunier Beaumont,,,,21 Allée du Clos Meunier,,,,74160
-21 Allée du Clos Meunier 74160,,,,21 Allée du Clos Meunier,,,Beaumont,
-21 Allée du Clos Meunier,6.113461,46.096284,,21 Allée du Clos Meunier,,,,74160
-103 Rue des Bellossy Bons-en-Chablais,,,,103 Rue des Bellossy,,,,74890
-103 Rue des Bellossy 74890,,,,103 Rue des Bellossy,,,Bons-en-Chablais,
-103 Rue des Bellossy,6.369766,46.262436,,103 Rue des Bellossy,,,,74890
-107 Chemin de Clairmont Chamonix-Mont-Blanc,,,,107 Chemin de Clairmont,,,,74400
-107 Chemin de Clairmont 74400,,,,107 Chemin de Clairmont,,,Chamonix-Mont-Blanc,
-107 Chemin de Clairmont,6.876178,45.937040,,107 Chemin de Clairmont,,,,74400
-1182 Route des Freinets Châtel,,,,1182 Route des Freinets,,,,74390
-1182 Route des Freinets 74390,,,,1182 Route des Freinets,,,Châtel,
-1182 Route des Freinets,6.832309,46.258886,,1182 Route des Freinets,,,,74390
-519 Route du Col de la Croix Fry La Clusaz,,,,519 Route du Col de la Croix Fry,,,,74220
-519 Route du Col de la Croix Fry 74220,,,,519 Route du Col de la Croix Fry,,,La Clusaz,
-519 Route du Col de la Croix Fry,6.436227,45.883470,,519 Route du Col de la Croix Fry,,,,74220
-300 Route de Genève Collonges-sous-Salève,,,,300 Route de Genève,,,,74160
-300 Route de Genève 74160,,,,300 Route de Genève,,,Collonges-sous-Salève,
-300 Route de Genève,6.139224,46.142904,,300 Route de Genève,,,,74160
-107 Route de la Côte La Côte-d'Arbroz,,,,107 Route de la Côte,,,,74110
-107 Route de la Côte 74110,,,,107 Route de la Côte,,,La Côte-d'Arbroz,
-107 Route de la Côte,6.669223,46.188845,,107 Route de la Côte,,,,74110
-735 Route de Burgaz Cuvat,,,,735 Route de Burgaz,,,,74350
-735 Route de Burgaz 74350,,,,735 Route de Burgaz,,,Cuvat,
-735 Route de Burgaz,6.122387,45.979614,,735 Route de Burgaz,,,,74350
-9 Chemin des Contins Droisy,,,,9 Chemin des Contins,,,,74270
-9 Chemin des Contins 74270,,,,9 Chemin des Contins,,,Droisy,
-9 Chemin des Contins,5.882912,45.965051,,9 Chemin des Contins,,,,74270
-1 Rue de la Touvière Évian-les-Bains,,,,1 Rue de la Touvière,,,,74500
-1 Rue de la Touvière 74500,,,,1 Rue de la Touvière,,,Évian-les-Bains,
-1 Rue de la Touvière,6.592183,46.400647,,1 Rue de la Touvière,,,,74500
-831 Route de la Plaine Fillinges,,,,831 Route de la Plaine,,,,74250
-831 Route de la Plaine 74250,,,,831 Route de la Plaine,,,Fillinges,
-831 Route de la Plaine,6.331631,46.162330,,831 Route de la Plaine,,,,74250
-1717 Route du Nant Robert Le Grand-Bornand,,,,1717 Route du Nant Robert,,,,74450
-1717 Route du Nant Robert 74450,,,,1717 Route du Nant Robert,,,Le Grand-Bornand,
-1717 Route du Nant Robert,6.447967,45.943272,,1717 Route du Nant Robert,,,,74450
-422 Route de la Fruitière Lathuile,,,,422 Route de la Fruitière,,,,74210
-422 Route de la Fruitière 74210,,,,422 Route de la Fruitière,,,Lathuile,
-422 Route de la Fruitière,6.203562,45.785647,,422 Route de la Fruitière,,,,74210
-617 Chemin de Montpellaz Manigod,,,,617 Chemin de Montpellaz,,,,74230
-617 Chemin de Montpellaz 74230,,,,617 Chemin de Montpellaz,,,Manigod,
-617 Chemin de Montpellaz,6.385013,45.865319,,617 Chemin de Montpellaz,,,,74230
-139 Chemin de la Perouse Marlioz,,,,139 Chemin de la Perouse,,,,74270
-139 Chemin de la Perouse 74270,,,,139 Chemin de la Perouse,,,Marlioz,
-139 Chemin de la Perouse,6.007836,46.032689,,139 Chemin de la Perouse,,,,74270
-387 Route du Tour Megève,,,,387 Route du Tour,,,,74120
-387 Route du Tour 74120,,,,387 Route du Tour,,,Megève,
-387 Route du Tour,6.630925,45.843684,,387 Route du Tour,,,,74120
-53 Impasse du Four A Pain Minzier,,,,53 Impasse du Four à Pain,,,,74270
-53 Impasse du Four A Pain 74270,,,,53 Impasse du Four à Pain,,,Minzier,
-53 Impasse du Four A Pain,6.000473,46.068079,,53 Impasse du Four à Pain,,,,74270
-7 Impasse des Marais Moye,,,,7 Impasse des Marais,,,,74150
-7 Impasse des Marais 74150,,,,7 Impasse des Marais,,,Moye,
-7 Impasse des Marais,5.892670,45.889787,,7 Impasse des Marais,,,,74150
-1457 Chemin de l'Epagny Passy,,,,1457 Chemin de l'Epagny,,,,74480
-1457 Chemin de l'Epagny 74480,,,,1457 Chemin de l'Epagny,,,Passy,
-1457 Chemin de l'Epagny,6.703829,45.928896,,1457 Chemin de l'Epagny,,,,74480
-181 Route de la Couloute Poisy,,,,181 Route de la Couloute,,,,74330
-181 Route de la Couloute 74330,,,,181 Route de la Couloute,,,Poisy,
-181 Route de la Couloute,6.073276,45.918025,,181 Route de la Couloute,,,,74330
-313 Route de la Biolle Reignier-Ésery,,,,313 Route de la Biolle,,,,74930
-313 Route de la Biolle 74930,,,,313 Route de la Biolle,,,Reignier-Ésery,
-313 Route de la Biolle,6.233814,46.144331,,313 Route de la Biolle,,,,74930
-6 Rue des Pérouses Rumilly,,,,6 Rue des Pérouses,,,,74150
-6 Rue des Pérouses 74150,,,,6 Rue des Pérouses,,,Rumilly,
-6 Rue des Pérouses,5.957252,45.846881,,6 Rue des Pérouses,,,,74150
-33 Impasse des Hochettes Saint-Gervais-les-Bains,,,,33 Impasse des Hochettes,,,,74170
-33 Impasse des Hochettes 74170,,,,33 Impasse des Hochettes,,,Saint-Gervais-les-Bains,
-33 Impasse des Hochettes,6.723384,45.845940,,33 Impasse des Hochettes,,,,74170
-271 Route du Villard Saint-Jorioz,,,,271 Route du Villard,,,,74410
-271 Route du Villard 74410,,,,271 Route du Villard,,,Saint-Jorioz,
-271 Route du Villard,6.165947,45.830889,,271 Route du Villard,,,,74410
-39 Rue des Myosotis Saint-Pierre-en-Faucigny,,,,39 Rue des Myosotis,,,,74800
-39 Rue des Myosotis 74800,,,,39 Rue des Myosotis,,,Saint-Pierre-en-Faucigny,
-39 Rue des Myosotis,6.364174,46.059960,,39 Rue des Myosotis,,,,74800
-70 Rue Clos Tête Noire Sallanches,,,,70 Rue Clos Tête Noire,,,,74700
-70 Rue Clos Tête Noire 74700,,,,70 Rue Clos Tête Noire,,,Sallanches,
-70 Rue Clos Tête Noire,6.641087,45.929202,,70 Rue Clos Tête Noire,,,,74700
-96 Allée des Rosiers Scionzier,,,,96 Allée des Rosiers,,,,74950
-96 Allée des Rosiers 74950,,,,96 Allée des Rosiers,,,Scionzier,
-96 Allée des Rosiers,6.560820,46.057664,,96 Allée des Rosiers,,,,74950
-2249 Route des Combes Seythenex,,,,2249 Route des Combes,,,,74210
-2249 Route des Combes 74210,,,,2249 Route des Combes,,,Seythenex,
-2249 Route des Combes,6.318349,45.712624,,2249 Route des Combes,,,,74210
-4 Rue des Vernaies Thônes,,,,4 Rue des Vernaies,,,,74230
-4 Rue des Vernaies 74230,,,,4 Rue des Vernaies,,,Thônes,
-4 Rue des Vernaies,6.303785,45.893808,,4 Rue des Vernaies,,,,74230
-5 Impasse du Vuard Marchat Thonon-les-Bains,,,,5 Impasse du Vuard Marchat,,,,74200
-5 Impasse du Vuard Marchat 74200,,,,5 Impasse du Vuard Marchat,,,Thonon-les-Bains,
-5 Impasse du Vuard Marchat,6.494475,46.366770,,5 Impasse du Vuard Marchat,,,,74200
-275 Chemin des Verrières Veigy-Foncenex,,,,275 Chemin des Verrières,,,,74140
-275 Chemin des Verrières 74140,,,,275 Chemin des Verrières,,,Veigy-Foncenex,
-275 Chemin des Verrières,6.273185,46.266120,,275 Chemin des Verrières,,,,74140
-11 Rue de Deux Montagnes Québec Ville-la-Grand,,,,11 Rue de Deux Montagnes Québec,,,,74100
-11 Rue de Deux Montagnes Québec 74100,,,,11 Rue de Deux Montagnes Québec,,,Ville-la-Grand,
-11 Rue de Deux Montagnes Québec,6.279359,46.205767,,11 Rue de Deux Montagnes Québec,,,,74100
-1576 Avenue de Savoie Viuz-en-Sallaz,,,,1576 Avenue de Savoie,,,,74250
-1576 Avenue de Savoie 74250,,,,1576 Avenue de Savoie,,,Viuz-en-Sallaz,
-1576 Avenue de Savoie,6.410829,46.152398,,1576 Avenue de Savoie,,,,74250
-26 avenue du maréchal foch Lyon,,,,,26,Avenue Maréchal Foch,Lyon,
- 56 avenue Maréchal de Saxe,,,,,56,Avenue du Maréchal de Saxe,Lyon,
-60 avenue du Maréchal de Saxe,,,,,60,Avenue Maréchal de Saxe,Lyon,
-771 chemin de la Bruyère,4.8649,45.7488,,,,Chemin de la Bruyère,Limonest,
-38 chemin de la Bruyère dardilly,4.7748,45.8055,,,,Chemin de la Bruyère,Dardilly,
-79 cours charlemagne,,,,,,Cours Charlemagne,Lyon,
-"rue du mont d'or Saint-Didier-au-Mont-d'Or",,,,Rue du Mont d'Or,,,Saint-Didier-au-Mont-d'Or,
-"rue du mont d'or Saint cyr",,,,Rue du Mont d'Or,,,Saint-Cyr-au-Mont-d'Or,
+query,lon,lat,limit,expected_housenumber,expected_street,expected_city,expected_postcode
+71 Rue du Midi Arbignieu,,,,71,Rue du Midi,,1300
+71 Rue du Midi 01300,,,,71,Rue du Midi,,1300
+71 Rue du Midi,5.65122,45.727888,,71,Rue du Midi,,1300
+3 Lotissement des Bruyères Béligneux,,,,3,Lotissement des Bruyères,,1360
+3 Lotissement des Bruyères 01360,,,,3,Lotissement des Bruyères,Béligneux,
+3 Lotissement des Bruyères,5.119688,45.849975,,3,Lotissement des Bruyères,,1360
+2 Lotissement les Barronnières Beynost,,,,2,Lotissement les Barronnières,,1700
+2 Lotissement les Barronnières 01700,,,,2,Lotissement les Barronnières,Beynost,
+2 Lotissement les Barronnières,5.009839,45.834903,,2,Lotissement les Barronnières,,1700
+18 Avenue de Jasseron Bourg-en-Bresse,,,,18,Avenue de Jasseron,,1000
+18 Avenue de Jasseron 01000,,,,18,Avenue de Jasseron,Bourg-en-Bresse,
+18 Avenue de Jasseron,5.245963,46.211275,,18,Avenue de Jasseron,,1000
+13 Rue de la Cité Briord,,,,13,Rue de la Cité,,1470
+13 Rue de la Cité 01470,,,,13,Rue de la Cité,Briord,
+13 Rue de la Cité,5.45372,45.789074,,13,Rue de la Cité,,1470
+1BIS Chemin de la Vie du Bois Château-Gaillard,,,,1BIS,Chemin de la Vie du Bois,,1500
+1BIS Chemin de la Vie du Bois 01500,,,,1BIS,Chemin de la Vie du Bois,Château-Gaillard,
+1BIS Chemin de la Vie du Bois,5.326293,45.958574,,1BIS,Chemin de la Vie du Bois,,1500
+104 Route de la Buissonnière Condeissiat,,,,104,Route de la Buissonnière,,1400
+104 Route de la Buissonnière 01400,,,,104,Route de la Buissonnière,Condeissiat,
+104 Route de la Buissonnière,5.08346,46.15862,,104,Route de la Buissonnière,,1400
+170 Chemin des Aranyes Divonne-les-Bains,,,,170,Chemin des Aranyes,,1220
+170 Chemin des Aranyes 01220,,,,170,Chemin des Aranyes,Divonne-les-Bains,
+170 Chemin des Aranyes,6.132675,46.362707,,170,Chemin des Aranyes,,1220
+17 Chemin des Jargilières Ferney-Voltaire,,,,17,Chemin des Jargilières,,1210
+17 Chemin des Jargilières 01210,,,,17,Chemin des Jargilières,Ferney-Voltaire,
+17 Chemin des Jargilières,6.11532,46.254142,,17,Chemin des Jargilières,,1210
+337 Grand-Rue Grilly,,,,337,Grand-Rue,,1220
+337 Grand-Rue 01220,,,,337,Grand-Rue,Grilly,
+337 Grand-Rue,6.118239,46.329142,,337,Grand-Rue,,1220
+150 Place du Platre Jujurieux,,,,150,Place du Platre,,1640
+150 Place du Platre 01640,,,,150,Place du Platre,Jujurieux,
+150 Place du Platre,5.43091,46.047761,,150,Place du Platre,,1640
+317 Rue de la Gare Massieux,,,,317,Rue de la Gare,,1600
+317 Rue de la Gare 01600,,,,317,Rue de la Gare,Massieux,
+317 Rue de la Gare,4.819576,45.90615,,317,Rue de la Gare,,1600
+71 Impasse des Berlie Miribel,,,,71,Impasse des Berlie,,1700
+71 Impasse des Berlie 01700,,,,71,Impasse des Berlie,Miribel,
+71 Impasse des Berlie,4.961274,45.828364,,71,Impasse des Berlie,,1700
+1 Chemin des Muriers Montmerle-sur-Saône,,,,1,Chemin des Muriers,,1090
+1 Chemin des Muriers 01090,,,,1,Chemin des Muriers,Montmerle-sur-Saône,
+1 Chemin des Muriers,4.763544,46.076027,,1,Chemin des Muriers,,1090
+303 Rue des Hautains de la Crotte Ornex,,,,303,Rue des Hautains de la Crotte,,1210
+303 Rue des Hautains de la Crotte 01210,,,,303,Rue des Hautains de la Crotte,Ornex,
+303 Rue des Hautains de la Crotte,6.101622,46.270873,,303,Rue des Hautains de la Crotte,,1210
+32 Impasse sous Millier Parves,,,,32,Impasse sous Millier,,1300
+32 Impasse sous Millier 01300,,,,32,Impasse sous Millier,Parves,
+32 Impasse sous Millier,5.733193,45.741999,,32,Impasse sous Millier,,1300
+74 Chemin des Pruniers Pougny,,,,74,Chemin des Pruniers,,1550
+74 Chemin des Pruniers 01550,,,,74,Chemin des Pruniers,Pougny,
+74 Chemin des Pruniers,5.953276,46.136237,,74,Chemin des Pruniers,,1550
+13 Impasse de la Grange Raclet Saint-André-de-Corcy,,,,13,Impasse de la Grange Raclet,,1390
+13 Impasse de la Grange Raclet 01390,,,,13,Impasse de la Grange Raclet,Saint-André-de-Corcy,
+13 Impasse de la Grange Raclet,4.952409,45.935141,,13,Impasse de la Grange Raclet,,1390
+499 Lotissement Les Fayettes Saint-Didier-de-Formans,,,,499,Lotissement Les Fayettes,,1600
+499 Lotissement Les Fayettes 01600,,,,499,Lotissement Les Fayettes,Saint-Didier-de-Formans,
+499 Lotissement Les Fayettes,4.773252,45.954384,,499,Lotissement Les Fayettes,,1600
+13 Grande Rue des Brovonnes Saint-Marcel,,,,13,Grande Rue des Brovonnes,,1390
+13 Grande Rue des Brovonnes 01390,,,,13,Grande Rue des Brovonnes,Saint-Marcel,
+13 Grande Rue des Brovonnes,4.983415,45.952445,,13,Grande Rue des Brovonnes,,1390
+4 Impasse des Chênes Samognat,,,,4,Impasse des Chênes,,1580
+4 Impasse des Chênes 01580,,,,4,Impasse des Chênes,Samognat,
+4 Impasse des Chênes,5.570487,46.249293,,4,Impasse des Chênes,,1580
+655 Rue de Fenières Thoiry,,,,655,Rue de Fenières,,1710
+655 Rue de Fenières 01710,,,,655,Rue de Fenières,Thoiry,
+655 Rue de Fenières,5.969659,46.225401,,655,Rue de Fenières,,1710
+23 Chemin de la Fruitière Versonnex,,,,23,Chemin de la Fruitière,,1210
+23 Chemin de la Fruitière 01210,,,,23,Chemin de la Fruitière,Versonnex,
+23 Chemin de la Fruitière,6.096438,46.30328,,23,Chemin de la Fruitière,,1210
+124 Allée des Ecluses Viriat,,,,124,Allée des Ecluses,,1440
+124 Allée des Ecluses 01440,,,,124,Allée des Ecluses,Viriat,
+124 Allée des Ecluses,5.213705,46.217523,,124,Allée des Ecluses,,1440
+30 Boulevard Gambetta Aubenas,,,,30,Boulevard Gambetta,,7200
+30 Boulevard Gambetta 07200,,,,30,Boulevard Gambetta,Aubenas,
+30 Boulevard Gambetta,4.390374,44.619548,,30,Boulevard Gambetta,,7200
+4 Lotissement Les Oliviers Charmes-sur-Rhône,,,,4,Lotissement Les Oliviers,,7800
+4 Lotissement Les Oliviers 07800,,,,4,Lotissement Les Oliviers,Charmes-sur-Rhône,
+4 Lotissement Les Oliviers,4.838387,44.864818,,4,Lotissement Les Oliviers,,7800
+5 Rue Victor Hugo Cruas,,,,5,Rue Victor Hugo,,7350
+5 Rue Victor Hugo 07350,,,,5,Rue Victor Hugo,Cruas,
+5 Rue Victor Hugo,4.775005,44.662054,,5,Rue Victor Hugo,,7350
+6 Route Nationale Labégude,,,,6,Route Nationale,,7200
+6 Route Nationale 07200,,,,6,Route Nationale,Labégude,
+6 Route Nationale,4.364493,44.649574,,6,Route Nationale,,7200
+83A Route d'Aubenas Privas,,,,83A,Route d'Aubenas,,7000
+83A Route d'Aubenas 07000,,,,83A,Route d'Aubenas,Privas,
+83A Route d'Aubenas,4.575742,44.729159,,83A,Route d'Aubenas,,7000
+175 Route de la Mairie Saint-Désirat,,,,175,Route de la Mairie,,7340
+175 Route de la Mairie 07340,,,,175,Route de la Mairie,Saint-Désirat,
+175 Route de la Mairie,4.785556,45.25427,,175,Route de la Mairie,,7340
+22 Allée du Plantier Saint-Péray,,,,22,Allée du Plantier,,7130
+22 Allée du Plantier 07130,,,,22,Allée du Plantier,Saint-Péray,
+22 Allée du Plantier,4.847865,44.948976,,22,Allée du Plantier,,7130
+39 Chemin des Helviens Le Teil,,,,39,Chemin des Helviens,,7400
+39 Chemin des Helviens 07400,,,,39,Chemin des Helviens,Le Teil,
+39 Chemin des Helviens,4.66255,44.54928,,39,Chemin des Helviens,,7400
+38TER Rue des Luettes Tournon-sur-Rhône,,,,38TER,Rue des Luettes,,7300
+38TER Rue des Luettes 07300,,,,38TER,Rue des Luettes,Tournon-sur-Rhône,
+38TER Rue des Luettes,4.843824,45.057647,,38TER,Rue des Luettes,,7300
+21 Chemin de Barulas Viviers,,,,21,Chemin de Barulas,,7220
+21 Chemin de Barulas 07220,,,,21,Chemin de Barulas,Viviers,
+21 Chemin de Barulas,4.682277,44.483215,,21,Chemin de Barulas,,7220
+5 Lotissement Le Point du Jour Beauvallon,,,,5,Lotissement Le Point du Jour,,26800
+5 Lotissement Le Point du Jour 26800,,,,5,Lotissement Le Point du Jour,Beauvallon,
+5 Lotissement Le Point du Jour,4.915161,44.855969,,5,Lotissement Le Point du Jour,,26800
+682 Route des Gamelles Bourg-lès-Valence,,,,682,Route des Gamelles,,26500
+682 Route des Gamelles 26500,,,,682,Route des Gamelles,Bourg-lès-Valence,
+682 Route des Gamelles,4.898542,44.968199,,682,Route des Gamelles,,26500
+9 Allée des Vignes Chabeuil,,,,9,Allée des Vignes,,26120
+9 Allée des Vignes 26120,,,,9,Allée des Vignes,Chabeuil,
+9 Allée des Vignes,5.012226,44.903936,,9,Allée des Vignes,,26120
+15 Rue du Lieutenant Michel Prunet Crest,,,,15,Rue du Lieutenant Michel Prunet,,26400
+15 Rue du Lieutenant Michel Prunet 26400,,,,15,Rue du Lieutenant Michel Prunet,Crest,
+15 Rue du Lieutenant Michel Prunet,5.008723,44.733202,,15,Rue du Lieutenant Michel Prunet,,26400
+6236 Rue du Huit Mai 1945 Étoile-sur-Rhône,,,,6236,Rue du 8 Mai 1945,,26800
+6236 Rue du Huit Mai 1945 26800,,,,6236,Rue du 8 Mai 1945,Étoile-sur-Rhône,
+6236 Rue du Huit Mai 1945,4.896874,44.836841,,6236,Rue du 8 Mai 1945,,26800
+28 Rue des Clots Loriol-sur-Drôme,,,,28,Rue des Clots,,26270
+28 Rue des Clots 26270,,,,28,Rue des Clots,Loriol-sur-Drôme,
+28 Rue des Clots,4.830877,44.764844,,28,Rue des Clots,,26270
+115 Rue du Boulanger Mirmande,,,,115,Rue du Boulanger,,26270
+115 Rue du Boulanger 26270,,,,115,Rue du Boulanger,Mirmande,
+115 Rue du Boulanger,4.834896,44.698695,,115,Rue du Boulanger,,26270
+21 Rue Georges Brassens Montélimar,,,,21,Rue Georges Brassens,,26200
+21 Rue Georges Brassens 26200,,,,21,Rue Georges Brassens,Montélimar,
+21 Rue Georges Brassens,4.75561,44.576516,,21,Rue Georges Brassens,,26200
+14 Vieille Route du Teil Montélimar,,,,14,Vieille Route du Teil,,26200
+14 Vieille Route du Teil 26200,,,,14,Vieille Route du Teil,Montélimar,
+14 Vieille Route du Teil,4.731572,44.558359,,14,Vieille Route du Teil,,26200
+5 Allée Charles Gounod Pierrelatte,,,,5,Allée Charles Gounod,,26700
+5 Allée Charles Gounod 26700,,,,5,Allée Charles Gounod,Pierrelatte,
+5 Allée Charles Gounod,4.694689,44.365609,,5,Allée Charles Gounod,,26700
+15 Rue Victor Hugo Portes-lès-Valence,,,,15,Rue Victor Hugo,,26800
+15 Rue Victor Hugo 26800,,,,15,Rue Victor Hugo,Portes-lès-Valence,
+15 Rue Victor Hugo,4.878442,44.869579,,15,Rue Victor Hugo,,26800
+12 Rue Gaillard Romans-sur-Isère,,,,12,Rue Gaillard,,26100
+12 Rue Gaillard 26100,,,,12,Rue Gaillard,Romans-sur-Isère,
+12 Rue Gaillard,5.047856,45.04671,,12,Rue Gaillard,,26100
+55 Allée des Peupliers Saint-Barthélemy-de-Vals,,,,55,Allée des Peupliers,,26240
+55 Allée des Peupliers 26240,,,,55,Allée des Peupliers,Saint-Barthélemy-de-Vals,
+55 Allée des Peupliers,4.866406,45.172857,,55,Allée des Peupliers,,26240
+1BIS Rue de la Pousterle Saint-Paul-Trois-Châteaux,,,,1BIS,Rue de la Pousterle,,26130
+1BIS Rue de la Pousterle 26130,,,,1BIS,Rue de la Pousterle,Saint-Paul-Trois-Châteaux,
+1BIS Rue de la Pousterle,4.769158,44.350009,,1BIS,Rue de la Pousterle,,26130
+275 Impasse des Genêts Suze-la-Rousse,,,,275,Impasse des Genêts,,26790
+275 Impasse des Genêts 26790,,,,275,Impasse des Genêts,Suze-la-Rousse,
+275 Impasse des Genêts,4.836092,44.297845,,275,Impasse des Genêts,,26790
+22 Rue Colette Valence,,,,22,Rue Colette,,26000
+22 Rue Colette 26000,,,,22,Rue Colette,Valence,
+22 Rue Colette,4.881536,44.908171,,22,Rue Colette,,26000
+1 Rue du Maréchal Foch Valence,,,,1,Rue du Maréchal Foch,,26000
+1 Rue du Maréchal Foch 26000,,,,1,Rue du Maréchal Foch,Valence,
+1 Rue du Maréchal Foch,4.901738,44.937949,,1,Rue du Maréchal Foch,,26000
+5 Chemin des Grands Blancs Gervans,,,,5,Chemin des Grands Blancs,,26600
+5 Chemin des Grands Blancs 26600,,,,5,Chemin des Grands Blancs,Gervans,
+5 Chemin des Grands Blancs,4.831904,45.113003,,5,Chemin des Grands Blancs,,26600
+13 Rue de Gasavignard Assieu,,,,13,Rue de Gasavignard,,38150
+13 Rue de Gasavignard 38150,,,,13,Rue de Gasavignard,Assieu,
+13 Rue de Gasavignard,4.860239,45.40617,,13,Rue de Gasavignard,,38150
+36 Chemin du Gurdin La Bâtie-Montgascon,,,,36,Chemin du Gurdin,,38110
+36 Chemin du Gurdin 38110,,,,36,Chemin du Gurdin,La Bâtie-Montgascon,
+36 Chemin du Gurdin,5.533308,45.569391,,36,Chemin du Gurdin,,38110
+3 Lotissement des Mésanges Biviers,,,,3,Lotissement des Mésanges,,38330
+3 Lotissement des Mésanges 38330,,,,3,Lotissement des Mésanges,Biviers,
+3 Lotissement des Mésanges,5.804175,45.233897,,3,Lotissement des Mésanges,,38330
+14 Rue des Pâquerettes Bourgoin-Jallieu,,,,14,Rue des Pâquerettes,,38300
+14 Rue des Pâquerettes 38300,,,,14,Rue des Pâquerettes,Bourgoin-Jallieu,
+14 Rue des Pâquerettes,5.283596,45.593782,,14,Rue des Pâquerettes,,38300
+25 Chemin de Pévrin Cessieu,,,,25,Chemin de Pévrin,,38110
+25 Chemin de Pévrin 38110,,,,25,Chemin de Pévrin,Cessieu,
+25 Chemin de Pévrin,5.407829,45.568561,,25,Chemin de Pévrin,,38110
+129 Chemin du Granjon Charantonnay,,,,129,Chemin du Granjon,,38790
+129 Chemin du Granjon 38790,,,,129,Chemin du Granjon,Charantonnay,
+129 Chemin du Granjon,5.106241,45.538471,,129,Chemin du Granjon,,38790
+34 Rue du Château Chavanoz,,,,34,Rue du Château,,38230
+34 Rue du Château 38230,,,,34,Rue du Château,Chavanoz,
+34 Rue du Château,5.167467,45.777709,,34,Rue du Château,,38230
+4 Allée Montaler Claix,,,,4,Allée Montaler,,38640
+4 Allée Montaler 38640,,,,4,Allée Montaler,Claix,
+4 Allée Montaler,5.670668,45.130661,,4,Allée Montaler,,38640
+19 Rue des Remparts La Côte-Saint-André,,,,19,Rue des Remparts,,38260
+19 Rue des Remparts 38260,,,,19,Rue des Remparts,La Côte-Saint-André,
+19 Rue des Remparts,5.259863,45.395187,,19,Rue des Remparts,,38260
+17 Avenue des Fleurs Diémoz,,,,17,Avenue des Fleurs,,38790
+17 Avenue des Fleurs 38790,,,,17,Avenue des Fleurs,Diémoz,
+17 Avenue des Fleurs,5.093148,45.588669,,17,Avenue des Fleurs,,38790
+36 Rue Jean Moulin Échirolles,,,,36,Rue Jean Moulin,,38130
+36 Rue Jean Moulin 38130,,,,36,Rue Jean Moulin,Échirolles,
+36 Rue Jean Moulin,5.698649,45.142399,,36,Rue Jean Moulin,,38130
+331 Chemin sous l'École Faverges-de-la-Tour,,,,331,Chemin sous l'École,,38110
+331 Chemin sous l'École 38110,,,,331,Chemin sous l'École,Faverges-de-la-Tour,
+331 Chemin sous l'École,5.502051,45.595432,,331,Chemin sous l'École,,38110
+40 Rue du Docteur Ludovic Klein Froges,,,,40,Rue du Docteur Ludovic Klein,,38190
+40 Rue du Docteur Ludovic Klein 38190,,,,40,Rue du Docteur Ludovic Klein,Froges,
+40 Rue du Docteur Ludovic Klein,5.920758,45.277324,,40,Rue du Docteur Ludovic Klein,,38190
+11 Avenue Albert 1er de Belgique Grenoble,,,,11,Avenue Albert 1er de Belgique,,38000
+11 Avenue Albert 1er de Belgique 38000,,,,11,Avenue Albert 1er de Belgique,Grenoble,
+11 Avenue Albert 1er de Belgique,5.732519,45.181713,,11,Avenue Albert 1er de Belgique,,38000
+1 Chemin de Gordes Grenoble,,,,1,Chemin de Gordes,,38000
+1 Chemin de Gordes 38000,,,,1,Chemin de Gordes,Grenoble,
+1 Chemin de Gordes,5.732519,45.175525,,1,Chemin de Gordes,,38000
+6 Rue Prosper Mérimée Grenoble,,,,6,Rue Prosper Mérimée,,38000
+6 Rue Prosper Mérimée 38000,,,,6,Rue Prosper Mérimée,Grenoble,
+6 Rue Prosper Mérimée,5.728118,45.172884,,6,Rue Prosper Mérimée,,38000
+51 Avenue de Murcia L'Isle-d'Abeau,,,,51,Avenue de Murcia,,38080
+51 Avenue de Murcia 38080,,,,51,Avenue de Murcia,L'Isle-d'Abeau,
+51 Avenue de Murcia,5.248591,45.619333,,51,Avenue de Murcia,,38080
+2527 Route de Saint-Germain Luzinay,,,,2527,Route de Saint-Germain,,38200
+2527 Route de Saint-Germain 38200,,,,2527,Route de Saint-Germain,Luzinay,
+2527 Route de Saint-Germain,4.98157,45.599532,,2527,Route de Saint-Germain,,38200
+133 Rue Grande Rue Monestier-de-Clermont,,,,133,Rue Grande Rue,,38650
+133 Rue Grande Rue 38650,,,,133,Rue Grande Rue,Monestier-de-Clermont,
+133 Rue Grande Rue,5.634036,44.915516,,133,Rue Grande Rue,,38650
+20 Route du Grand Prè La Motte-d'Aveillans,,,,20,Route du Grand Prè,,38770
+20 Route du Grand Prè 38770,,,,20,Route du Grand Prè,La Motte-d'Aveillans,
+20 Route du Grand Prè,5.731757,44.960157,,20,Route du Grand Prè,,38770
+106 Rue du Maupas Noyarey,,,,106,Rue du Maupas,,38360
+106 Rue du Maupas 38360,,,,106,Rue du Maupas,Noyarey,
+106 Rue du Maupas,5.631349,45.244027,,106,Rue du Maupas,,38360
+523 Route de Brésin Le Pin,,,,523,Route de Brésin,,38730
+523 Route de Brésin 38730,,,,523,Route de Brésin,,38730
+523 Route de Brésin,5.517661,45.4682,,523,Route de Brésin,,38730
+6 Rue du Canal du Drac Le Pont-de-Claix,,,,6,Rue du Canal du Drac,,38800
+6 Rue du Canal du Drac 38800,,,,6,Rue du Canal du Drac,Le Pont-de-Claix,
+6 Rue du Canal du Drac,5.696753,45.124476,,6,Rue du Canal du Drac,,38800
+987 Chemin du Priolaz Romagnieu,,,,987,Chemin de Priolaz,,38480
+987 Chemin du Priolaz 38480,,,,987,Chemin de Priolaz,Romagnieu,
+987 Chemin du Priolaz,5.616106,45.55383,,987,Chemin de Priolaz,,38480
+23 Rue Pasteur Saint-André-le-Gaz,,,,23,Rue Pasteur,,38490
+23 Rue Pasteur 38490,,,,23,Rue Pasteur,Saint-André-le-Gaz,
+23 Rue Pasteur,5.52734,45.543927,,23,Rue Pasteur,,38490
+74 Route de Ferrossière Saint-Didier-de-la-Tour,,,,74,Route de Ferrossière,,38110
+74 Route de Ferrossière 38110,,,,74,Route de Ferrossière,Saint-Didier-de-la-Tour,
+74 Route de Ferrossière,5.468255,45.559857,,74,Route de Ferrossière,,38110
+7 Rue Joseph Servanin Saint-Georges-d'Espéranche,,,,7,Rue Joseph Servanin,,38790
+7 Rue Joseph Servanin 38790,,,,7,Rue Joseph Servanin,Saint-Georges-d'Espéranche,
+7 Rue Joseph Servanin,5.077563,45.560161,,7,Rue Joseph Servanin,,38790
+19 Rue Charles Berty Saint-Laurent-du-Pont,,,,19,Rue Charles Berty,,38380
+19 Rue Charles Berty 38380,,,,19,Rue Charles Berty,Saint-Laurent-du-Pont,
+19 Rue Charles Berty,5.731019,45.389024,,19,Rue Charles Berty,,38380
+17 Rue Jacques Anquetil Saint-Martin-d'Hères,,,,17,Rue Jacques Anquetil,,38400
+17 Rue Jacques Anquetil 38400,,,,17,Rue Jacques Anquetil,Saint-Martin-d'Hères,
+17 Rue Jacques Anquetil,5.753371,45.171806,,17,Rue Jacques Anquetil,,38400
+243 Chemin du Brinchet Saint-Nazaire-les-Eymes,,,,243,Chemin du Brinchet,,38330
+243 Chemin du Brinchet 38330,,,,243,Chemin du Brinchet,Saint-Nazaire-les-Eymes,
+243 Chemin du Brinchet,5.852739,45.253718,,243,Chemin du Brinchet,,38330
+90 Route de Barens Saint-Romain-de-Jalionas,,,,90,Route de Barens,,38460
+90 Route de Barens 38460,,,,90,Route de Barens,Saint-Romain-de-Jalionas,
+90 Route de Barens,5.21339,45.73781,,90,Route de Barens,,38460
+12B Rue Jean Rostand Salaise-sur-Sanne,,,,12B,Rue Jean Rostand,,38150
+12B Rue Jean Rostand 38150,,,,12B,Rue Jean Rostand,Salaise-sur-Sanne,
+12B Rue Jean Rostand,4.810286,45.345459,,12B,Rue Jean Rostand,,38150
+28 Rue des Murailles Seyssinet-Pariset,,,,28,Rue des Murailles,,38180
+28 Rue des Murailles 38180,,,,28,Rue des Murailles,Seyssinet-Pariset,
+28 Rue des Murailles,5.690661,45.179447,,28,Rue des Murailles,,38180
+595 Chemin de l'Étang Berger Thodure,,,,595,Chemin de l'Étang Berger,,38260
+595 Chemin de l'Étang Berger 38260,,,,595,Chemin de l'Étang Berger,Thodure,
+595 Chemin de l'Étang Berger,5.140099,45.311305,,595,Chemin de l'Étang Berger,,38260
+44 Avenue de la Gare Tullins,,,,44,Avenue de la Gare,,38210
+44 Avenue de la Gare 38210,,,,44,Avenue de la Gare,Tullins,
+44 Avenue de la Gare,5.488241,45.300807,,44,Avenue de la Gare,,38210
+48BIS Chemin de l'Eau Vernioz,,,,48BIS,Chemin de l'Eau,,38150
+48BIS Chemin de l'Eau 38150,,,,48BIS,Chemin de l'Eau,Vernioz,
+48BIS Chemin de l'Eau,4.87778,45.426346,,48BIS,Chemin de l'Eau,,38150
+30 Rue Bartholdi Vienne,,,,30,Rue Auguste Bartholdi,,38200
+30 Rue Bartholdi 38200,,,,30,Rue Auguste Bartholdi,Vienne,
+30 Rue Bartholdi,4.912712,45.51677,,30,Rue Auguste Bartholdi,,38200
+48 Route des Celliers Vif,,,,48,Route des Celliers,,38450
+48 Route des Celliers 38450,,,,48,Route des Celliers,Vif,
+48 Route des Celliers,5.661361,45.048116,,48,Route des Celliers,,38450
+10 Chemin Vert Villard-de-Lans,,,,10,Chemin Vert,,38250
+10 Chemin Vert 38250,,,,10,Chemin Vert,Villard-de-Lans,
+10 Chemin Vert,5.56428,45.068207,,10,Chemin Vert,,38250
+596 Route de Valence Vinay,,,,596,Route de Valence,,38470
+596 Route de Valence 38470,,,,596,Route de Valence,Vinay,
+596 Route de Valence,5.397078,45.19988,,596,Route de Valence,,38470
+6 Place de la République Voiron,,,,6,Place de la République,,38500
+6 Place de la République 38500,,,,6,Place de la République,Voiron,
+6 Place de la République,5.591458,45.367702,,6,Place de la République,,38500
+9 Avenue de Saint-Marcellin Bonson,,,,9,Avenue de Saint-Marcellin,,42160
+9 Avenue de Saint-Marcellin 42160,,,,9,Avenue de Saint-Marcellin,Bonson,
+9 Avenue de Saint-Marcellin,4.210461,45.520523,,9,Avenue de Saint-Marcellin,,42160
+120 Allée de la Chana Champdieu,,,,120,Allée de la Chana,,42600
+120 Allée de la Chana 42600,,,,120,Allée de la Chana,Champdieu,
+120 Allée de la Chana,4.048975,45.643583,,120,Allée de la Chana,,42600
+5 Rue des Lilas Commelle-Vernay,,,,5,Rue des Lilas,,42120
+5 Rue des Lilas 42120,,,,5,Rue des Lilas,Commelle-Vernay,
+5 Rue des Lilas,4.067571,45.99044,,5,Rue des Lilas,,42120
+3 Rue Jean-Marie Nigay Feurs,,,,3,Rue Jean-Marie Nigay,,42110
+3 Rue Jean-Marie Nigay 42110,,,,3,Rue Jean-Marie Nigay,Feurs,
+3 Rue Jean-Marie Nigay,4.224515,45.742044,,3,Rue Jean-Marie Nigay,,42110
+2 Rue Jean Macé Fraisses,,,,2,Rue Jean Macé,,42490
+2 Rue Jean Macé 42490,,,,2,Rue Jean Macé,Fraisses,
+2 Rue Jean Macé,4.264596,45.387243,,2,Rue Jean Macé,,42490
+24 Rue de l'Artisanat Mably,,,,24,Rue de l'Artisanat,,42300
+24 Rue de l'Artisanat 42300,,,,24,Rue de l'Artisanat,Mably,
+24 Rue de l'Artisanat,4.04933,46.068859,,24,Rue de l'Artisanat,,42300
+4BIS Rue des Legouve Montbrison,,,,4BIS,Rue des Legouve,,42600
+4BIS Rue des Legouve 42600,,,,4BIS,Rue des Legouve,Montbrison,
+4BIS Rue des Legouve,4.064809,45.606866,,4BIS,Rue des Legouve,,42600
+48 Place de la Liberté Panissières,,,,48,Place de la Liberté,,42360
+48 Place de la Liberté 42360,,,,48,Place de la Liberté,Panissières,
+48 Place de la Liberté,4.344788,45.791668,,48,Place de la Liberté,,42360
+15 Rue Denfert-Rochereau La Ricamarie,,,,15,Rue Denfert-Rochereau,,42150
+15 Rue Denfert-Rochereau 42150,,,,15,Rue Denfert-Rochereau,La Ricamarie,
+15 Rue Denfert-Rochereau,4.365803,45.401768,,15,Rue Denfert-Rochereau,,42150
+2626 Rue de Saint-Romain Riorges,,,,2626,Rue de Saint-Romain,,42153
+2626 Rue de Saint-Romain 42153,,,,2626,Rue de Saint-Romain,Riorges,
+2626 Rue de Saint-Romain,4.026861,46.05498,,2626,Rue de Saint-Romain,,42153
+2 Rue Bellevue Roanne,,,,2,Rue Bellevue,,42300
+2 Rue Bellevue 42300,,,,2,Rue Bellevue,Roanne,
+2 Rue Bellevue,4.063596,46.027664,,2,Rue Bellevue,,42300
+7 Rue Jules Massenet Roanne,,,,7,Rue Jules Massenet,,42300
+7 Rue Jules Massenet 42300,,,,7,Rue Jules Massenet,Roanne,
+7 Rue Jules Massenet,4.055731,46.02439,,7,Rue Jules Massenet,,42300
+26 Rue Jean Monnet Roche-la-Molière,,,,26,Rue Jean Monnet,,42230
+26 Rue Jean Monnet 42230,,,,26,Rue Jean Monnet,Roche-la-Molière,
+26 Rue Jean Monnet,4.313609,45.435683,,26,Rue Jean Monnet,,42230
+79 Route de la Chabure Saint-Chamond,,,,79,Route de la Chabure,,42400
+79 Route de la Chabure 42400,,,,79,Route de la Chabure,Saint-Chamond,
+79 Route de la Chabure,4.485001,45.450912,,79,Route de la Chabure,,42400
+1 Rue du Soleil Levant Saint-Christo-en-Jarez,,,,1,Rue du Soleil Levant,,42320
+1 Rue du Soleil Levant 42320,,,,1,Rue du Soleil Levant,Saint-Christo-en-Jarez,
+1 Rue du Soleil Levant,4.486989,45.545133,,1,Rue du Soleil Levant,,42320
+18 Rue de Chavassieux Saint-Étienne,,,,18,Rue de Chavassieux,,42100
+18 Rue de Chavassieux 42100,,,,18,Rue de Chavassieux,Saint-Étienne,
+18 Rue de Chavassieux,4.368271,45.445876,,18,Rue de Chavassieux,,42100
+6 Passage du Gazomêtre Saint-Étienne,,,,6,Passage du Gazomètre,,42100
+6 Passage du Gazomêtre 42100,,,,6,Passage du Gazomètre,Saint-Étienne,
+6 Passage du Gazomêtre,4.439609,45.434532,,6,Passage du Gazomètre,,42100
+104 Rue de la Montat Saint-Étienne,,,,104,Rue de la Montat,,42100
+104 Rue de la Montat 42100,,,,104,Rue de la Montat,Saint-Étienne,
+104 Rue de la Montat,4.411026,45.442595,,104,Rue de la Montat,,42100
+18 Rue de Tardy Saint-Étienne,,,,18,Rue de Tardy,,42100
+18 Rue de Tardy 42100,,,,18,Rue de Tardy,Saint-Étienne,
+18 Rue de Tardy,4.384639,45.427799,,18,Rue de Tardy,,42100
+375 Route du Mont du Feu Genilac,,,,375,Route du Mont du Feu,,42800
+375 Route du Mont du Feu 42800,,,,375,Route du Mont du Feu,Genilac,
+375 Route du Mont du Feu,4.583861,45.526417,,375,Route du Mont du Feu,,42800
+2 Route des Cités Saint-Julien-la-Vêtre,,,,2,Route des Cités,,42440
+2 Route des Cités 42440,,,,2,Route des Cités,Saint-Julien-la-Vêtre,
+2 Route des Cités,3.824623,45.813799,,2,Route des Cités,,42440
+50 Rue de la Plagne Saint-Paul-en-Jarez,,,,50,Rue de la Plagne,,42740
+50 Rue de la Plagne 42740,,,,50,Rue de la Plagne,Saint-Paul-en-Jarez,
+50 Rue de la Plagne,4.575049,45.481849,,50,Rue de la Plagne,,42740
+27 Route de Saint-Côme Saint-Just-Saint-Rambert,,,,27,Route de Saint-Côme,,42170
+27 Route de Saint-Côme 42170,,,,27,Route de Saint-Côme,Saint-Just-Saint-Rambert,
+27 Route de Saint-Côme,4.23928,45.505083,,27,Route de Saint-Côme,,42170
+5 Rue Auguste Barret Sury-le-Comtal,,,,5,Rue Auguste Barret,,42450
+5 Rue Auguste Barret 42450,,,,5,Rue Auguste Barret,Sury-le-Comtal,
+5 Rue Auguste Barret,4.184336,45.540943,,5,Rue Auguste Barret,,42450
+4 Impasse Jean Zay Unieux,,,,4,Impasse Jean Zay,,42240
+4 Impasse Jean Zay 42240,,,,4,Impasse Jean Zay,Unieux,
+4 Impasse Jean Zay,4.277781,45.395143,,4,Impasse Jean Zay,,42240
+25 Rue des Cotes du Vernois Villerest,,,,25,Rue des Cotes du Vernois,,42300
+25 Rue des Cotes du Vernois 42300,,,,25,Rue des Cotes du Vernois,Villerest,
+25 Rue des Cotes du Vernois,4.043665,46.021085,,25,Rue des Cotes du Vernois,,42300
+493 Avenue du Champ d'Asile L'Arbresle,,,,493,Avenue du Champ d'Asile,,69210
+493 Avenue du Champ d'Asile 69210,,,,493,Avenue du Champ d'Asile,L'Arbresle,
+493 Avenue du Champ d'Asile,4.602992,45.833977,,493,Avenue du Champ d'Asile,,69210
+24 Place du Marché Bessenay,,,,24,Place du Marché,,69690
+24 Place du Marché 69690,,,,24,Place du Marché,Bessenay,
+24 Place du Marché,4.553018,45.776179,,24,Place du Marché,,69690
+153 Route du Pont de Chêne Brindas,,,,153,Route du Pont de Chêne,,69126
+153 Route du Pont de Chêne 69126,,,,153,Route du Pont de Chêne,Brindas,
+153 Route du Pont de Chêne,4.732078,45.723409,,153,Route du Pont de Chêne,,69126
+40 Chemin de la Vie Guerse Bron,,,,40,Chemin de la Vie Guerse,,69500
+40 Chemin de la Vie Guerse 69500,,,,40,Chemin de la Vie Guerse,Bron,
+40 Chemin de la Vie Guerse,4.933654,45.7407,,40,Chemin de la Vie Guerse,,69500
+16B Rue de la Tarentaise Caluire-et-Cuire,,,,16B,Rue de la Tarentaise,,69300
+16B Rue de la Tarentaise 69300,,,,16B,Rue de la Tarentaise,Caluire-et-Cuire,
+16B Rue de la Tarentaise,4.823688,45.785788,,16B,Rue de la Tarentaise,,69300
+21 Chemin des Cailloux Charly,,,,21,Chemin des Cailloux,,69390
+21 Chemin des Cailloux 69390,,,,21,Chemin des Cailloux,Charly,
+21 Chemin des Cailloux,4.785364,45.654203,,21,Chemin des Cailloux,,69390
+2 Chemin des Prés Secs Civrieux-d'Azergues,,,,2,Chemin des Prés Secs,,69380
+2 Chemin des Prés Secs 69380,,,,2,Chemin des Prés Secs,Civrieux-d'Azergues,
+2 Chemin des Prés Secs,4.703734,45.856237,,2,Chemin des Prés Secs,,69380
+102 Avenue Pierre Dumond Craponne,,,,102,Avenue Pierre Dumond,,69290
+102 Avenue Pierre Dumond 69290,,,,102,Avenue Pierre Dumond,Craponne,
+102 Avenue Pierre Dumond,4.721378,45.747416,,102,Avenue Pierre Dumond,,69290
+678 Rue des Rivetières Dracé,,,,678,Rue des Rivetières,,69220
+678 Rue des Rivetières 69220,,,,678,Rue des Rivetières,Dracé,
+678 Rue des Rivetières,4.760704,46.155751,,678,Rue des Rivetières,,69220
+33 Chemin de Montgay Fontaines-sur-Saône,,,,33,Chemin de Montgay,,69270
+33 Chemin de Montgay 69270,,,,33,Chemin de Montgay,Fontaines-sur-Saône,
+33 Chemin de Montgay,4.86109,45.831976,,33,Chemin de Montgay,,69270
+6 Chemin de la Perle Givors,,,,6,Chemin de la Perle,,69700
+6 Chemin de la Perle 69700,,,,6,Chemin de la Perle,Givors,
+6 Chemin de la Perle,4.750301,45.580299,,6,Chemin de la Perle,,69700
+9 Rue Marcel Paul Grigny,,,,9,Rue Marcel Paul,,69520
+9 Rue Marcel Paul 69520,,,,9,Rue Marcel Paul,Grigny,
+9 Rue Marcel Paul,4.781991,45.607959,,9,Rue Marcel Paul,,69520
+33 Domaine de l'Étang Lentilly,,,,33,Domaine de l'Étang,,69210
+33 Domaine de l'Étang 69210,,,,33,Domaine de l'Étang,Lentilly,
+33 Domaine de l'Étang,4.671859,45.819288,,33,Domaine de l'Étang,,69210
+150 Chemin du Bois Don Lozanne,,,,150,Chemin du Bois Don,,69380
+150 Chemin du Bois Don 69380,,,,150,Chemin du Bois Don,Lozanne,
+150 Chemin du Bois Don,4.688746,45.864026,,150,Chemin du Bois Don,,69380
+390 Chemin des Trois Bois Morancé,,,,390,Chemin des Trois Bois,,69480
+390 Chemin des Trois Bois 69480,,,,390,Chemin des Trois Bois,Morancé,
+390 Chemin des Trois Bois,4.707248,45.890011,,390,Chemin des Trois Bois,,69480
+12 Rue Fernand Forest Oullins,,,,12,Rue Fernand Forest,,69600
+12 Rue Fernand Forest 69600,,,,12,Rue Fernand Forest,Oullins,
+12 Rue Fernand Forest,4.803198,45.722023,,12,Rue Fernand Forest,,69600
+366 Chemin du Paradis Pommiers,,,,366,Chemin du Paradis,,69480
+366 Chemin du Paradis 69480,,,,366,Chemin du Paradis,Pommiers,
+366 Chemin du Paradis,4.681926,45.966464,,366,Chemin du Paradis,,69480
+9 Rue des Roches Sourcieux-les-Mines,,,,9,Rue des Roches,,69210
+9 Rue des Roches 69210,,,,9,Rue des Roches,Sourcieux-les-Mines,
+9 Rue des Roches,4.62977,45.799167,,9,Rue des Roches,,69210
+265 Rue des Guérins Saint-Didier-sur-Beaujeu,,,,265,Rue des Guérins,,69430
+265 Rue des Guérins 69430,,,,265,Rue des Guérins,Saint-Didier-sur-Beaujeu,
+265 Rue des Guérins,4.565371,46.164203,,265,Rue des Guérins,,69430
+21 Rue du Neyrard Sainte-Foy-lès-Lyon,,,,21,Rue du Neyrard,,69110
+21 Rue du Neyrard 69110,,,,21,Rue du Neyrard,Sainte-Foy-lès-Lyon,
+21 Rue du Neyrard,4.801978,45.734129,,21,Rue du Neyrard,,69110
+26 Rue du Cornet Saint-Genis-les-Ollières,,,,26,Rue du Cornet,,69290
+26 Rue du Cornet 69290,,,,26,Rue du Cornet,Saint-Genis-les-Ollières,
+26 Rue du Cornet,4.721758,45.755684,,26,Rue du Cornet,,69290
+663 Route des Brouilly Saint-Lager,,,,663,Route des Brouilly,,69220
+663 Route des Brouilly 69220,,,,663,Route des Brouilly,Saint-Lager,
+663 Route des Brouilly,4.672601,46.111487,,663,Route des Brouilly,,69220
+73 Impasse des Maraichers Taponas,,,,73,Impasse des Maraîchers,,69220
+73 Impasse des Maraichers 69220,,,,73,Impasse des Maraîchers,Taponas,
+73 Impasse des Maraichers,4.753904,46.113933,,73,Impasse des Maraîchers,,69220
+40 Avenue de la République Tassin-la-Demi-Lune,,,,40,Avenue de la République,,69160
+40 Avenue de la République 69160,,,,40,Avenue de la République,Tassin-la-Demi-Lune,
+40 Avenue de la République,4.780399,45.764062,,40,Avenue de la République,,69160
+25B Rue Balland Vaulx-en-Velin,,,,25B,Rue Balland,,69120
+25B Rue Balland 69120,,,,25B,Rue Balland,Vaulx-en-Velin,
+25B Rue Balland,4.907498,45.773664,,25B,Rue Balland,,69120
+36 Rue Victor Hugo Vaulx-en-Velin,,,,36,Rue Victor Hugo,,69120
+36 Rue Victor Hugo 69120,,,,36,Rue Victor Hugo,Vaulx-en-Velin,
+36 Rue Victor Hugo,4.923935,45.785912,,36,Rue Victor Hugo,,69120
+24 Rue Pierre Dupont Vénissieux,,,,24,Rue Pierre Dupont,,69200
+24 Rue Pierre Dupont 69200,,,,24,Rue Pierre Dupont,Vénissieux,
+24 Rue Pierre Dupont,4.870589,45.695952,,24,Rue Pierre Dupont,,69200
+35 Rue Hector Berlioz Villefranche-sur-Saône,,,,35,Rue Hector Berlioz,,69400
+35 Rue Hector Berlioz 69400,,,,35,Rue Hector Berlioz,Villefranche-sur-Saône,
+35 Rue Hector Berlioz,4.721373,45.980203,,35,Rue Hector Berlioz,,69400
+22 Rue Raspail Villeurbanne,,,,22,Rue Raspail,,69100
+22 Rue Raspail 69100,,,,22,Rue Raspail,Villeurbanne,
+22 Rue Raspail,4.882217,45.773359,,22,Rue Raspail,,69100
+38 Rue Jean-Claude Vivant Villeurbanne,,,,38,Rue Jean-Claude Vivant,,69100
+38 Rue Jean-Claude Vivant 69100,,,,38,Rue Jean-Claude Vivant,Villeurbanne,
+38 Rue Jean-Claude Vivant,4.868025,45.768635,,38,Rue Jean-Claude Vivant,,69100
+100 Cours Tolstoï Villeurbanne,,,,100,Cours Tolstoï,,69100
+100 Cours Tolstoï 69100,,,,100,Cours Tolstoï,Villeurbanne,
+100 Cours Tolstoï,4.879328,45.762315,,100,Cours Tolstoï,,69100
+68 Avenue du Progrès Chassieu,,,,68,Avenue du Progrès,,69680
+68 Avenue du Progrès 69680,,,,68,Avenue du Progrès,Chassieu,
+68 Avenue du Progrès,4.963698,45.730519,,68,Avenue du Progrès,,69680
+16 Rue Anatole France Décines-Charpieu,,,,16,Rue Anatole France,,69150
+16 Rue Anatole France 69150,,,,16,Rue Anatole France,Décines-Charpieu,
+16 Rue Anatole France,4.95193,45.7713,,16,Rue Anatole France,,69150
+17 Rue d'Auvergne Feyzin,,,,17,Rue d'Auvergne,,69320
+17 Rue d'Auvergne 69320,,,,17,Rue d'Auvergne,Feyzin,
+17 Rue d'Auvergne,4.86009,45.664058,,17,Rue d'Auvergne,,69320
+1 Impasse Pierre Dupont Genas,,,,1,Impasse Pierre Dupont,,69740
+1 Impasse Pierre Dupont 69740,,,,1,Impasse Pierre Dupont,Genas,
+1 Impasse Pierre Dupont,5.00059,45.722506,,1,Impasse Pierre Dupont,,69740
+42 Rue Armand Salacrou Meyzieu,,,,42,Rue Armand Salacrou,,69330
+42 Rue Armand Salacrou 69330,,,,42,Rue Armand Salacrou,Meyzieu,
+42 Rue Armand Salacrou,4.99961,45.785047,,42,Rue Armand Salacrou,,69330
+8 Rue Marivaux Meyzieu,,,,8,Rue Marivaux,,69330
+8 Rue Marivaux 69330,,,,8,Rue Marivaux,Meyzieu,
+8 Rue Marivaux,4.987752,45.771953,,8,Rue Marivaux,,69330
+3 Rue Joliot-Curie Mions,,,,3,Rue Joliot-Curie,,69780
+3 Rue Joliot-Curie 69780,,,,3,Rue Joliot-Curie,Mions,
+3 Rue Joliot-Curie,4.945128,45.680533,,3,Rue Joliot-Curie,,69780
+15 Allée des Cavaliers Rillieux-la-Pape,,,,15,Allée des Cavaliers,,69140
+15 Allée des Cavaliers 69140,,,,15,Allée des Cavaliers,Rillieux-la-Pape,
+15 Allée des Cavaliers,4.888308,45.818904,,15,Allée des Cavaliers,,69140
+23 Chemin de Quincieu Saint-Bonnet-de-Mure,,,,23,Chemin de Quincieu,,69720
+23 Chemin de Quincieu 69720,,,,23,Chemin de Quincieu,Saint-Bonnet-de-Mure,
+23 Chemin de Quincieu,5.036118,45.704843,,23,Chemin de Quincieu,,69720
+10 2e Avenue Saint-Priest,,,,10,2e Avenue,,69800
+10 2e Avenue 69800,,,,10,2e Avenue,Saint-Priest,
+10 2e Avenue,4.898453,45.702513,,10,2e Avenue,,69800
+39 Rue Centrale Saint-Symphorien-d'Ozon,,,,39,Rue Centrale,,69360
+39 Rue Centrale 69360,,,,39,Rue Centrale,Saint-Symphorien-d'Ozon,
+39 Rue Centrale,4.855765,45.633635,,39,Rue Centrale,,69360
+5 Chemin de Papillon Ternay,,,,5,Chemin de Papillon,,69360
+5 Chemin de Papillon 69360,,,,5,Chemin de Papillon,Ternay,
+5 Chemin de Papillon,4.801087,45.596221,,5,Chemin de Papillon,,69360
+2 Rue Childebert Lyon,,,,2,Rue Childebert,,69002
+2 Rue Childebert 69002,,,,2,Rue Childebert,Lyon,
+2 Rue Childebert,4.834232,45.760219,,2,Rue Childebert,,69002
+23 Rue François Villon Lyon,,,,23,Rue François Villon,,69003
+23 Rue François Villon 69003,,,,23,Rue François Villon,Lyon,
+23 Rue François Villon,4.890268,45.74261,,23,Rue François Villon,,69003
+51 Rue Deleuvre Lyon,,,,51,Rue Deleuvre,,69004
+51 Rue Deleuvre 69004,,,,51,Rue Deleuvre,Lyon,
+51 Rue Deleuvre,4.825272,45.780077,,51,Rue Deleuvre,,69004
+32 Rue Tramassac Lyon,,,,32,Rue Tramassac,,69005
+32 Rue Tramassac 69005,,,,32,Rue Tramassac,Lyon,
+32 Rue Tramassac,4.825515,45.760464,,32,Rue Tramassac,,69005
+60 Cours Gambetta Lyon,,,,60,Cours Gambetta,,69007
+60 Cours Gambetta 69007,,,,60,Cours Gambetta,Lyon,
+60 Cours Gambetta,4.848349,45.753314,,60,Cours Gambetta,,69007
+31 Rue Henri Barbusse Lyon,,,,31,Rue Henri Barbusse,,69008
+31 Rue Henri Barbusse 69008,,,,31,Rue Henri Barbusse,Lyon,
+31 Rue Henri Barbusse,4.856546,45.730484,,31,Rue Henri Barbusse,,69008
+21 Rue Jean Zay Lyon,,,,21,Rue Jean Zay,,69009
+21 Rue Jean Zay 69009,,,,21,Rue Jean Zay,Lyon,
+21 Rue Jean Zay,4.801252,45.766324,,21,Rue Jean Zay,,69009
+166 Avenue du Petit Port Aix-les-Bains,,,,166,Avenue du Petit Port,,73100
+166 Avenue du Petit Port 73100,,,,166,Avenue du Petit Port,Aix-les-Bains,
+166 Avenue du Petit Port,5.896628,45.694642,,166,Avenue du Petit Port,,73100
+120 Chemin du Nant Bauchet Arbin,,,,120,Chemin du Nant Bauchet,,73800
+120 Chemin du Nant Bauchet 73800,,,,120,Chemin du Nant Bauchet,Arbin,
+120 Chemin du Nant Bauchet,6.073832,45.510952,,120,Chemin du Nant Bauchet,,73800
+1249 Avenue du Maréchal Leclerc Bourg-Saint-Maurice,,,,1249,Avenue du Maréchal Leclerc,,73700
+1249 Avenue du Maréchal Leclerc 73700,,,,1249,Avenue du Maréchal Leclerc,Bourg-Saint-Maurice,
+1249 Avenue du Maréchal Leclerc,6.762228,45.609582,,1249,Avenue du Maréchal Leclerc,,73700
+35 Rue Émile Combes Chambéry,,,,35,Rue Émile Combes,,73000
+35 Rue Émile Combes 73000,,,,35,Rue Émile Combes,Chambéry,
+35 Rue Émile Combes,5.918722,45.559311,,35,Rue Émile Combes,,73000
+258 Route des Platières La Chavanne,,,,258,Route des Platières,,73800
+258 Route des Platières 73800,,,,258,Route des Platières,La Chavanne,
+258 Route des Platières,6.071095,45.488933,,258,Route des Platières,,73800
+638 Route de Corsuet Grésy-sur-Aix,,,,638,Route de Corsuet,,73100
+638 Route de Corsuet 73100,,,,638,Route de Corsuet,Grésy-sur-Aix,
+638 Route de Corsuet,5.911992,45.713434,,638,Route de Corsuet,,73100
+461 Avenue Alphonse Daudet La Motte-Servolex,,,,461,Avenue Alphonse Daudet,,73290
+461 Avenue Alphonse Daudet 73290,,,,461,Avenue Alphonse Daudet,La Motte-Servolex,
+461 Avenue Alphonse Daudet,5.87336,45.587883,,461,Avenue Alphonse Daudet,,73290
+5 Rue Amélie Gex La Ravoire,,,,5,Rue Amélie Gex,,73490
+5 Rue Amélie Gex 73490,,,,5,Rue Amélie Gex,La Ravoire,
+5 Rue Amélie Gex,5.958842,45.553969,,5,Rue Amélie Gex,,73490
+214A Route du Petit Bois Saint-Genix-sur-Guiers,,,,214A,Route du Petit Bois,,73240
+214A Route du Petit Bois 73240,,,,214A,Route du Petit Bois,Saint-Genix-sur-Guiers,
+214A Route du Petit Bois,5.665062,45.586809,,214A,Route du Petit Bois,,73240
+1540 Route du Grand Village Tours-en-Savoie,,,,1540,Route du Grand Village,,73790
+1540 Route du Grand Village 73790,,,,1540,Route du Grand Village,Tours-en-Savoie,
+1540 Route du Grand Village,6.441014,45.650407,,1540,Route du Grand Village,,73790
+3 Passage des Bains Annecy,,,,3,Passage des Bains,,74000
+3 Passage des Bains 74000,,,,3,Passage des Bains,Annecy,
+3 Passage des Bains,6.123348,45.899438,,3,Passage des Bains,,74000
+12 Chemin de la Thuillere Annecy-le-Vieux,,,,12,Chemin de la Thuillère,,74940
+12 Chemin de la Thuillere 74940,,,,12,Chemin de la Thuillère,Annecy-le-Vieux,
+12 Chemin de la Thuillere,6.164267,45.922017,,12,Chemin de la Thuillère,,74940
+90 Route de Fessy Arenthon,,,,90,Route de Fessy,,74800
+90 Route de Fessy 74800,,,,90,Route de Fessy,Arenthon,
+90 Route de Fessy,6.339992,46.094066,,90,Route de Fessy,,74800
+21 Allée du Clos Meunier Beaumont,,,,21,Allée du Clos Meunier,,74160
+21 Allée du Clos Meunier 74160,,,,21,Allée du Clos Meunier,Beaumont,
+21 Allée du Clos Meunier,6.113461,46.096284,,21,Allée du Clos Meunier,,74160
+103 Rue des Bellossy Bons-en-Chablais,,,,103,Rue des Bellossy,,74890
+103 Rue des Bellossy 74890,,,,103,Rue des Bellossy,Bons-en-Chablais,
+103 Rue des Bellossy,6.369766,46.262436,,103,Rue des Bellossy,,74890
+107 Chemin de Clairmont Chamonix-Mont-Blanc,,,,107,Chemin de Clairmont,,74400
+107 Chemin de Clairmont 74400,,,,107,Chemin de Clairmont,Chamonix-Mont-Blanc,
+107 Chemin de Clairmont,6.876178,45.93704,,107,Chemin de Clairmont,,74400
+1182 Route des Freinets Châtel,,,,1182,Route des Freinets,,74390
+1182 Route des Freinets 74390,,,,1182,Route des Freinets,Châtel,
+1182 Route des Freinets,6.832309,46.258886,,1182,Route des Freinets,,74390
+519 Route du Col de la Croix Fry La Clusaz,,,,519,Route du Col de la Croix Fry,,74220
+519 Route du Col de la Croix Fry 74220,,,,519,Route du Col de la Croix Fry,La Clusaz,
+519 Route du Col de la Croix Fry,6.436227,45.88347,,519,Route du Col de la Croix Fry,,74220
+300 Route de Genève Collonges-sous-Salève,,,,300,Route de Genève,,74160
+300 Route de Genève 74160,,,,300,Route de Genève,Collonges-sous-Salève,
+300 Route de Genève,6.139224,46.142904,,300,Route de Genève,,74160
+107 Route de la Côte La Côte-d'Arbroz,,,,107,Route de la Côte,,74110
+107 Route de la Côte 74110,,,,107,Route de la Côte,La Côte-d'Arbroz,
+107 Route de la Côte,6.669223,46.188845,,107,Route de la Côte,,74110
+735 Route de Burgaz Cuvat,,,,735,Route de Burgaz,,74350
+735 Route de Burgaz 74350,,,,735,Route de Burgaz,Cuvat,
+735 Route de Burgaz,6.122387,45.979614,,735,Route de Burgaz,,74350
+9 Chemin des Contins Droisy,,,,9,Chemin des Contins,,74270
+9 Chemin des Contins 74270,,,,9,Chemin des Contins,Droisy,
+9 Chemin des Contins,5.882912,45.965051,,9,Chemin des Contins,,74270
+1 Rue de la Touvière Évian-les-Bains,,,,1,Rue de la Touvière,,74500
+1 Rue de la Touvière 74500,,,,1,Rue de la Touvière,Évian-les-Bains,
+1 Rue de la Touvière,6.592183,46.400647,,1,Rue de la Touvière,,74500
+831 Route de la Plaine Fillinges,,,,831,Route de la Plaine,,74250
+831 Route de la Plaine 74250,,,,831,Route de la Plaine,Fillinges,
+831 Route de la Plaine,6.331631,46.16233,,831,Route de la Plaine,,74250
+1717 Route du Nant Robert Le Grand-Bornand,,,,1717,Route du Nant Robert,,74450
+1717 Route du Nant Robert 74450,,,,1717,Route du Nant Robert,Le Grand-Bornand,
+1717 Route du Nant Robert,6.447967,45.943272,,1717,Route du Nant Robert,,74450
+422 Route de la Fruitière Lathuile,,,,422,Route de la Fruitière,,74210
+422 Route de la Fruitière 74210,,,,422,Route de la Fruitière,Lathuile,
+422 Route de la Fruitière,6.203562,45.785647,,422,Route de la Fruitière,,74210
+617 Chemin de Montpellaz Manigod,,,,617,Chemin de Montpellaz,,74230
+617 Chemin de Montpellaz 74230,,,,617,Chemin de Montpellaz,Manigod,
+617 Chemin de Montpellaz,6.385013,45.865319,,617,Chemin de Montpellaz,,74230
+139 Chemin de la Perouse Marlioz,,,,139,Chemin de la Perouse,,74270
+139 Chemin de la Perouse 74270,,,,139,Chemin de la Perouse,Marlioz,
+139 Chemin de la Perouse,6.007836,46.032689,,139,Chemin de la Perouse,,74270
+387 Route du Tour Megève,,,,387,Route du Tour,,74120
+387 Route du Tour 74120,,,,387,Route du Tour,Megève,
+387 Route du Tour,6.630925,45.843684,,387,Route du Tour,,74120
+53 Impasse du Four A Pain Minzier,,,,53,Impasse du Four à Pain,,74270
+53 Impasse du Four A Pain 74270,,,,53,Impasse du Four à Pain,Minzier,
+53 Impasse du Four A Pain,6.000473,46.068079,,53,Impasse du Four à Pain,,74270
+7 Impasse des Marais Moye,,,,7,Impasse des Marais,,74150
+7 Impasse des Marais 74150,,,,7,Impasse des Marais,Moye,
+7 Impasse des Marais,5.89267,45.889787,,7,Impasse des Marais,,74150
+1457 Chemin de l'Epagny Passy,,,,1457,Chemin de l'Epagny,,74480
+1457 Chemin de l'Epagny 74480,,,,1457,Chemin de l'Epagny,Passy,
+1457 Chemin de l'Epagny,6.703829,45.928896,,1457,Chemin de l'Epagny,,74480
+181 Route de la Couloute Poisy,,,,181,Route de la Couloute,,74330
+181 Route de la Couloute 74330,,,,181,Route de la Couloute,Poisy,
+181 Route de la Couloute,6.073276,45.918025,,181,Route de la Couloute,,74330
+313 Route de la Biolle Reignier-Ésery,,,,313,Route de la Biolle,,74930
+313 Route de la Biolle 74930,,,,313,Route de la Biolle,Reignier-Ésery,
+313 Route de la Biolle,6.233814,46.144331,,313,Route de la Biolle,,74930
+6 Rue des Pérouses Rumilly,,,,6,Rue des Pérouses,,74150
+6 Rue des Pérouses 74150,,,,6,Rue des Pérouses,Rumilly,
+6 Rue des Pérouses,5.957252,45.846881,,6,Rue des Pérouses,,74150
+33 Impasse des Hochettes Saint-Gervais-les-Bains,,,,33,Impasse des Hochettes,,74170
+33 Impasse des Hochettes 74170,,,,33,Impasse des Hochettes,Saint-Gervais-les-Bains,
+33 Impasse des Hochettes,6.723384,45.84594,,33,Impasse des Hochettes,,74170
+271 Route du Villard Saint-Jorioz,,,,271,Route du Villard,,74410
+271 Route du Villard 74410,,,,271,Route du Villard,Saint-Jorioz,
+271 Route du Villard,6.165947,45.830889,,271,Route du Villard,,74410
+39 Rue des Myosotis Saint-Pierre-en-Faucigny,,,,39,Rue des Myosotis,,74800
+39 Rue des Myosotis 74800,,,,39,Rue des Myosotis,Saint-Pierre-en-Faucigny,
+39 Rue des Myosotis,6.364174,46.05996,,39,Rue des Myosotis,,74800
+70 Rue Clos Tête Noire Sallanches,,,,70,Rue Clos Tête Noire,,74700
+70 Rue Clos Tête Noire 74700,,,,70,Rue Clos Tête Noire,Sallanches,
+70 Rue Clos Tête Noire,6.641087,45.929202,,70,Rue Clos Tête Noire,,74700
+96 Allée des Rosiers Scionzier,,,,96,Allée des Rosiers,,74950
+96 Allée des Rosiers 74950,,,,96,Allée des Rosiers,Scionzier,
+96 Allée des Rosiers,6.56082,46.057664,,96,Allée des Rosiers,,74950
+2249 Route des Combes Seythenex,,,,2249,Route des Combes,,74210
+2249 Route des Combes 74210,,,,2249,Route des Combes,Seythenex,
+2249 Route des Combes,6.318349,45.712624,,2249,Route des Combes,,74210
+4 Rue des Vernaies Thônes,,,,4,Rue des Vernaies,,74230
+4 Rue des Vernaies 74230,,,,4,Rue des Vernaies,Thônes,
+4 Rue des Vernaies,6.303785,45.893808,,4,Rue des Vernaies,,74230
+5 Impasse du Vuard Marchat Thonon-les-Bains,,,,5,Impasse du Vuard Marchat,,74200
+5 Impasse du Vuard Marchat 74200,,,,5,Impasse du Vuard Marchat,Thonon-les-Bains,
+5 Impasse du Vuard Marchat,6.494475,46.36677,,5,Impasse du Vuard Marchat,,74200
+275 Chemin des Verrières Veigy-Foncenex,,,,275,Chemin des Verrières,,74140
+275 Chemin des Verrières 74140,,,,275,Chemin des Verrières,Veigy-Foncenex,
+275 Chemin des Verrières,6.273185,46.26612,,275,Chemin des Verrières,,74140
+11 Rue de Deux Montagnes Québec Ville-la-Grand,,,,11,Rue de Deux Montagnes Québec,,74100
+11 Rue de Deux Montagnes Québec 74100,,,,11,Rue de Deux Montagnes Québec,Ville-la-Grand,
+11 Rue de Deux Montagnes Québec,6.279359,46.205767,,11,Rue de Deux Montagnes Québec,,74100
+1576 Avenue de Savoie Viuz-en-Sallaz,,,,1576,Avenue de Savoie,,74250
+1576 Avenue de Savoie 74250,,,,1576,Avenue de Savoie,Viuz-en-Sallaz,
+1576 Avenue de Savoie,6.410829,46.152398,,1576,Avenue de Savoie,,74250
+26 avenue du maréchal foch Lyon,,,,26,Avenue Maréchal Foch,Lyon,
+56 avenue Maréchal de Saxe,,,,56,Avenue du Maréchal de Saxe,Lyon,
+60 avenue du Maréchal de Saxe,,,,60,Avenue Maréchal de Saxe,Lyon,
+771 chemin de la Bruyère,4.8649,45.7488,,,Chemin de la Bruyère,Limonest,
+38 chemin de la Bruyère dardilly,4.7748,45.8055,,,Chemin de la Bruyère,Dardilly,
+79 cours charlemagne,,,,,Cours Charlemagne,Lyon,
+rue du mont d'or Saint-Didier-au-Mont-d'Or,,,,,,Saint-Didier-au-Mont-d'Or,
+rue du mont d'or Saint cyr,,,,,,Saint-Cyr-au-Mont-d'Or,


### PR DESCRIPTION
The address tests expect that the geocoder returns an artificial name `<housenumber>  <street name>` for addresses. However this is not required by the geocodejson spec and neither Nominatim nor Photon do this. Consequently we had pretty much all French address tests fail.

Expect instead the housenumber and street to be returned in their respective fields. The Addok geocoder (where the name assumption seems to come from) returns this information as well, so there is no real regression here.