### PR TITLE
Add license to project

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+Copyright by the geocoder-tester contributors. See git log and history
+for a full list.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ list), that you can then run with `-m yourmarker`.
 Geocoder-tester is available under a MIT license. See LICENSE.txt for more
 information.
 
-As a special exception, the test cases under `geocoder_tester/world/` are
-considered to be in the public domain. You may use them without any
-restrictions.
+Some of the test cases under `geocoder_tester/world/` are derived from data
+with other licenses:
+
+ * [OpenFlights](https://github.com/jpatokal/openflights) airport data
+   available under [ODbL](https://opendatacommons.org/licenses/odbl/1.0/)
+ * [Wikidata](https://wikidata.org)
+   available under [CC0](https://creativecommons.org/publicdomain/zero/1.0/)
+
+Please refer to the license files in the appropriate subdirectories. When
+no separate license file is present, the tests are considered to be in the
+public domain. You may use them without any restrictions.

--- a/README.md
+++ b/README.md
@@ -118,3 +118,12 @@ has the subkeys you want to test against (`name`, `housenumber`…).
 Optional keys: `limit`, `lang`, `lat` and `lon`, `skip`.
 You can add categories to your test by using the key `mark` (which expects a
 list), that you can then run with `-m yourmarker`.
+
+## License
+
+Geocoder-tester is available under a MIT license. See LICENSE.txt for more
+information.
+
+As a special exception, the test cases under `geocoder_tester/world/` are
+considered to be in the public domain. You may use them without any
+restrictions.


### PR DESCRIPTION
As discussed in #60, this adds a license to the project. The basic license is MIT. In addition, there is a special exception in the README that puts all tests into the public domain to make them as reusable as possible.

I would kindly request that all that have contributed so far explicitly approve this PR if the license is fine with you. In particular, please make sure that tests that you have contributed can be put into the public domain. If you have reservations or questions, please comment on #60 or get in touch with me directly.

Contributors list according to github: @yohanboniface @nlehuby @hbruch @karussell @kinnou02 @antoine-de @jfgigand 
Please approve this PR or comment, if this change is okay with you.